### PR TITLE
docs: community engagement kickoff — whitepaper, tokenomics, roadmap, social drafts

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,86 @@
+# SINT Protocol Roadmap
+
+**Last updated:** March 2026
+
+---
+
+## Phase 1: Foundation (Current)
+
+**Status: Complete**
+
+- Core types, Zod schemas, tier constants (`@sint/core`)
+- Ed25519 capability tokens with delegation and attenuation (`@sint/gate-capability-tokens`)
+- Policy Gateway — single enforcement point with tier assignment, constraints, forbidden combos (`@sint/gate-policy-gateway`)
+- SHA-256 hash-chained evidence ledger (`@sint/gate-evidence-ledger`)
+- MCP bridge adapter — tool call interception and risk classification (`@sint/bridge-mcp`)
+- ROS 2 bridge adapter — topic/service/action interception with physics extraction (`@sint/bridge-ros2`)
+- In-memory persistence implementations (`@sint/persistence`)
+- TypeScript client SDK (`@sint/client`)
+- Conformance test suite — 29 security regression tests (`@sint/conformance-tests`)
+- Gateway HTTP API server with approval routes and metrics (`@sint/gateway-server`)
+- Security-first multi-MCP proxy server (`@sint/mcp`)
+- Real-time approval management dashboard (`@sint/dashboard`)
+- 370+ tests passing across 12 packages
+
+---
+
+## Phase 2: Production Infrastructure
+
+**Target: Q2 2026**
+
+- [ ] PostgreSQL persistence backend (durable ledger, policy store, approval queue)
+- [ ] Redis persistence backend (caching, session store, rate limiting)
+- [ ] WebSocket approval transport (real-time approval streaming to replace SSE)
+- [ ] gRPC bridge adapter (generic service interception)
+- [ ] Docker Compose production deployment template
+- [ ] Helm chart for Kubernetes deployment
+- [ ] Monitoring and alerting (Prometheus metrics, Grafana dashboards)
+- [ ] Load testing and performance benchmarks
+
+---
+
+## Phase 3: Multi-Agent and Economy
+
+**Target: Q3 2026**
+
+- [ ] Multi-agent orchestration (agent-to-agent delegation, hierarchical policies)
+- [ ] Token economy implementation ($SINT staking, slashing, validator rewards)
+- [ ] Python SDK (`sint-py`)
+- [ ] Go SDK (`sint-go`)
+- [ ] Agent identity federation (cross-organization capability delegation)
+- [ ] Policy language v2 (declarative policy DSL)
+- [ ] Constraint library expansion (domain-specific constraint sets)
+
+---
+
+## Phase 4: Ecosystem and Certification
+
+**Target: Q4 2026 — Q1 2027**
+
+- [ ] Conformance certification program for bridge adapters
+- [ ] Enterprise features (SSO, RBAC, audit export, SLA dashboards)
+- [ ] HTTP/REST bridge adapter
+- [ ] GraphQL bridge adapter
+- [ ] Decentralized evidence ledger (on-chain anchoring)
+- [ ] Insurance pool for T3 incident coverage
+- [ ] Formal verification of core policy engine
+- [ ] Hardware security module (HSM) support for token signing
+
+---
+
+## Phase 5: Standards and Adoption
+
+**Target: 2027+**
+
+- [ ] IETF or W3C standards track submission
+- [ ] Reference implementations in Rust, Java
+- [ ] Integration partnerships with major robotics platforms
+- [ ] Integration with major AI agent frameworks (LangChain, CrewAI, AutoGen)
+- [ ] Academic research program and grants
+- [ ] Bug bounty program
+
+---
+
+## Contributing
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for how to get involved. The best place to start is with issues labeled `good first issue`.

--- a/docs/social/show-hn-draft.md
+++ b/docs/social/show-hn-draft.md
@@ -1,0 +1,34 @@
+# Show HN Draft — SINT Protocol
+
+> **Title:** Show HN: SINT Protocol – Open-source security layer for physical AI (capability tokens + tiered approval)
+
+> **URL:** https://github.com/sint-ai/sint-protocol
+
+---
+
+## Comment text (post as top-level comment by OP)
+
+Hi HN,
+
+We built SINT Protocol because AI agents are increasingly controlling physical systems — robots, industrial equipment, financial infrastructure — and there's no standard security layer between the model's decision and the physical action.
+
+**What SINT does:** Every agent action (tool call, robot command, API request) passes through a single Policy Gateway that enforces:
+
+1. **Capability tokens** — Ed25519-signed, attenuating credentials scoped to specific resources and actions. Delegation can only reduce permissions, never escalate.
+
+2. **Tiered approval** — Four levels (T0–T3) matching authorization requirements to physical consequence severity. Read-only is auto-approved. Moving a robot arm requires escalation. Executing code requires a human.
+
+3. **Physical constraints** — Hard limits on velocity, force, temperature, geofence boundaries enforced at the protocol level.
+
+4. **Evidence ledger** — SHA-256 hash-chained, append-only audit log. Every decision is recorded and tamper-detectable.
+
+**Technical details:**
+- TypeScript monorepo, 12 packages, 370+ tests
+- Bridge adapters for MCP (Model Context Protocol) and ROS 2
+- Works as a proxy between any AI agent and any tool server
+- Result<T, E> pattern throughout — no exceptions for control flow
+- Apache 2.0 licensed
+
+**What we're looking for:** Feedback on the security model, the tier classification system, and the capability token design. We're especially interested in hearing from people building with MCP servers or robotic systems.
+
+We built this because we needed it for our own AI agents and couldn't find anything like it. Happy to answer questions about the architecture or design decisions.

--- a/docs/social/twitter-launch-thread.md
+++ b/docs/social/twitter-launch-thread.md
@@ -1,0 +1,72 @@
+# X/Twitter Launch Thread — SINT Protocol
+
+> **Instructions:** Post as a thread from @sint_ai. Each numbered section is one tweet.
+
+---
+
+**1/**
+We just open-sourced SINT Protocol — a security enforcement layer for physical AI.
+
+AI agents can now control robots, move money, and execute code. But there's no standard security layer between "the model decided" and "the action happened."
+
+SINT is that layer.
+
+github.com/sint-ai/sint-protocol
+
+**2/**
+How it works:
+
+Every agent action passes through a single Policy Gateway.
+
+The gateway checks:
+- Capability tokens (Ed25519-signed, scoped credentials)
+- Approval tier (T0 observe → T3 irreversible)
+- Physical constraints (velocity, force, geofence)
+- Forbidden action combos
+
+No action bypasses the gate.
+
+**3/**
+The approval tier system matches authorization to physical consequence:
+
+T0 OBSERVE — auto-approve (read sensors)
+T1 PREPARE — auto-approve (save config)
+T2 ACT — requires escalation (move robot)
+T3 COMMIT — human required (exec code, transfer funds)
+
+**4/**
+Every decision is recorded in a SHA-256 hash-chained evidence ledger.
+
+Append-only. No updates. No deletes.
+
+Any tampering is cryptographically detectable.
+
+This is your audit trail when the regulator asks "what did your AI do and why?"
+
+**5/**
+What's shipping today:
+
+- 12 packages, 370+ tests
+- MCP bridge (works with Claude, Cursor, any MCP client)
+- ROS 2 bridge (robots, drones, industrial equipment)
+- Ed25519 capability tokens with delegation
+- Real-time approval dashboard
+- TypeScript SDK
+
+**6/**
+We built SINT because we needed it ourselves.
+
+We run AI agents that operate in the physical world. The security primitives available were either too coarse (ACLs) or too brittle (prompt constraints).
+
+So we built the enforcement layer we wished existed and open-sourced it.
+
+**7/**
+Want to contribute?
+
+- 3 good-first-issue tickets open now
+- Whitepaper, tokenomics, and roadmap in docs/
+- GitHub Discussions enabled
+
+Apache 2.0 licensed. Build with us.
+
+github.com/sint-ai/sint-protocol

--- a/docs/tokenomics.md
+++ b/docs/tokenomics.md
@@ -1,0 +1,120 @@
+# SINT Token Economics
+
+**Version 0.1 — Draft**
+**Date:** March 2026
+
+---
+
+## Overview
+
+SINT Protocol's economic layer aligns incentives between AI agent operators, infrastructure providers, and security validators. The token model ensures that the cost of misbehavior always exceeds the benefit, creating a self-enforcing security perimeter.
+
+---
+
+## Token: $SINT
+
+**Purpose:** Governance, staking, and economic enforcement for the SINT Protocol network.
+
+### Utility
+
+1. **Staking for Capability Tokens** — Agents must stake $SINT to receive capability tokens. Higher-tier capabilities (T2, T3) require proportionally larger stakes. If an agent violates policy, its stake is slashed.
+
+2. **Validator Rewards** — Nodes that validate evidence ledger entries and verify policy compliance earn $SINT rewards.
+
+3. **Governance** — $SINT holders vote on protocol upgrades, tier classification changes, and constraint parameter adjustments.
+
+4. **Fee Market** — T2/T3 approval requests incur a small fee paid in $SINT, creating sustainable economics for approval validators (human or automated).
+
+---
+
+## Supply
+
+| Parameter | Value |
+|-----------|-------|
+| Total supply | 1,000,000,000 $SINT |
+| Initial circulating | 15% (150M) |
+| Vesting | 4-year linear with 1-year cliff |
+
+### Allocation
+
+| Bucket | % | Tokens | Vesting |
+|--------|---|--------|---------|
+| Protocol development | 25% | 250M | 4yr linear, 1yr cliff |
+| Team + advisors | 15% | 150M | 4yr linear, 1yr cliff |
+| Community + ecosystem | 30% | 300M | Unlocked per governance milestones |
+| Validators + staking rewards | 20% | 200M | Emission schedule over 10 years |
+| Strategic partners | 10% | 100M | 2yr linear, 6mo cliff |
+
+---
+
+## Staking Model
+
+### Capability Stake Requirements
+
+| Tier | Minimum Stake | Slash Risk | Slash % |
+|------|--------------|------------|---------|
+| T0 (Observe) | 0 $SINT | None | 0% |
+| T1 (Prepare) | 100 $SINT | Low | 5% |
+| T2 (Act) | 1,000 $SINT | Medium | 25% |
+| T3 (Commit) | 10,000 $SINT | High | 50% |
+
+### Slashing Conditions
+
+- **Policy violation:** Agent action blocked by gateway after capability was issued
+- **Ledger tampering:** Attempted modification of evidence ledger entries
+- **Constraint breach:** Physical constraint exceeded (velocity, force, geofence)
+- **Token forgery:** Invalid delegation chain detected
+
+Slashed tokens are split: 50% burned, 50% to the reporting validator.
+
+---
+
+## Validator Economics
+
+Validators perform two functions:
+
+1. **Ledger verification:** Validate hash chain integrity of evidence ledger entries
+2. **Policy attestation:** Confirm that gateway decisions match published policy
+
+### Reward Structure
+
+- Base reward: proportional to stake weight
+- Bonus: for catching violations (share of slash)
+- Penalty: for false attestations (own stake slashed)
+
+---
+
+## Fee Market
+
+T2 and T3 approval requests create demand for human and automated approvers:
+
+- **T2 approvals:** Small fee, can be automated by approved validator sets
+- **T3 approvals:** Higher fee, requires human-in-the-loop from authorized approver
+
+Fees create a sustainable market for security review without centralized approval bottlenecks.
+
+---
+
+## Governance
+
+$SINT holders can propose and vote on:
+
+- Protocol parameter changes (tier thresholds, constraint defaults)
+- Bridge adapter certification
+- Validator set changes
+- Treasury allocation for ecosystem grants
+
+Voting weight: 1 token = 1 vote, with quadratic scaling option for major protocol changes.
+
+---
+
+## Open Questions
+
+- Exact emission curve for validator rewards
+- Cross-chain bridge design (Ethereum L2 vs Solana vs standalone)
+- Insurance pool mechanics for T3 incident coverage
+- Dynamic stake requirements based on historical agent behavior
+
+---
+
+*This document is a working draft. Token economics will be refined through community feedback and simulation before any token launch.*

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -1,0 +1,173 @@
+# SINT Protocol: A Layered Open Standard for Security, Governance, and Economic Enforcement in Physical AI Systems
+
+**Version 0.1 — Draft**
+**Authors:** SINT AI Team
+**Date:** March 2026
+
+---
+
+## Abstract
+
+As AI agents gain the ability to control physical systems — robots, vehicles, industrial equipment, financial infrastructure — a critical gap has emerged: there is no standard security layer between "the model decided to act" and "the action occurred in the physical world." SINT Protocol fills this gap with a capability-based, tiered enforcement architecture that governs every interaction between AI agents and physical actuators.
+
+This paper describes the protocol's design, its security model, and its approach to economic enforcement through staked capability tokens.
+
+---
+
+## 1. Introduction
+
+### 1.1 The Problem
+
+AI systems are increasingly autonomous. Foundation models can now execute tool calls, operate robotic arms, deploy code to production, and initiate financial transactions. Yet the security primitives available to constrain these systems remain inadequate:
+
+- **Access control lists** are too coarse — they grant blanket permissions rather than scoped capabilities.
+- **Prompt-level constraints** are brittle — they can be bypassed through prompt injection or context manipulation.
+- **Manual approval workflows** don't scale — they create bottlenecks that defeat the purpose of automation.
+
+The result is a binary choice: either restrict agents so heavily they can't be useful, or grant them broad access and hope nothing goes wrong.
+
+### 1.2 SINT's Approach
+
+SINT introduces a **Policy Gateway** — a single enforcement point through which every agent action must pass. The gateway evaluates each request against:
+
+1. **Capability tokens** — Ed25519-signed, attenuating credentials that scope what an agent can do
+2. **Tier classification** — A four-level system (T0–T3) that matches authorization requirements to physical consequence severity
+3. **Physical constraints** — Hard limits on velocity, force, temperature, geofence boundaries
+4. **Forbidden combinations** — Detection and blocking of dangerous action sequences
+5. **Evidence ledger** — A SHA-256 hash-chained, append-only audit log of every decision
+
+---
+
+## 2. Architecture
+
+### 2.1 Design Principles
+
+- **Single choke point:** Every action flows through `PolicyGateway.intercept()`. No bridge, route handler, or service makes authorization decisions independently.
+- **Result<T, E> — never throw:** All fallible operations return typed results. No exceptions for control flow.
+- **Attenuation only:** Delegated tokens can only reduce permissions. Escalation is structurally impossible.
+- **Append-only audit:** The evidence ledger is INSERT-only with hash chaining. No updates, no deletes.
+
+### 2.2 System Topology
+
+```
+┌─────────────────────────────────┐
+│  AI Agent (Claude, GPT, etc.)   │
+│        (MCP Client)             │
+└──────────┬──────────────────────┘
+           │ stdio / SSE
+┌──────────▼──────────────────────┐
+│         SINT MCP Proxy          │
+│  ┌───────────────────────────┐  │
+│  │   Tool Aggregator         │  │
+│  │   Policy Enforcer         │  │
+│  │   Agent Identity          │  │
+│  │   Approval Bridge         │  │
+│  │   Audit Resources         │  │
+│  └───────────────────────────┘  │
+└──┬──────┬──────┬────────────────┘
+   │      │      │   stdio connections
+┌──▼──┐┌──▼──┐┌──▼──┐
+│FS   ││Git  ││Shell│  ← Any MCP servers
+│MCP  ││MCP  ││MCP  │
+└─────┘└─────┘└─────┘
+```
+
+### 2.3 Approval Tiers
+
+| Tier | Name | Auto-Approve? | Physical Consequence |
+|------|------|---------------|---------------------|
+| T0 | OBSERVE | Yes | None — read-only sensors, queries |
+| T1 | PREPARE | Yes | Low — save waypoint, write config |
+| T2 | ACT | No — escalate | Moderate — move robot, operate gripper |
+| T3 | COMMIT | No — human required | Severe/irreversible — exec code, transfer funds |
+
+---
+
+## 3. Capability Token System
+
+### 3.1 Token Structure
+
+Each capability token is an Ed25519-signed credential containing:
+
+- **Subject:** The agent's public key
+- **Resource:** Scoped resource pattern (e.g., `ros2:///cmd_vel`, `mcp://filesystem/writeFile`)
+- **Actions:** Permitted operations on that resource
+- **Constraints:** Physical limits (max velocity, force bounds, geofence)
+- **Expiry:** Token lifetime
+- **Delegation chain:** Parent token references for attenuation verification
+
+### 3.2 Attenuation
+
+Tokens can be delegated, but only with equal or reduced permissions. A token for `ros2:///*` can delegate to `ros2:///cmd_vel`, but never the reverse. This is enforced cryptographically through the delegation chain.
+
+---
+
+## 4. Evidence Ledger
+
+Every gateway decision — allow, deny, escalate — is recorded in a SHA-256 hash-chained append-only ledger. Each entry references the previous entry's hash, creating a tamper-evident audit trail.
+
+```typescript
+interface LedgerEntry {
+  eventId: UUIDv7;
+  previousHash: SHA256;
+  timestamp: ISO8601;
+  request: SintRequest;
+  decision: Decision;
+  tier: ApprovalTier;
+  policySnapshot: PolicyHash;
+}
+```
+
+The ledger supports verification: any entry can be validated against the chain, and any tampering is detectable.
+
+---
+
+## 5. Bridge Adapters
+
+SINT is protocol-agnostic. Bridge adapters translate between domain-specific protocols and SINT requests:
+
+- **MCP Bridge:** Intercepts Model Context Protocol tool calls, classifies risk, enforces policy
+- **ROS 2 Bridge:** Intercepts robot middleware topics, services, and actions with physics extraction
+- **gRPC Bridge:** (Planned) Generic gRPC service interception
+- **HTTP Bridge:** (Planned) REST/GraphQL API interception
+
+Each bridge adapter extracts domain-specific metadata (e.g., velocity vectors from ROS 2 messages) and attaches it to the SINT request for constraint evaluation.
+
+---
+
+## 6. Deployment Models
+
+### 6.1 Sidecar
+SINT runs as a sidecar container alongside the AI agent, intercepting all outbound tool calls.
+
+### 6.2 Gateway
+A centralized SINT gateway serves multiple agents, with per-agent policy configuration and a shared evidence ledger.
+
+### 6.3 Embedded
+For latency-critical applications, SINT's policy engine can be embedded directly into the agent runtime.
+
+---
+
+## 7. Roadmap
+
+See [roadmap.md](roadmap.md) for the detailed development timeline.
+
+**Phase 1 (Current):** Core protocol, MCP + ROS 2 bridges, in-memory persistence, 370+ tests
+**Phase 2:** PostgreSQL/Redis persistence, WebSocket approval transport, gRPC bridge
+**Phase 3:** Multi-agent orchestration, token economy, Python/Go SDKs
+**Phase 4:** Conformance certification program, enterprise features
+
+---
+
+## 8. Conclusion
+
+SINT Protocol provides the missing security infrastructure for physical AI. By enforcing capability-based permissions, graduated approval tiers, physical constraints, and tamper-evident auditing through a single policy gateway, SINT enables AI agents to operate in the physical world with appropriate guardrails — without sacrificing the autonomy that makes them useful.
+
+---
+
+## References
+
+1. Dennis, J.B. & Van Horn, E.C. "Programming Semantics for Multiprogrammed Computations." Communications of the ACM, 1966.
+2. Miller, M.S. et al. "Capability-based Financial Instruments." Financial Cryptography, 2000.
+3. Model Context Protocol Specification. Anthropic, 2024.
+4. ROS 2 Design. Open Robotics, 2017.


### PR DESCRIPTION
## Summary
- Added `docs/whitepaper.md` — protocol design covering architecture, capability tokens, evidence ledger, bridge adapters, and deployment models
- Added `docs/tokenomics.md` — $SINT token economics with staking tiers, slashing conditions, validator rewards, and governance
- Added `docs/roadmap.md` — phased development timeline (Phase 1 complete through Phase 5 standards track)
- Added `docs/social/twitter-launch-thread.md` — 7-tweet X/Twitter launch thread draft
- Added `docs/social/show-hn-draft.md` — Show HN post with technical summary and discussion prompt

Also completed outside this PR:
- Enabled GitHub Discussions on the repo
- Created welcome/intro discussion thread (#10)
- Created 3 good-first-issue labeled issues (#7, #8, #9)

## SINT-155 Deliverables Checklist
- [x] README.md (already existed)
- [x] CONTRIBUTING.md (already existed)
- [x] docs/ folder: whitepaper, tokenomics, roadmap
- [x] GitHub Discussions enabled with pinned intro thread
- [x] First 3 GitHub Issues created (good first issue tags)
- [x] X/Twitter thread draft
- [x] HN Show HN post draft
- [x] Repo is public with Apache 2.0 license

🤖 Generated with [Claude Code](https://claude.com/claude-code)