### PR TITLE
Add CONTRIBUTING.md and whitepaper outline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,78 +1,101 @@
 # Contributing to SINT Protocol
 
-Thank you for your interest in contributing to SINT Protocol. This document explains how to get involved.
+Thank you for your interest in SINT Protocol! This document provides guidelines for contributing to the project.
 
 ## Getting Started
 
-1. Fork the repository
-2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/sint-protocol.git`
-3. Install dependencies: `pnpm install` (requires Node.js 22+ and pnpm 9+)
-4. Build all packages: `pnpm run build`
-5. Run tests: `pnpm run test`
+1. **Fork the repository** and clone your fork locally
+2. **Install dependencies**: `pnpm install` (requires Node.js >= 22, pnpm >= 9)
+3. **Build**: `pnpm run build`
+4. **Run tests**: `pnpm run test` to verify everything works
 
 ## Development Workflow
 
-1. Create a feature branch from `main`: `git checkout -b feat/your-feature`
-2. Make your changes
-3. Run `pnpm run typecheck` and `pnpm run test` to verify
-4. Commit with a clear message describing what and why
-5. Push to your fork and open a Pull Request
+1. Create a feature branch from `main`:
+   ```bash
+   git checkout -b feat/your-feature-name
+   ```
+2. Make your changes, following the code style and design principles below
+3. Add or update tests for your changes
+4. Ensure all tests pass: `pnpm run test`
+5. Ensure types check: `pnpm run typecheck`
+6. Open a pull request against `main`
 
-## Code Standards
+## Code Style & Design Principles
 
-- **TypeScript strict mode** — no `any` types, no implicit returns
-- **Result\<T, E\> over exceptions** — fallible operations return discriminated unions, not thrown errors
+SINT Protocol follows strict conventions. Please review these before contributing:
+
+- **TypeScript strict mode** — all code must pass strict type checking
+- **Result\<T, E\> over exceptions** — fallible operations return discriminated unions, never throw
 - **Interface-first persistence** — storage adapters implement clean interfaces
-- **Vitest** for all tests — aim for meaningful coverage, not 100% line coverage
-- **Zod** for runtime validation schemas
+- **Single choke point** — every agent action flows through `PolicyGateway.intercept()`
+- **Append-only audit** — the evidence ledger is INSERT-only with hash chain integrity
+- **Attenuation only** — delegated tokens can only reduce permissions, never escalate
+- **Physical safety first** — velocity, force, and geofence constraints are first-class
 
 ## Project Structure
 
-```
-sint-protocol/
-├── apps/           # Deployable applications (gateway, MCP proxy, dashboard)
-├── packages/       # Shared libraries (core, tokens, gateway, ledger, bridges)
-├── scripts/        # Build and development scripts
-└── docker-compose.yml
-```
+The monorepo uses pnpm workspaces + Turborepo:
 
-Each package has its own `package.json`, `tsconfig.json`, and test suite. Use `pnpm --filter @sint/<package> test` to run a single package's tests.
+- `packages/` — core libraries (core, policy-gateway, capability-tokens, evidence-ledger, etc.)
+- `apps/` — runnable applications (gateway-server, sint-mcp, dashboard)
+- `packages/conformance-tests/` — security regression suite
 
-## What to Contribute
+## Types of Contributions
 
-- **Bug fixes** — always welcome
-- **Bridge adapters** — new integrations (gRPC, MQTT, HTTP webhooks)
-- **Policy rules** — new forbidden combination patterns or tier escalation triggers
-- **Persistence backends** — additional storage adapters
-- **Documentation** — improvements, examples, tutorials
-- **Conformance tests** — new security regression test cases
+### Bug Reports
 
-## Pull Request Guidelines
+Open an issue with:
+- A clear description of the bug
+- Steps to reproduce
+- Expected vs. actual behavior
+- Environment details (Node version, OS, etc.)
+
+### Feature Requests
+
+Use [GitHub Discussions → Ideas](https://github.com/sint-ai/sint-protocol/discussions/categories/ideas) to propose new features. Include:
+- The problem you're trying to solve
+- Your proposed solution
+- Any alternatives you've considered
+
+### Integration Proposals
+
+Building a bridge to a new platform (ROS 2, MQTT, gRPC, etc.)? Start a discussion in the [Integrations](https://github.com/sint-ai/sint-protocol/discussions/categories/integrations) category first to align on the approach.
+
+### Pull Requests
 
 - Keep PRs focused — one feature or fix per PR
 - Include tests for new functionality
-- Update relevant documentation
-- Ensure all existing tests pass
-- Describe what changed and why in the PR description
+- Update documentation if your change affects the public API
+- Reference any related issues in the PR description
 
-## Reporting Issues
+## Testing
 
-Use [GitHub Issues](https://github.com/sint-ai/sint-protocol/issues) to report bugs or request features. Include:
+```bash
+# Run all tests
+pnpm run test
 
-- What you expected to happen
-- What actually happened
-- Steps to reproduce
-- Environment details (OS, Node.js version, pnpm version)
+# Run tests for a specific package
+pnpm --filter @sint/policy-gateway test
+pnpm --filter @sint/mcp test
 
-## Security Vulnerabilities
+# Type-check without emitting
+pnpm run typecheck
+```
 
-If you discover a security vulnerability, **do not** open a public issue. Instead, use [GitHub Security Advisories](https://github.com/sint-ai/sint-protocol/security/advisories) to report it privately. We will respond within 48 hours.
+All PRs must pass the full test suite and type checking before merge.
 
-## Community
+## Security
 
-- [GitHub Discussions](https://github.com/sint-ai/sint-protocol/discussions) — questions, ideas, and general discussion
-- Pull Request reviews — we aim to review PRs within one week
+If you discover a security vulnerability, **do not open a public issue**. Instead, email security@sint.ai with details. We take security seriously and will respond promptly.
 
 ## License
 
 By contributing, you agree that your contributions will be licensed under the Apache-2.0 License.
+
+## Community
+
+- [GitHub Discussions](https://github.com/sint-ai/sint-protocol/discussions) — questions, ideas, and general chat
+- [Issues](https://github.com/sint-ai/sint-protocol/issues) — bug reports and tracked work
+
+We welcome contributors of all experience levels. If you're unsure about anything, open a discussion — we're happy to help.

--- a/docs/whitepaper-outline.md
+++ b/docs/whitepaper-outline.md
@@ -1,0 +1,129 @@
+# SINT Protocol Whitepaper — Outline
+
+> **Status:** Draft outline. Full whitepaper in progress.
+
+## Abstract
+
+SINT Protocol is a layered open standard for security, governance, and economic enforcement in physical AI systems. As AI agents gain the ability to control robots, execute code, move funds, and operate machinery, SINT provides the missing security stack between "the LLM decided to do X" and "X happened in the physical world."
+
+## 1. Introduction
+
+- The rise of autonomous AI agents with physical-world capabilities
+- The security gap: no standard enforcement layer between AI decisions and physical actions
+- Why existing approaches (prompt engineering, model alignment) are insufficient for physical safety
+- SINT's thesis: security must be enforced at the protocol level, not the model level
+
+## 2. Problem Statement
+
+- **Uncontrolled agent autonomy** — agents can chain tool calls with no authorization checks
+- **No audit trail** — actions disappear after execution, making forensics impossible
+- **Permission sprawl** — agents inherit the full permissions of their host environment
+- **Physical safety** — a software bug becomes a physical hazard when agents control actuators
+- **Delegation risk** — agents delegating to other agents with no attenuation guarantees
+
+## 3. Architecture
+
+### 3.1 Design Principles
+- Single choke point (Policy Gateway)
+- Result types over exceptions
+- Append-only audit
+- Attenuation-only delegation
+- Physical constraints as first-class citizens
+
+### 3.2 Layer Model
+- **Layer 0: Identity** — Ed25519 keypairs, agent sessions, delegation chains
+- **Layer 1: Policy** — Capability tokens, tier classification, constraint enforcement
+- **Layer 2: Enforcement** — Policy Gateway intercept, forbidden combination detection
+- **Layer 3: Evidence** — Hash-chained ledger, proof receipts, tamper detection
+- **Layer 4: Bridges** — Protocol-specific adapters (MCP, ROS 2, gRPC, MQTT)
+
+### 3.3 Approval Tiers
+- T0 OBSERVE → T1 PREPARE → T2 ACT → T3 COMMIT
+- Mapping physical consequence severity to authorization requirements
+- Dynamic escalation triggers (human proximity, untrusted agent, forbidden sequences)
+
+## 4. Capability Token System
+
+- Ed25519-signed tokens with resource scoping and action restrictions
+- Physical constraint embedding (max velocity, max force, geofence polygons)
+- Delegation chains with max 3-hop depth and mandatory attenuation
+- Revocation: instant invalidation via revocation store
+- Token lifecycle: issuance → delegation → exercise → expiry/revocation
+
+## 5. Policy Gateway
+
+- The single intercept point for all agent actions
+- Tier assignment algorithm
+- Constraint validation (physical bounds checking)
+- Forbidden combination detection (temporal sequence analysis)
+- Per-server policy enforcement (maxTier ceilings, requireApproval overrides)
+- Batch evaluation for atomic multi-action requests
+
+## 6. Evidence Ledger
+
+- SHA-256 hash-chained append-only log
+- Event schema and chain integrity
+- Proof receipts for individual decisions
+- Query interface for forensics and compliance
+- Storage backend abstraction (in-memory, PostgreSQL, Redis)
+
+## 7. Bridge Architecture
+
+### 7.1 MCP Bridge
+- Tool call interception and risk classification
+- Multi-server aggregation with per-server policy
+- Built-in security tools (sint__ prefix)
+
+### 7.2 ROS 2 Bridge
+- Topic, service, and action interception
+- Physics extraction from ROS 2 messages (velocity, force, position)
+- Real-time constraint enforcement for robot commands
+
+### 7.3 Future Bridges
+- gRPC service interception
+- MQTT topic filtering
+- HTTP/REST API gateway mode
+
+## 8. Economic Layer (Future)
+
+- Token-gated access to SINT infrastructure
+- Staking for agent identity and reputation
+- Economic penalties for policy violations
+- Marketplace for policy templates and bridge adapters
+- Governance: protocol upgrades via token holder voting
+
+## 9. Security Analysis
+
+- Threat model: compromised agent, malicious delegation, replay attacks
+- Formal properties: no bypass, no escalation, tamper evidence
+- Comparison with existing approaches (OAuth, RBAC, ABAC)
+- Limitations and known trade-offs
+
+## 10. Implementation
+
+- Reference implementation: TypeScript monorepo
+- Package architecture and dependency graph
+- Performance characteristics and benchmarks
+- Deployment models: embedded, sidecar, gateway
+
+## 11. Related Work
+
+- Model Context Protocol (MCP) — Anthropic
+- Robot Operating System 2 (ROS 2)
+- Capability-based security (Dennis & Van Horn, 1966)
+- SPIFFE/SPIRE for workload identity
+- Open Policy Agent (OPA)
+
+## 12. Conclusion & Roadmap
+
+- Current status: working reference implementation with 370+ tests
+- Near-term: production hardening, additional bridges, conformance certification
+- Medium-term: economic layer, governance framework, ecosystem growth
+- Long-term: industry standard for physical AI security
+
+## Appendices
+
+- A. API Reference
+- B. Configuration Examples
+- C. Conformance Test Specification
+- D. Glossary of Terms


### PR DESCRIPTION
## Summary
- Adds `CONTRIBUTING.md` with development workflow, code style guidelines, PR process, and security disclosure policy
- Adds `docs/whitepaper-outline.md` — 12-section draft outline covering the full protocol architecture, capability tokens, policy gateway, evidence ledger, bridge architecture, and economic layer

Part of SINT-158: GitHub repo setup and community foundation.

## Remaining (manual)
- Create "Integrations" GitHub Discussions category (requires UI — GitHub GraphQL API doesn't support category creation)
- Post announcements to Web3/AI Discord servers and HN (requires human action)

## Test plan
- [ ] Verify CONTRIBUTING.md renders correctly on GitHub
- [ ] Verify docs/whitepaper-outline.md renders correctly
- [ ] Confirm no existing tests are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>