### PR TITLE
docs(SINT-260): add SECURITY.md and finalize protocol community setup

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported Versions
+
+SINT Protocol is currently in active development. Security fixes are applied to the latest `main` branch.
+
+## Reporting a Vulnerability
+
+If you discover a vulnerability, do not open a public issue.
+
+Please report privately to:
+
+- `security@sint.ai`
+
+Include:
+
+- A clear description of the issue
+- Steps to reproduce
+- Potential impact
+- Suggested remediation (if available)
+
+## Response Expectations
+
+We will acknowledge receipt as quickly as possible and triage based on severity.
+For valid reports, we will coordinate remediation and disclosure timing with the reporter.
+
+## Disclosure
+
+Please avoid public disclosure until a fix is released or a coordinated disclosure date is agreed.


### PR DESCRIPTION
## Summary
- adds SECURITY.md with responsible disclosure policy
- confirms repo/discussions/category/topic setup for SINT-260 is complete

## Validation
- pre-commit scan (regex): no secret hits
- pre-commit scan (trufflehog filesystem SECURITY.md): 0 findings
- pre-PR full diff scan (regex + trufflehog git against merge-base): 0 findings

## SINT-260 checklist
- [x] sint-ai/sint-protocol exists
- [x] README.md present in repo
- [x] CONTRIBUTING.md present in repo
- [x] SECURITY.md added
- [x] Discussions enabled
- [x] Categories include Announcements, Q&A, Ideas
- [x] Topics include ai-agents, protocol, coordination, openai, anthropic
- [x] live repo link posted to SINT-249 comments
- [ ] Pin protocol overview discussion (manual UI step; API pin endpoint unavailable in this runtime)