### PR TITLE
Add issue templates (bug, feature, agent integration)

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent_integration.yml
+++ b/.github/ISSUE_TEMPLATE/agent_integration.yml
@@ -1,0 +1,53 @@
+name: Agent Integration Request
+description: Request help integrating an AI agent or platform with SINT Protocol
+labels: ["integration"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Tell us about the agent or platform you want to integrate with SINT Protocol.
+  - type: input
+    id: agent-platform
+    attributes:
+      label: Agent / Platform
+      description: What agent framework or platform are you integrating?
+      placeholder: "Claude, GPT, LangChain, custom agent, ROS 2 robot, etc."
+    validations:
+      required: true
+  - type: dropdown
+    id: bridge
+    attributes:
+      label: Bridge type
+      options:
+        - MCP (tool calls via Model Context Protocol)
+        - ROS 2 (robotics topics/services/actions)
+        - HTTP API (direct Gateway Server calls)
+        - Custom / Other
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: What will the agent do? What physical or sensitive actions need governance?
+    validations:
+      required: true
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Requirements
+      description: Specific policy, approval, or audit requirements for your integration.
+    validations:
+      required: false
+  - type: dropdown
+    id: tier-range
+    attributes:
+      label: Expected max tier
+      description: Highest risk tier your agent actions will reach.
+      options:
+        - T0 — Read-only, no side effects
+        - T1 — Reversible side effects
+        - T2 — Irreversible but non-dangerous
+        - T3 — Dangerous physical actions
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,48 @@
+name: Bug Report
+description: Report a bug in SINT Protocol
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please fill out the details below.
+  - type: input
+    id: package
+    attributes:
+      label: Package
+      description: Which package is affected?
+      placeholder: "@sint/core, @sint/bridge-mcp, etc."
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the issue.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: SINT Protocol version (run `pnpm list @sint/core`)
+    validations:
+      required: false
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Low — cosmetic or minor inconvenience
+        - Medium — incorrect behavior, workaround exists
+        - High — blocks usage, no workaround
+        - Critical — security vulnerability or data loss
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/sint-ai/sint-protocol/discussions
+    about: Ask questions and share ideas in Discussions

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the feature you'd like to see in SINT Protocol.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve? What use case does it enable?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How should this work? Include API sketches if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've thought about.
+    validations:
+      required: false
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - Core — types, schemas, tier system
+        - Policy Gateway — rules, constraints, combos
+        - Evidence Ledger — audit logging
+        - MCP Bridge — tool call interception
+        - ROS 2 Bridge — robotics integration
+        - Dashboard — approval UI
+        - SDK / Client — developer experience
+        - Other
+    validations:
+      required: true


### PR DESCRIPTION
## Summary
- Adds 3 structured GitHub issue form templates: bug report, feature request, agent integration request
- Adds config.yml linking blank issues to Discussions
- Completes community setup per SINT-291

## Templates
- **Bug Report** — package, description, repro steps, severity dropdown
- **Feature Request** — problem, proposed solution, scope dropdown
- **Agent Integration** — agent/platform, bridge type, use case, tier range

## Test plan
- [ ] Verify templates render at github.com/sint-ai/sint-protocol/issues/new/choose
- [ ] Submit a test issue with each template

🤖 Generated with [Claude Code](https://claude.com/claude-code)