### PR TITLE
SINT-494: Add structured trajectory logging and export pipeline

### DIFF
--- a/apps/sint-mcp/__tests__/trajectory.test.ts
+++ b/apps/sint-mcp/__tests__/trajectory.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  TrajectoryRecorder,
+  TrajectoryExportService,
+} from "../src/trajectory.js";
+
+describe("TrajectoryRecorder", () => {
+  it("captures tool calls/results with parent-child links", () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "sint-trajectory-"));
+
+    try {
+      const recorder = new TrajectoryRecorder({
+        runId: "run-1",
+        agentId: "agent-1",
+        taskId: "task-1",
+        model: "test-model",
+        outputDir,
+      });
+
+      const toolCallId = recorder.recordToolCall({
+        tool: "filesystem.writeFile",
+        args: { path: "/tmp/test.txt" },
+      });
+
+      recorder.recordToolResult({
+        tool: "filesystem.writeFile",
+        result: { ok: true },
+        durationMs: 12,
+        parentEventId: toolCallId,
+      });
+
+      const trajectory = recorder.snapshot();
+      expect(trajectory.events).toHaveLength(2);
+      expect(trajectory.events[0]!.type).toBe("tool_call");
+      expect(trajectory.events[1]!.type).toBe("tool_result");
+      expect(trajectory.events[1]!.parentEventId).toBe(toolCallId);
+      expect(trajectory.metadata.totalToolCalls).toBe(1);
+      expect(trajectory.metadata.totalDurationMs).toBe(12);
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("persists one JSON file per run with classified outcome", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "sint-trajectory-"));
+
+    try {
+      const recorder = new TrajectoryRecorder({
+        runId: "run-2",
+        agentId: "agent-2",
+        taskId: "task-2",
+        model: "test-model",
+        outputDir,
+      });
+
+      recorder.recordDecision("allow", "filesystem.readFile");
+      recorder.markOutcome("partial");
+      const filePath = await recorder.flushToFile();
+
+      const fileContents = JSON.parse(readFileSync(filePath, "utf-8")) as {
+        runId: string;
+        outcome: string;
+      };
+      expect(fileContents.runId).toBe("run-2");
+      expect(fileContents.outcome).toBe("partial");
+      expect(filePath.endsWith("run-2.json")).toBe(true);
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("TrajectoryExportService", () => {
+  it("exports JSON, JSONL, and replay script", () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "sint-trajectory-"));
+
+    try {
+      const recorder = new TrajectoryRecorder({
+        runId: "run-3",
+        agentId: "agent-3",
+        taskId: "task-3",
+        model: "test-model",
+        outputDir,
+      });
+
+      recorder.recordToolCall({
+        tool: "filesystem.readFile",
+        args: { path: "/tmp/x" },
+      });
+      recorder.recordToolResult({
+        tool: "filesystem.readFile",
+        result: "ok",
+        durationMs: 5,
+      });
+
+      const trajectory = recorder.snapshot();
+      const exporter = new TrajectoryExportService();
+
+      const json = exporter.exportJSON(trajectory);
+      const jsonl = exporter.exportJSONL([trajectory]);
+      const replay = exporter.exportReplay(trajectory);
+
+      expect(JSON.parse(json).runId).toBe("run-3");
+      expect(jsonl.trim().split("\n")).toHaveLength(1);
+      expect(replay.steps.length).toBe(2);
+      expect(replay.steps[0]!.type).toBe("tool_call");
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/sint-mcp/src/enforcer.ts
+++ b/apps/sint-mcp/src/enforcer.ts
@@ -16,6 +16,7 @@ import { toResourceUri, toSintAction } from "@sint/bridge-mcp";
 import type { MCPToolCall } from "@sint/bridge-mcp";
 import type { ParsedNamespace } from "./aggregator.js";
 import type { DownstreamManager } from "./downstream.js";
+import type { TrajectoryRecorder } from "./trajectory.js";
 
 /**
  * Ordered tier values for comparison.
@@ -78,6 +79,7 @@ export class PolicyEnforcer {
     private readonly downstream: DownstreamManager,
     private readonly agentId: string,
     private readonly tokenId: string,
+    private readonly trajectory?: TrajectoryRecorder,
   ) {}
 
   /**
@@ -94,6 +96,18 @@ export class PolicyEnforcer {
     parsed: ParsedNamespace,
     args: Record<string, unknown>,
   ): Promise<EnforcementResult> {
+    const startedAtMs = Date.now();
+    const parentEventId =
+      typeof args["parentEventId"] === "string"
+        ? args["parentEventId"]
+        : undefined;
+    const tool = `${parsed.serverName}.${parsed.toolName}`;
+    const toolCallEventId = this.trajectory?.recordToolCall({
+      tool,
+      args,
+      parentEventId,
+    });
+
     // Build MCP tool call
     const toolCall: MCPToolCall = {
       callId: generateUUIDv7(),
@@ -117,6 +131,11 @@ export class PolicyEnforcer {
 
     // Route through PolicyGateway
     const decision = await this.gateway.intercept(sintRequest);
+    this.trajectory?.recordDecision(
+      decision.action,
+      tool,
+      toolCallEventId,
+    );
 
     // Record action for combo detection
     this.recentActions.push(`${parsed.serverName}.${parsed.toolName}`);
@@ -138,6 +157,8 @@ export class PolicyEnforcer {
           parsed,
           args,
           `Server "${parsed.serverName}" requires human approval for all non-observe actions`,
+          toolCallEventId,
+          startedAtMs,
         );
       }
     }
@@ -169,11 +190,21 @@ export class PolicyEnforcer {
           parsed.toolName,
           args,
         );
+        this.trajectory?.recordToolResult({
+          tool,
+          result,
+          durationMs: Date.now() - startedAtMs,
+          parentEventId: toolCallEventId,
+        });
+        if (result.isError) {
+          this.trajectory?.recordError("Downstream tool call returned isError=true", tool, toolCallEventId);
+        }
         return { allowed: true, decision, result };
       }
 
       case "deny": {
         const reason = decision.denial?.reason ?? "Denied by SINT policy";
+        this.trajectory?.recordError(reason, tool, toolCallEventId);
         return { allowed: false, decision, denyReason: reason };
       }
 
@@ -184,6 +215,8 @@ export class PolicyEnforcer {
           parsed,
           args,
           decision.escalation?.reason ?? "Requires human approval",
+          toolCallEventId,
+          startedAtMs,
         );
       }
 
@@ -194,10 +227,21 @@ export class PolicyEnforcer {
           parsed.toolName,
           args,
         );
+        this.trajectory?.recordToolResult({
+          tool,
+          result,
+          durationMs: Date.now() - startedAtMs,
+          parentEventId: toolCallEventId,
+        });
         return { allowed: true, decision, result };
       }
 
       default: {
+        this.trajectory?.recordError(
+          `Unknown decision action: ${decision.action}`,
+          tool,
+          toolCallEventId,
+        );
         return {
           allowed: false,
           decision,
@@ -216,7 +260,11 @@ export class PolicyEnforcer {
     parsed: ParsedNamespace,
     args: Record<string, unknown>,
     reason: string,
+    toolCallEventId?: string,
+    startedAtMs?: number,
   ): Promise<EnforcementResult> {
+    const tool = `${parsed.serverName}.${parsed.toolName}`;
+    this.trajectory?.recordEscalation(reason, tool, toolCallEventId);
     const approvalReq = this.approvalQueue.enqueue(sintRequest, decision);
 
     // Wait for resolution with timeout
@@ -228,12 +276,24 @@ export class PolicyEnforcer {
         parsed.toolName,
         args,
       );
+      this.trajectory?.recordToolResult({
+        tool,
+        result,
+        durationMs: startedAtMs !== undefined ? Date.now() - startedAtMs : 0,
+        parentEventId: toolCallEventId,
+      });
       return {
         allowed: true,
         decision,
         approvalRequestId: approvalReq.requestId,
         result,
       };
+    }
+
+    if (resolution === "timeout") {
+      this.trajectory?.markOutcome("timeout");
+    } else {
+      this.trajectory?.recordError(`Escalation denied: ${reason}`, tool, toolCallEventId);
     }
 
     return {

--- a/apps/sint-mcp/src/index.ts
+++ b/apps/sint-mcp/src/index.ts
@@ -21,6 +21,20 @@ import { randomUUID } from "node:crypto";
 import { loadConfig } from "./config.js";
 import { SintMCPServer } from "./server.js";
 
+let activeServer: SintMCPServer | null = null;
+let trajectoryFlushed = false;
+
+async function flushTrajectory(outcome: "success" | "failure" | "partial" | "timeout"): Promise<void> {
+  if (!activeServer || trajectoryFlushed) return;
+  try {
+    const filePath = await activeServer.finalizeTrajectory(outcome);
+    trajectoryFlushed = true;
+    console.error(`  Trajectory: ${filePath}`);
+  } catch (err) {
+    console.error("  Failed to flush trajectory:", err);
+  }
+}
+
 async function main(): Promise<void> {
   const config = loadConfig();
 
@@ -36,6 +50,7 @@ async function main(): Promise<void> {
 
   // Create and initialize server
   const sintMCP = new SintMCPServer(config);
+  activeServer = sintMCP;
   await sintMCP.initialize();
 
   const identity = sintMCP.getIdentity();
@@ -95,17 +110,23 @@ async function main(): Promise<void> {
   // Graceful shutdown
   process.on("SIGINT", async () => {
     console.error("\n  Shutting down...");
+    await flushTrajectory("success");
     await sintMCP.dispose();
     process.exit(0);
   });
 
   process.on("SIGTERM", async () => {
+    await flushTrajectory("success");
     await sintMCP.dispose();
     process.exit(0);
   });
 }
 
-main().catch((err) => {
+main().catch(async (err) => {
   console.error("Fatal error:", err);
+  await flushTrajectory("failure");
+  if (activeServer) {
+    await activeServer.dispose();
+  }
   process.exit(1);
 });

--- a/apps/sint-mcp/src/server.ts
+++ b/apps/sint-mcp/src/server.ts
@@ -36,6 +36,10 @@ import {
   type ResourceContext,
 } from "./resources/sint-resources.js";
 import type { SintMCPConfig } from "./config.js";
+import {
+  TrajectoryRecorder,
+  type TrajectoryOutcome,
+} from "./trajectory.js";
 
 /** SINT MCP Server — the security-first multi-MCP proxy. */
 export class SintMCPServer {
@@ -47,6 +51,7 @@ export class SintMCPServer {
   readonly ledger: LedgerWriter;
   readonly gateway: PolicyGateway;
   readonly approvalQueue: ApprovalQueue;
+  readonly trajectory: TrajectoryRecorder;
 
   private identity: AgentIdentity | null = null;
   private enforcer: PolicyEnforcer | null = null;
@@ -72,6 +77,13 @@ export class SintMCPServer {
     this.ledger = new LedgerWriter();
     this.approvalQueue = new ApprovalQueue({
       defaultTimeoutMs: config.approvalTimeoutMs,
+    });
+    this.trajectory = new TrajectoryRecorder({
+      runId: process.env["PAPERCLIP_RUN_ID"] ?? `run-${Date.now()}`,
+      agentId: process.env["PAPERCLIP_AGENT_ID"] ?? "unknown-agent",
+      taskId: process.env["PAPERCLIP_TASK_ID"] ?? "unknown-task",
+      model: process.env["OPENAI_MODEL"] ?? process.env["MODEL"] ?? "unknown-model",
+      outputDir: process.env["SINT_TRAJECTORY_DIR"] ?? ".sint/trajectories",
     });
 
     this.gateway = new PolicyGateway({
@@ -115,6 +127,7 @@ export class SintMCPServer {
       this.downstream,
       this.identity.publicKey,
       this.identity.defaultToken.tokenId,
+      this.trajectory,
     );
 
     // Connect to downstream servers
@@ -233,6 +246,11 @@ export class SintMCPServer {
    */
   getSintToolCount(): number {
     return getSintToolDefinitions().length;
+  }
+
+  async finalizeTrajectory(outcome: TrajectoryOutcome): Promise<string> {
+    this.trajectory.markOutcome(outcome);
+    return this.trajectory.flushToFile();
   }
 
   private getToolContext(): SintToolContext {

--- a/apps/sint-mcp/src/trajectory.ts
+++ b/apps/sint-mcp/src/trajectory.ts
@@ -1,0 +1,276 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { resolve, join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+function nowISO8601(): string {
+  return new Date().toISOString();
+}
+
+export type TrajectoryEventType =
+  | "tool_call"
+  | "tool_result"
+  | "decision"
+  | "error"
+  | "escalation";
+
+export interface TrajectoryEvent {
+  readonly id: string;
+  readonly runId: string;
+  readonly agentId: string;
+  readonly timestamp: string;
+  readonly type: TrajectoryEventType;
+  readonly payload: {
+    readonly tool?: string;
+    readonly args?: Record<string, unknown>;
+    readonly result?: unknown;
+    readonly reasoning?: string;
+    readonly durationMs?: number;
+  };
+  readonly parentEventId?: string;
+}
+
+export type TrajectoryOutcome = "success" | "failure" | "partial" | "timeout";
+
+export interface Trajectory {
+  readonly runId: string;
+  readonly agentId: string;
+  readonly taskId: string;
+  readonly events: readonly TrajectoryEvent[];
+  readonly outcome: TrajectoryOutcome;
+  readonly startedAt: string;
+  readonly completedAt: string;
+  readonly metadata: {
+    readonly model: string;
+    readonly totalTokens: number;
+    readonly totalToolCalls: number;
+    readonly totalDurationMs: number;
+  };
+}
+
+export interface ReplayStep {
+  readonly index: number;
+  readonly timestamp: string;
+  readonly type: TrajectoryEventType;
+  readonly summary: string;
+  readonly payload: TrajectoryEvent["payload"];
+  readonly parentEventId?: string;
+}
+
+export interface ReplayScript {
+  readonly runId: string;
+  readonly agentId: string;
+  readonly startedAt: string;
+  readonly completedAt: string;
+  readonly steps: readonly ReplayStep[];
+}
+
+export interface TrajectoryRecorderConfig {
+  readonly runId: string;
+  readonly agentId: string;
+  readonly taskId: string;
+  readonly model: string;
+  readonly outputDir: string;
+}
+
+export class TrajectoryRecorder {
+  private readonly runId: string;
+  private readonly agentId: string;
+  private readonly taskId: string;
+  private readonly model: string;
+  private readonly outputDir: string;
+  private readonly startedAt: string;
+  private outcome: TrajectoryOutcome = "success";
+  private totalDurationMs = 0;
+  private totalToolCalls = 0;
+  private readonly events: TrajectoryEvent[] = [];
+
+  constructor(config: TrajectoryRecorderConfig) {
+    this.runId = config.runId;
+    this.agentId = config.agentId;
+    this.taskId = config.taskId;
+    this.model = config.model;
+    this.outputDir = resolve(config.outputDir);
+    this.startedAt = nowISO8601();
+  }
+
+  recordToolCall(input: {
+    readonly tool: string;
+    readonly args: Record<string, unknown>;
+    readonly parentEventId?: string;
+  }): string {
+    const eventId = randomUUID();
+    this.events.push({
+      id: eventId,
+      runId: this.runId,
+      agentId: this.agentId,
+      timestamp: nowISO8601(),
+      type: "tool_call",
+      payload: {
+        tool: input.tool,
+        args: input.args,
+      },
+      parentEventId: input.parentEventId,
+    });
+    this.totalToolCalls += 1;
+    return eventId;
+  }
+
+  recordToolResult(input: {
+    readonly tool: string;
+    readonly result: unknown;
+    readonly durationMs: number;
+    readonly parentEventId?: string;
+  }): string {
+    const eventId = randomUUID();
+    this.events.push({
+      id: eventId,
+      runId: this.runId,
+      agentId: this.agentId,
+      timestamp: nowISO8601(),
+      type: "tool_result",
+      payload: {
+        tool: input.tool,
+        result: input.result,
+        durationMs: input.durationMs,
+      },
+      parentEventId: input.parentEventId,
+    });
+    this.totalDurationMs += input.durationMs;
+    return eventId;
+  }
+
+  recordDecision(decision: string, tool: string, parentEventId?: string): string {
+    return this.pushEvent({
+      type: "decision",
+      payload: {
+        tool,
+        reasoning: decision,
+      },
+      parentEventId,
+    });
+  }
+
+  recordError(reason: string, tool?: string, parentEventId?: string): string {
+    if (this.outcome === "success") {
+      this.outcome = "partial";
+    }
+    return this.pushEvent({
+      type: "error",
+      payload: {
+        tool,
+        reasoning: reason,
+      },
+      parentEventId,
+    });
+  }
+
+  recordEscalation(reason: string, tool?: string, parentEventId?: string): string {
+    return this.pushEvent({
+      type: "escalation",
+      payload: {
+        tool,
+        reasoning: reason,
+      },
+      parentEventId,
+    });
+  }
+
+  markOutcome(outcome: TrajectoryOutcome): void {
+    this.outcome = outcome;
+  }
+
+  snapshot(): Trajectory {
+    return {
+      runId: this.runId,
+      agentId: this.agentId,
+      taskId: this.taskId,
+      events: [...this.events],
+      outcome: this.outcome,
+      startedAt: this.startedAt,
+      completedAt: nowISO8601(),
+      metadata: {
+        model: this.model,
+        totalTokens: 0,
+        totalToolCalls: this.totalToolCalls,
+        totalDurationMs: this.totalDurationMs,
+      },
+    };
+  }
+
+  async flushToFile(): Promise<string> {
+    await mkdir(this.outputDir, { recursive: true });
+    const trajectory = this.snapshot();
+    const filePath = join(this.outputDir, `${this.runId}.json`);
+    await writeFile(filePath, JSON.stringify(trajectory, null, 2), "utf-8");
+    return filePath;
+  }
+
+  private pushEvent(input: {
+    readonly type: TrajectoryEventType;
+    readonly payload: TrajectoryEvent["payload"];
+    readonly parentEventId?: string;
+  }): string {
+    const eventId = randomUUID();
+    this.events.push({
+      id: eventId,
+      runId: this.runId,
+      agentId: this.agentId,
+      timestamp: nowISO8601(),
+      type: input.type,
+      payload: input.payload,
+      parentEventId: input.parentEventId,
+    });
+    return eventId;
+  }
+}
+
+export class TrajectoryExportService {
+  exportJSON(trajectory: Trajectory): string {
+    return JSON.stringify(trajectory, null, 2);
+  }
+
+  exportJSONL(trajectories: readonly Trajectory[]): string {
+    return trajectories.map((t) => JSON.stringify(t)).join("\n");
+  }
+
+  exportReplay(trajectory: Trajectory): ReplayScript {
+    const sorted = [...trajectory.events].sort((a, b) => {
+      return a.timestamp.localeCompare(b.timestamp);
+    });
+
+    const steps: ReplayStep[] = sorted.map((event, idx) => ({
+      index: idx + 1,
+      timestamp: event.timestamp,
+      type: event.type,
+      summary: this.describeEvent(event),
+      payload: event.payload,
+      parentEventId: event.parentEventId,
+    }));
+
+    return {
+      runId: trajectory.runId,
+      agentId: trajectory.agentId,
+      startedAt: trajectory.startedAt,
+      completedAt: trajectory.completedAt,
+      steps,
+    };
+  }
+
+  private describeEvent(event: TrajectoryEvent): string {
+    const tool = event.payload.tool ?? "unknown-tool";
+    switch (event.type) {
+      case "tool_call":
+        return `Call ${tool}`;
+      case "tool_result":
+        return `Result ${tool}`;
+      case "decision":
+        return `Decision ${event.payload.reasoning ?? "n/a"}`;
+      case "error":
+        return `Error ${event.payload.reasoning ?? "n/a"}`;
+      case "escalation":
+        return `Escalation ${event.payload.reasoning ?? "n/a"}`;
+      default:
+        return event.type;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `TrajectoryRecorder` to capture structured run events (tool calls, decisions, escalations, errors, results)
- wire trajectory capture through `PolicyEnforcer` and flush on shutdown/failure in server startup path
- add trajectory export support (JSON, JSONL, replay payload) and focused unit tests

## Validation
- `pnpm --filter @sint/mcp test`
- `pnpm --filter @sint/mcp typecheck`
- `pnpm --filter @sint/mcp build`

## Secret Scanning
- pre-commit scope scan (changed files): 0 findings
- pre-PR diff scan vs merge-base: 0 findings
