### PR TITLE
docs(SINT-494): establish governance baseline docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,69 @@
+# SINT Protocol Architecture
+
+This document defines the current system architecture for the SINT Protocol monorepo.
+
+## 1. System Purpose
+
+SINT is a security enforcement layer between AI agents and high-impact operations (tool calls, code execution, robot actions). The architecture guarantees that authorization, constraints, and auditability are enforced before side effects occur.
+
+## 2. Top-Level Components
+
+- `apps/sint-mcp` (`@sint/mcp`): MCP proxy that mediates upstream clients and downstream MCP servers.
+- `apps/gateway-server` (`@sint/gateway-server`): HTTP API for interception, token ops, approvals, ledger query, and metrics.
+- `apps/dashboard` (`@sint/dashboard`): operator UI for pending approvals and audit visibility.
+
+Core packages:
+
+- `packages/core` (`@sint/core`): shared types, schemas, constants.
+- `packages/capability-tokens` (`@sint/gate-capability-tokens`): Ed25519 token issue/delegate/validate/revoke.
+- `packages/policy-gateway` (`@sint/gate-policy-gateway`): policy engine and interception decisions.
+- `packages/evidence-ledger` (`@sint/gate-evidence-ledger`): hash-chained append-only evidence log.
+- `packages/bridge-mcp` (`@sint/bridge-mcp`): MCP call-to-SINT request mapping.
+- `packages/bridge-ros2` (`@sint/bridge-ros2`): ROS2 action mapping and physics-context extraction.
+- `packages/persistence` (`@sint/persistence`): storage interfaces plus in-memory, PostgreSQL, and Redis adapters.
+- `packages/client` (`@sint/client`): TS client SDK for gateway APIs.
+- `packages/conformance-tests` (`@sint/conformance-tests`): regression suite for security invariants.
+
+## 3. Decision Flow
+
+1. A request enters via MCP bridge, ROS2 bridge, or HTTP endpoint.
+2. Request is normalized into `SintRequest` semantics.
+3. `PolicyGateway.intercept()` computes decision: `allow`, `deny`, `escalate`, or `transform`.
+4. Decision and context are written to the evidence ledger.
+5. If escalation is required, approval queue + dashboard/API workflows handle resolution.
+6. Caller receives final outcome with any applied constraints.
+
+## 4. Security Invariants
+
+These are architectural invariants and must remain true:
+
+- Single choke point: all authorization passes through `PolicyGateway.intercept()`.
+- Attenuation-only delegation: delegated tokens can only reduce privileges.
+- Append-only ledger: events are never updated/deleted after insertion.
+- Explicit fallibility model: operations return result objects; avoid exception-driven control flow.
+- Tiered approvals: T0/T1 auto paths, T2/T3 escalation paths with human/ops controls.
+
+## 5. Data and State Boundaries
+
+- Token lifecycle state: issuance, delegation chains, revocation status.
+- Policy decision state: assigned tiers, risk classification, escalation metadata.
+- Evidence state: hash-linked event history and proof receipts.
+- Approval state: pending and resolved decisions, streamed via SSE for operators.
+
+## 6. Deployment View
+
+Primary runtime surfaces:
+
+- Gateway API on HTTP (health, intercept, tokens, approvals, ledger, metrics).
+- MCP proxy via stdio/SSE integration with upstream MCP clients.
+- Dashboard as separate UI process, polling/streaming against gateway.
+- Storage is interface-driven; in-memory for tests/dev, PostgreSQL/Redis for persistent deployments.
+
+## 7. Change Rules
+
+When architecture changes:
+
+1. Update this file.
+2. Update `CLAUDE.md` if agent guidance changes.
+3. Add an ADR entry in `DECISIONS.md` for architectural choices.
+4. Ensure conformance tests cover new security-relevant behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this repository are documented in this file.
+
+## 2026-03-21
+
+### Added
+- `ARCHITECTURE.md` created to define current SINT system architecture, invariants, and change rules. (Agent: Linus / 116f366b-ccac-4412-8ba9-d22f1d84cc3b)
+- `MODULES.md` created to define canonical app/package module map and governance update rules. (Agent: Linus / 116f366b-ccac-4412-8ba9-d22f1d84cc3b)
+- `CHANGELOG.md` baseline created for protocol-compliant per-task history. (Agent: Linus / 116f366b-ccac-4412-8ba9-d22f1d84cc3b)
+- `DECISIONS.md` baseline created for ADR tracking. (Agent: Linus / 116f366b-ccac-4412-8ba9-d22f1d84cc3b)

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,26 @@
+# Architecture Decision Records
+
+## ADR-0001: Establish Baseline Architecture and Module Governance Docs
+
+- Date: 2026-03-21
+- Status: Accepted
+- Decision Makers: SINT agent execution context (Linus / 116f366b-ccac-4412-8ba9-d22f1d84cc3b)
+
+### Context
+
+The repository did not contain `ARCHITECTURE.md` and `MODULES.md`, while the operational protocol requires both files before implementation planning. The same protocol also defines `DECISIONS.md` and `CHANGELOG.md` as sacred governance files.
+
+### Decision
+
+Create baseline governance files:
+
+- `ARCHITECTURE.md` as the canonical architecture and invariant reference.
+- `MODULES.md` as the canonical module inventory and update policy.
+- `DECISIONS.md` as ADR registry.
+- `CHANGELOG.md` as per-task change log.
+
+### Consequences
+
+- Plan-before-code gates can be executed with required docs present.
+- Future architectural changes must be recorded in ADR format.
+- No runtime or API behavior changes are introduced by this decision.

--- a/MODULES.md
+++ b/MODULES.md
@@ -1,0 +1,69 @@
+# SINT Protocol Module Map
+
+This file is the canonical map of modules in the monorepo.
+
+## Apps
+
+- `apps/gateway-server` (`@sint/gateway-server`)
+  - Role: HTTP policy gateway API, approvals, ledger query, metrics.
+  - Key entry points: `src/index.ts`, `src/server.ts`, `src/routes/*`.
+
+- `apps/sint-mcp` (`@sint/mcp`)
+  - Role: security-first MCP proxy with downstream server aggregation and enforcement.
+  - Key entry points: `src/index.ts`, `src/server.ts`, `src/enforcer.ts`, `src/aggregator.ts`.
+
+- `apps/dashboard` (`@sint/dashboard`)
+  - Role: approval and audit operator UI.
+  - Key entry points: `src/main.tsx`, `src/App.tsx`, `src/components/*`.
+
+## Packages
+
+- `packages/core` (`@sint/core`)
+  - Role: shared types, constants, Zod schemas.
+  - Key paths: `src/types/*`, `src/constants/*`, `src/schemas/*`.
+
+- `packages/capability-tokens` (`@sint/gate-capability-tokens`)
+  - Role: token issue/delegate/validate/revoke and crypto helpers.
+  - Key paths: `src/issuer.ts`, `src/delegator.ts`, `src/validator.ts`, `src/revocation.ts`.
+
+- `packages/policy-gateway` (`@sint/gate-policy-gateway`)
+  - Role: core authorization decision engine and tier/risk assignment.
+  - Key paths: `src/gateway.ts`, `src/tier-assigner.ts`, `src/constraint-checker.ts`, `src/approval-flow.ts`.
+
+- `packages/evidence-ledger` (`@sint/gate-evidence-ledger`)
+  - Role: append-only hash-chained audit event store and proof receipts.
+  - Key paths: `src/writer.ts`, `src/reader.ts`, `src/proof-receipt.ts`.
+
+- `packages/bridge-mcp` (`@sint/bridge-mcp`)
+  - Role: MCP session/interceptor/middleware integration.
+  - Key paths: `src/mcp-interceptor.ts`, `src/mcp-session.ts`, `src/mcp-resource-mapper.ts`.
+
+- `packages/bridge-ros2` (`@sint/bridge-ros2`)
+  - Role: ROS2 request mapping, message typing, QoS modeling.
+  - Key paths: `src/ros2-interceptor.ts`, `src/ros2-resource-mapper.ts`, `src/ros2-message-types.ts`.
+
+- `packages/persistence` (`@sint/persistence`)
+  - Role: storage interfaces plus in-memory and persistent adapters (PostgreSQL/Redis).
+  - Key paths: `src/interfaces.ts`, `src/in-memory-*.ts`, `src/pg-*.ts`, `src/redis-*.ts`.
+
+- `packages/client` (`@sint/client`)
+  - Role: SDK for interacting with gateway APIs.
+  - Key path: `src/sint-client.ts`.
+
+- `packages/conformance-tests` (`@sint/conformance-tests`)
+  - Role: security regression suites across bridges and core policy behavior.
+  - Key paths: `src/security-regression.test.ts`, `src/bridge-mcp-regression.test.ts`, `src/bridge-ros2-regression.test.ts`.
+
+## Docs and Governance Files
+
+- `CLAUDE.md`: agent operating guidance and architecture constraints.
+- `ARCHITECTURE.md`: system design and invariants.
+- `MODULES.md`: module inventory and ownership map.
+- `DECISIONS.md`: architecture decision records (create/update when architecture decisions are made).
+- `CHANGELOG.md`: per-task change log (create/update when issues are completed).
+
+## Update Rules
+
+- Add/update this file whenever a module is added, removed, renamed, or materially repurposed.
+- Keep package names and paths synchronized with `package.json` and workspace layout.
+- Do not add utility modules without recording them here first.


### PR DESCRIPTION
## Summary
- Add `ARCHITECTURE.md` as canonical architecture and invariant reference.
- Add `MODULES.md` as canonical module map.
- Add `DECISIONS.md` with ADR-0001 documenting this governance decision.
- Add `CHANGELOG.md` entry for the task.

## Validation
- Secret scan (staged diff): passed, 0 findings (`trufflehog`).
- Secret scan (full diff vs `origin/main`): passed, 0 findings (`trufflehog`).
- Tests: not run (docs-only changes).

## Handoff
- Changed: `ARCHITECTURE.md`, `MODULES.md`, `DECISIONS.md`, `CHANGELOG.md`
- Pattern: baseline sacred-file governance for protocol compliance
- Next: use these files as mandatory planning gate and update them on architecture/module changes
- Watch: keep ADR/changelog updates coupled to every architectural/task change
