### PR TITLE
feat: ship persistence, websocket approvals, grpc bridge, sdk upgrades, and standards assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ If you are an AI agent (Claude, GPT, Gemini, Cursor, etc.) working in this repo,
 | [`@sint/gate-policy-gateway`](packages/policy-gateway) | Authorization engine: tiers, constraints, rate limiting, M-of-N quorum | 152 |
 | [`@sint/gate-evidence-ledger`](packages/evidence-ledger) | SHA-256 hash-chained append-only audit log with TEE attestation | 45 |
 
-### Bridges (11 bridges)
+### Bridges (12 bridges)
 
 | Package | Description | Tests |
 |---------|-------------|-------|
@@ -143,10 +143,10 @@ If you are an AI agent (Claude, GPT, Gemini, Cursor, etc.) working in this repo,
 | [`@sint/bridge-mqtt-sparkplug`](packages/bridge-mqtt-sparkplug) | MQTT Sparkplug profile mapping with industrial command tiering defaults | 8 |
 | [`@sint/bridge-opcua`](packages/bridge-opcua) | OPC UA node/method mapping with safety-critical write/call promotion | 6 |
 | [`@sint/bridge-open-rmf`](packages/bridge-open-rmf) | Open-RMF fleet/facility mapping for warehouse dispatch workflows | 5 |
+| [`@sint/bridge-grpc`](packages/bridge-grpc) | gRPC service/method profile mapping with default tier assignment | 5 |
 | [`@sint/bridge-economy`](packages/bridge-economy) | Economy bridge: balance, budget, trust, billing ports | 47 |
 | [`@sint/bridge-mavlink`](packages/bridge-mavlink) | MAVLink drone/UAV command bridge | 15 |
 | [`@sint/bridge-swarm`](packages/bridge-swarm) | Multi-robot swarm coordination bridge | 9 |
-| [`@sint/bridge-economy`](packages/bridge-economy) | Economy enforcement: balance, budget, trust, billing | 47 |
 
 ### Engine (AI Execution Layer)
 
@@ -341,6 +341,7 @@ Machine-readable crosswalk endpoint: `GET /v1/compliance/tier-crosswalk`
 | `GET` | `/v1/approvals/pending` | List pending approval requests |
 | `POST` | `/v1/approvals/:id/resolve` | Approve or deny a request (M-of-N quorum) |
 | `GET` | `/v1/approvals/events` | SSE stream for real-time approval events |
+| `GET` | `/v1/approvals/ws` | WebSocket stream for low-latency approval events |
 | `POST` | `/v1/a2a` | JSON-RPC 2.0 A2A protocol endpoint |
 | `GET` | `/v1/metrics` | Prometheus metrics |
 | `GET` | `/v1/openapi.json` | OpenAPI surface for gateway integration |
@@ -402,6 +403,9 @@ docker-compose up
 - Deployment profiles: [`docs/profiles/`](docs/profiles/)
 - Examples: [`examples/`](examples/) (hello-world, warehouse-amr, industrial-cell)
 - Multi-language SDKs: [`sdks/`](sdks/) (TypeScript, Python, Go)
+- Persistence baseline guide: [`docs/guides/persistence-baseline.md`](docs/guides/persistence-baseline.md)
+- WebSocket approvals guide: [`docs/guides/websocket-approvals.md`](docs/guides/websocket-approvals.md)
+- gRPC bridge guide: [`docs/guides/grpc-bridge-skeleton.md`](docs/guides/grpc-bridge-skeleton.md)
 - Benchmark report: [`docs/reports/industrial-benchmark-report.md`](docs/reports/industrial-benchmark-report.md)
 - ROS2 loop benchmark report: [`docs/reports/ros2-control-loop-benchmark.md`](docs/reports/ros2-control-loop-benchmark.md)
 - Hardware safety controller roadmap: [`docs/roadmaps/hardware-safety-controller-integration.md`](docs/roadmaps/hardware-safety-controller-integration.md)

--- a/apps/gateway-server/__tests__/api.test.ts
+++ b/apps/gateway-server/__tests__/api.test.ts
@@ -68,6 +68,8 @@ describe("Gateway Server API", () => {
     expect(body.version).toBeDefined();
     expect(Array.isArray(body.supportedBridges)).toBe(true);
     expect(Array.isArray(body.deploymentProfiles)).toBe(true);
+    expect(body.approvalTransports?.sse).toBe("/v1/approvals/events");
+    expect(body.approvalTransports?.websocket).toBe("/v1/approvals/ws");
     expect(body.complianceCrosswalk?.path).toBe("/v1/compliance/tier-crosswalk");
   });
 
@@ -85,6 +87,8 @@ describe("Gateway Server API", () => {
     const body = await res.json();
     expect(body.openapi).toBe("3.1.0");
     expect(body.paths["/.well-known/sint.json"]).toBeDefined();
+    expect(body.paths["/v1/approvals/events"]).toBeDefined();
+    expect(body.paths["/v1/approvals/ws"]).toBeDefined();
     expect(body.paths["/v1/compliance/tier-crosswalk"]).toBeDefined();
   });
 

--- a/apps/gateway-server/package.json
+++ b/apps/gateway-server/package.json
@@ -33,10 +33,12 @@
     "@sint/bridge-a2a": "workspace:*",
     "@sint/persistence": "workspace:*",
     "hono": "^4.7.0",
+    "ws": "^8.18.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {
     "@types/node": "^22.13.0",
+    "@types/ws": "^8.18.1",
     "ioredis": "^5.4.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",

--- a/apps/gateway-server/src/index.ts
+++ b/apps/gateway-server/src/index.ts
@@ -10,25 +10,38 @@
 import { serve } from "@hono/node-server";
 import { createApp, createPersistentContext } from "./server.js";
 import { loadConfig } from "./config.js";
+import { attachApprovalsWebSocket } from "./ws/approvals-websocket.js";
 
-const config = loadConfig();
-const ctx = createPersistentContext(config);
-const app = createApp(ctx, {
-  apiKey: config.apiKey,
-  requireSignatures: config.requireSignatures,
-  rateLimitMax: config.rateLimitMax,
-});
+async function main(): Promise<void> {
+  const config = loadConfig();
+  const ctx = await createPersistentContext(config);
+  const app = createApp(ctx, {
+    apiKey: config.apiKey,
+    requireSignatures: config.requireSignatures,
+    rateLimitMax: config.rateLimitMax,
+  });
 
-serve({ fetch: app.fetch, port: config.port }, (info) => {
-  console.log(`
+  const server = serve({ fetch: app.fetch, port: config.port }, (info) => {
+    console.log(`
   ╔═══════════════════════════════════════════════╗
   ║         SINT GATE — Policy Gateway            ║
   ║         Security Wedge for Physical AI        ║
   ╠═══════════════════════════════════════════════╣
   ║  Server:  http://localhost:${info.port}              ║
   ║  Health:  http://localhost:${info.port}/v1/health     ║
+  ║  Approvals SSE: http://localhost:${info.port}/v1/approvals/events ║
+  ║  Approvals WS:  ws://localhost:${info.port}/v1/approvals/ws ║
   ║  Store:   ${config.store.padEnd(35)}║
   ║  Cache:   ${config.cache.padEnd(35)}║
   ╚═══════════════════════════════════════════════╝
   `);
+  });
+
+  // WebSocket approval transport (Issue #2): low-latency queue updates.
+  attachApprovalsWebSocket(server as any, ctx, { apiKey: config.apiKey });
+}
+
+void main().catch((err) => {
+  console.error("[SINT] gateway startup failed", err);
+  process.exit(1);
 });

--- a/apps/gateway-server/src/routes/approvals.ts
+++ b/apps/gateway-server/src/routes/approvals.ts
@@ -2,8 +2,9 @@
  * SINT Gateway Server — Approval routes.
  *
  * REST endpoints for managing the human approval queue.
- * WebSocket support can be layered on top via Hono's
- * WebSocket adapter when running in a Node.js environment.
+ * Real-time transports:
+ * - SSE: /v1/approvals/events (implemented here)
+ * - WebSocket: /v1/approvals/ws (attached at HTTP server level)
  */
 
 import { Hono } from "hono";

--- a/apps/gateway-server/src/routes/discovery.ts
+++ b/apps/gateway-server/src/routes/discovery.ts
@@ -51,6 +51,10 @@ export function discoveryRoutes(): Hono {
         path: "/v1/compliance/tier-crosswalk",
         frameworks: ["nist-ai-rmf-1.0", "iso-iec-42001-2023", "eu-ai-act-2024-1689"],
       },
+      approvalTransports: {
+        sse: "/v1/approvals/events",
+        websocket: "/v1/approvals/ws",
+      },
       openapi: "/v1/openapi.json",
     });
   });
@@ -105,6 +109,8 @@ export function discoveryRoutes(): Hono {
         "/v1/tokens/revoke": { post: { summary: "Revoke capability token" } },
         "/v1/ledger": { get: { summary: "Query evidence ledger" } },
         "/v1/approvals/pending": { get: { summary: "List pending approvals" } },
+        "/v1/approvals/events": { get: { summary: "SSE approval stream" } },
+        "/v1/approvals/ws": { get: { summary: "WebSocket approval stream (Upgrade)" } },
         "/v1/approvals/{requestId}/resolve": { post: { summary: "Resolve approval" } },
         "/v1/a2a": { post: { summary: "A2A JSON-RPC endpoint" } },
         "/v1/a2a/agents": { get: { summary: "List A2A agents" }, post: { summary: "Register A2A agent" } },

--- a/apps/gateway-server/src/server.ts
+++ b/apps/gateway-server/src/server.ts
@@ -22,6 +22,7 @@ import {
   PgTokenStore,
   PgLedgerStore,
   getPool,
+  ensurePgSchema,
   RedisCache,
   RedisRevocationBus,
 } from "@sint/persistence";
@@ -107,7 +108,7 @@ export function createContext(): ServerContext {
  * - RedisCache: Distributed TTL cache for hot token lookups
  * - RedisRevocationBus: Pub/sub for <1s revocation propagation across nodes
  */
-export function createPersistentContext(config: SintConfig): ServerContext {
+export async function createPersistentContext(config: SintConfig): Promise<ServerContext> {
   let tokenStore: TokenStore;
   let ledgerStore: LedgerStore;
   let cache: CacheStore;
@@ -116,8 +117,10 @@ export function createPersistentContext(config: SintConfig): ServerContext {
   // ── Storage backend ──
   if (config.store === "postgres" && config.databaseUrl) {
     const pool = getPool({ connectionString: config.databaseUrl });
+    await ensurePgSchema(pool);
     tokenStore = new PgTokenStore(pool);
     ledgerStore = new PgLedgerStore(pool);
+    console.log("[SINT] PostgreSQL schema verified");
   } else {
     tokenStore = new InMemoryTokenStore();
     ledgerStore = new InMemoryLedgerStore();
@@ -127,6 +130,9 @@ export function createPersistentContext(config: SintConfig): ServerContext {
   if (config.cache === "redis" && config.redisUrl) {
     const redisPublisher = createRedisClient(config.redisUrl);
     const redisCacheClient = createRedisClient(config.redisUrl);
+    // Fail-fast connectivity check so deploy issues surface at startup.
+    await redisPublisher.ping();
+    await redisCacheClient.ping();
     cache = new RedisCache(redisCacheClient);
     const redisUrl = config.redisUrl;
     revocationBus = new RedisRevocationBus(

--- a/apps/gateway-server/src/ws/approvals-websocket.ts
+++ b/apps/gateway-server/src/ws/approvals-websocket.ts
@@ -1,0 +1,85 @@
+/**
+ * SINT Gateway Server — Approval WebSocket transport.
+ *
+ * Provides low-latency approval queue updates as an alternative transport
+ * to the existing SSE endpoint at /v1/approvals/events.
+ *
+ * @module @sint/gateway-server/ws/approvals-websocket
+ */
+
+import type { Server as HttpServer, IncomingMessage } from "node:http";
+import { WebSocketServer, type WebSocket } from "ws";
+import type { ServerContext } from "../server.js";
+
+const WS_APPROVALS_PATH = "/v1/approvals/ws";
+
+export interface ApprovalsWebSocketOptions {
+  /** Optional API key; when set, clients must provide x-api-key or ?apiKey=. */
+  readonly apiKey?: string;
+}
+
+function isAuthorized(req: IncomingMessage, expectedApiKey?: string): boolean {
+  if (!expectedApiKey) return true;
+  const headerKey = req.headers["x-api-key"];
+  const providedHeader = Array.isArray(headerKey) ? headerKey[0] : headerKey;
+  if (providedHeader === expectedApiKey) return true;
+
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const queryKey = url.searchParams.get("apiKey");
+  return queryKey === expectedApiKey;
+}
+
+function safeSend(socket: WebSocket, payload: unknown): void {
+  if (socket.readyState !== socket.OPEN) return;
+  socket.send(JSON.stringify(payload));
+}
+
+/**
+ * Attach the approval WebSocket endpoint to an existing HTTP server.
+ * Path: /v1/approvals/ws
+ */
+export function attachApprovalsWebSocket(
+  server: HttpServer,
+  ctx: ServerContext,
+  options?: ApprovalsWebSocketOptions,
+): void {
+  const wss = new WebSocketServer({ noServer: true });
+
+  server.on("upgrade", (req, socket, head) => {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    if (url.pathname !== WS_APPROVALS_PATH) return;
+
+    if (!isAuthorized(req, options?.apiKey)) {
+      socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
+      socket.destroy();
+      return;
+    }
+
+    wss.handleUpgrade(req, socket, head, (ws: WebSocket) => {
+      wss.emit("connection", ws, req);
+    });
+  });
+
+  wss.on("connection", (ws: WebSocket) => {
+    // Initial snapshot so clients immediately render current queue state.
+    safeSend(ws, {
+      type: "snapshot",
+      pending: ctx.approvalQueue.getPending(),
+      timestamp: new Date().toISOString(),
+    });
+
+    const unsubscribe = ctx.approvalQueue.on((event) => {
+      safeSend(ws, event);
+    });
+
+    const heartbeat = setInterval(() => {
+      if (ws.readyState !== ws.OPEN) return;
+      safeSend(ws, { type: "heartbeat", ts: new Date().toISOString() });
+    }, 30_000);
+
+    ws.on("close", () => {
+      clearInterval(heartbeat);
+      unsubscribe();
+    });
+  });
+}

--- a/apps/gateway-server/src/ws/ws-compat.d.ts
+++ b/apps/gateway-server/src/ws/ws-compat.d.ts
@@ -1,0 +1,27 @@
+declare module "ws" {
+  import type { IncomingMessage } from "node:http";
+  import type { Duplex } from "node:stream";
+
+  export class WebSocket {
+    static readonly OPEN: number;
+    readonly OPEN: number;
+    readonly readyState: number;
+    send(data: string): void;
+    on(event: "close", listener: () => void): this;
+  }
+
+  export class WebSocketServer {
+    constructor(options?: { noServer?: boolean });
+    handleUpgrade(
+      request: IncomingMessage,
+      socket: Duplex,
+      head: Buffer,
+      cb: (socket: WebSocket) => void,
+    ): void;
+    emit(event: "connection", socket: WebSocket, request: IncomingMessage): boolean;
+    on(
+      event: "connection",
+      listener: (socket: WebSocket, request: IncomingMessage) => void,
+    ): this;
+  }
+}

--- a/apps/gateway-server/tsconfig.json
+++ b/apps/gateway-server/tsconfig.json
@@ -12,6 +12,6 @@
     { "path": "../../packages/bridge-economy" },
     { "path": "../../packages/bridge-a2a" }
   ],
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/docs/diagrams/state-machine-mermaid.md
+++ b/docs/diagrams/state-machine-mermaid.md
@@ -1,0 +1,47 @@
+# SINT State Machines (Mermaid)
+
+Tracking issue: #20
+
+## Policy Decision Flow
+
+```mermaid
+flowchart LR
+  A["Request Received"] --> B["Validate Token + Constraints"]
+  B --> C{"Policy Result"}
+  C -->|Allow T0/T1| D["Allow + Ledger Event"]
+  C -->|Escalate T2/T3| E["Approval Queue"]
+  C -->|Deny| F["Deny + Ledger Event"]
+  E --> G{"Approved?"}
+  G -->|Yes| H["Allow + approval.granted"]
+  G -->|No| I["Deny + approval.denied"]
+  E --> J{"Timeout"}
+  J -->|Fallback deny/safe-stop| K["Timeout Resolution + Ledger"]
+```
+
+## Approval Queue Lifecycle
+
+```mermaid
+stateDiagram-v2
+  [*] --> Queued
+  Queued --> Approved: quorum reached
+  Queued --> Denied: reviewer denial
+  Queued --> Timeout: deadline exceeded
+  Approved --> [*]
+  Denied --> [*]
+  Timeout --> [*]
+```
+
+## Revocation + Enforcement
+
+```mermaid
+flowchart LR
+  A["Token Revoked"] --> B["Revocation Bus Publish"]
+  B --> C["All Gateways Update Local RevocationStore"]
+  C --> D["Intercept Request"]
+  D --> E{"Tier"}
+  E -->|T0/T1| F["Apply normal checks"]
+  E -->|T2/T3| G{"Revoked?"}
+  G -->|Yes| H["Fail-closed deny"]
+  G -->|No| I["Continue policy pipeline"]
+```
+

--- a/docs/guides/grpc-bridge-skeleton.md
+++ b/docs/guides/grpc-bridge-skeleton.md
@@ -1,0 +1,20 @@
+# gRPC Bridge Skeleton (Issues #3 / #19)
+
+SINT now includes a baseline gRPC bridge package:
+
+- `@sint/bridge-grpc`
+
+## Included in v0 skeleton
+
+- Canonical gRPC resource URI mapper (`grpc://host/service/method`)
+- Call-pattern to action mapping (`unary`, `client_stream`, `server_stream`, `bidi_stream`)
+- Default tier mapping with safety-critical promotion heuristics
+- Discovery bridge profile export (`GRPC_BRIDGE_PROFILE`)
+- Unit tests for URI/action/tier behavior
+
+## What comes next
+
+- Runtime interceptor middleware for popular Node gRPC stacks
+- Conformance fixtures for warehouse/factory gRPC commands
+- Adapter docs for Envoy/ext-authz and sidecar deployment models
+

--- a/docs/guides/persistence-baseline.md
+++ b/docs/guides/persistence-baseline.md
@@ -1,0 +1,31 @@
+# Persistence Baseline (Issue #1)
+
+This guide describes the production baseline for SINT Gateway persistence.
+
+## What is now baseline
+
+- PostgreSQL-backed token + ledger stores (`SINT_STORE=postgres`)
+- Redis-backed cache + revocation bus (`SINT_CACHE=redis`)
+- Startup schema bootstrap (`ensurePgSchema`) for required tables/indexes
+- Redis fail-fast connectivity checks at gateway boot
+
+## Required environment
+
+```bash
+SINT_STORE=postgres
+SINT_CACHE=redis
+DATABASE_URL=postgresql://sint:sint@localhost:5432/sint
+REDIS_URL=redis://localhost:6379
+```
+
+## Operational checks
+
+1. `GET /v1/health` returns `status=ok`
+2. Issue token, intercept request, and query `/v1/ledger`
+3. Revoke token on one node and verify denial on another node
+
+## Notes
+
+- Schema creation is idempotent and runs at startup when `SINT_STORE=postgres`.
+- Redis startup checks are fail-fast to avoid hidden partial-deploy failures.
+

--- a/docs/guides/websocket-approvals.md
+++ b/docs/guides/websocket-approvals.md
@@ -1,0 +1,28 @@
+# WebSocket Approval Transport (Issue #2)
+
+SINT now supports approval queue streaming over WebSocket in addition to SSE.
+
+## Endpoints
+
+- SSE: `GET /v1/approvals/events`
+- WebSocket: `ws://<host>/v1/approvals/ws`
+
+## Authentication
+
+If `SINT_API_KEY` is configured, provide either:
+
+- `x-api-key` header, or
+- `?apiKey=<key>` query parameter
+
+## Event model
+
+- Initial `snapshot` payload with current pending requests
+- Incremental queue events (`queued`, `resolved`, `timeout`)
+- Periodic `heartbeat` event every 30s
+
+## Why use WebSocket
+
+- Lower latency for high-frequency operator workflows
+- Bi-directional transport compatibility for future interactive controls
+- Better fit for control-room and NOC dashboard integrations
+

--- a/docs/rfcs/SINT_PROTOCOL_DESIGN_RFC.md
+++ b/docs/rfcs/SINT_PROTOCOL_DESIGN_RFC.md
@@ -1,0 +1,73 @@
+# RFC: SINT Protocol Design Baseline (2026)
+
+## Status
+
+- Draft
+- Owner: SINT maintainers
+- Tracking issue: #22
+
+## Problem
+
+Agent ecosystems now have strong standards for:
+
+- agent-to-tool (`MCP`)
+- agent-to-agent (`A2A`)
+
+But they still lack a portable, enforceable governance layer for real-world execution.
+SINT defines this missing control plane.
+
+## Scope
+
+SINT covers:
+
+- delegated authority via capability tokens
+- runtime policy enforcement at a single choke point
+- deterministic tiering and human escalation
+- append-only evidence with chain-of-custody
+- bridge profiles for physical and industrial protocols
+
+SINT does not replace robot safety PLCs or orchestration runtimes.
+
+## Core Invariants
+
+1. All execution paths pass through `PolicyGateway.intercept()`.
+2. Tokens are attenuation-only (child scope cannot exceed parent scope).
+3. Evidence is append-only and hash chained.
+4. Revocation must never fail open for T2/T3 actions.
+
+## Protocol Surfaces
+
+- Discovery: `GET /.well-known/sint.json`
+- Schemas: `GET /v1/schemas`, `GET /v1/schemas/:name`
+- Compliance mapping: `GET /v1/compliance/tier-crosswalk`
+- Runtime API: intercept, approvals, tokens, ledger
+- Real-time approvals:
+  - SSE: `/v1/approvals/events`
+  - WebSocket: `/v1/approvals/ws`
+
+## Standards Positioning
+
+- MCP remains tool-call protocol.
+- A2A remains inter-agent protocol.
+- SINT provides delegated authority, runtime safety policy, and evidence.
+
+## Compliance Mapping
+
+SINT tiers are mapped in the protocol crosswalk to:
+
+- NIST AI RMF
+- ISO/IEC 42001
+- EU AI Act (agentic/high-risk execution contexts)
+
+## Open Questions
+
+1. gRPC bridge conformance profile depth for v0.3.
+2. Conformance certification scope for external bridge implementations.
+3. Governance cadence for SIP/RFC acceptance.
+
+## Acceptance Criteria
+
+- Publish this RFC in docs.
+- Keep crosswalk endpoint and schema in sync with implementation.
+- Maintain conformance fixtures for bridge/profile additions.
+

--- a/packages/bridge-grpc/__tests__/grpc-resource-mapper.test.ts
+++ b/packages/bridge-grpc/__tests__/grpc-resource-mapper.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { ApprovalTier } from "@sint/core";
+import {
+  grpcMethodToResourceUri,
+  grpcPatternToAction,
+  isSafetyCriticalGrpcMethod,
+  defaultTierForGrpcMethod,
+} from "../src/index.js";
+
+describe("grpcMethodToResourceUri", () => {
+  it("builds canonical URI with explicit host", () => {
+    expect(
+      grpcMethodToResourceUri("warehouse.v1.DispatchService", "DispatchTask", "rmf-gw.local:50051"),
+    ).toBe("grpc://rmf-gw.local:50051/warehouse.v1.DispatchService/DispatchTask");
+  });
+
+  it("falls back to local host when host missing", () => {
+    expect(grpcMethodToResourceUri("ops.v1.Health", "Watch")).toBe("grpc://local/ops.v1.Health/Watch");
+  });
+});
+
+describe("grpc pattern/action and tier defaults", () => {
+  it("maps server stream to observe/T0", () => {
+    expect(grpcPatternToAction("server_stream")).toBe("observe");
+    expect(defaultTierForGrpcMethod("server_stream", "ops.v1.Health", "Watch")).toBe(
+      ApprovalTier.T0_OBSERVE,
+    );
+  });
+
+  it("maps unary non-critical methods to T2", () => {
+    expect(grpcPatternToAction("unary")).toBe("call");
+    expect(defaultTierForGrpcMethod("unary", "warehouse.v1.DispatchService", "DispatchTask")).toBe(
+      ApprovalTier.T2_ACT,
+    );
+  });
+
+  it("promotes safety critical methods to T3", () => {
+    expect(isSafetyCriticalGrpcMethod("robot.v1.Safety", "EmergencyStop")).toBe(true);
+    expect(defaultTierForGrpcMethod("unary", "robot.v1.Safety", "EmergencyStop")).toBe(
+      ApprovalTier.T3_COMMIT,
+    );
+  });
+});
+

--- a/packages/bridge-grpc/package.json
+++ b/packages/bridge-grpc/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@sint/bridge-grpc",
+  "version": "0.1.0",
+  "description": "SINT Bridge — gRPC profile adapter for service/method governance with tier defaults",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc --build",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "test": "vitest run",
+    "test:watch": "vitest watch"
+  },
+  "dependencies": {
+    "@sint/core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}
+

--- a/packages/bridge-grpc/src/grpc-resource-mapper.ts
+++ b/packages/bridge-grpc/src/grpc-resource-mapper.ts
@@ -1,0 +1,85 @@
+import { ApprovalTier, type BridgeProfile } from "@sint/core";
+import type { GrpcCallPattern } from "./types.js";
+
+const SAFETY_CRITICAL_KEYWORDS = [
+  "safety",
+  "estop",
+  "emergency",
+  "shutdown",
+  "arm",
+  "unlock",
+  "startcycle",
+  "stopcycle",
+  "commit",
+  "transferfunds",
+];
+
+function normalizeHost(host?: string): string {
+  if (!host) return "local";
+  return host.replace(/[^a-zA-Z0-9.:-]/g, "_");
+}
+
+function encodeSegment(value: string): string {
+  return encodeURIComponent(value.trim());
+}
+
+/** Canonical SINT resource URI for a gRPC method. */
+export function grpcMethodToResourceUri(
+  service: string,
+  method: string,
+  host?: string,
+): string {
+  const normalizedHost = normalizeHost(host);
+  return `grpc://${normalizedHost}/${encodeSegment(service)}/${encodeSegment(method)}`;
+}
+
+/** Map gRPC call pattern to canonical SINT action category. */
+export function grpcPatternToAction(pattern: GrpcCallPattern): "observe" | "call" | "write" {
+  switch (pattern) {
+    case "server_stream":
+      return "observe";
+    case "client_stream":
+      return "write";
+    case "bidi_stream":
+      return "call";
+    case "unary":
+      return "call";
+  }
+}
+
+/** Detect whether a method should be treated as safety-critical by default. */
+export function isSafetyCriticalGrpcMethod(service: string, method: string): boolean {
+  const haystack = `${service}.${method}`.toLowerCase();
+  return SAFETY_CRITICAL_KEYWORDS.some((word) => haystack.includes(word));
+}
+
+/** Conservative default tier assignment for gRPC execution. */
+export function defaultTierForGrpcMethod(
+  pattern: GrpcCallPattern,
+  service: string,
+  method: string,
+): ApprovalTier {
+  const action = grpcPatternToAction(pattern);
+
+  if (action === "observe") return ApprovalTier.T0_OBSERVE;
+  if (isSafetyCriticalGrpcMethod(service, method)) return ApprovalTier.T3_COMMIT;
+  if (action === "write" || action === "call") return ApprovalTier.T2_ACT;
+  return ApprovalTier.T1_PREPARE;
+}
+
+/** Discovery profile for gRPC bridge integration. */
+export const GRPC_BRIDGE_PROFILE: BridgeProfile = {
+  bridgeId: "grpc",
+  protocol: "grpc",
+  version: "grpc-v1",
+  resourcePattern: "grpc://*/**",
+  defaultTierByAction: {
+    observe: ApprovalTier.T0_OBSERVE,
+    read: ApprovalTier.T0_OBSERVE,
+    write: ApprovalTier.T2_ACT,
+    call: ApprovalTier.T2_ACT,
+  },
+  notes:
+    "gRPC bridge profile for unary/stream calls. Safety-critical methods are promoted to T3 by keyword policy.",
+};
+

--- a/packages/bridge-grpc/src/index.ts
+++ b/packages/bridge-grpc/src/index.ts
@@ -1,0 +1,9 @@
+export type { GrpcCallPattern, GrpcMethodDescriptor, GrpcBridgeProfile } from "./types.js";
+export {
+  grpcMethodToResourceUri,
+  grpcPatternToAction,
+  isSafetyCriticalGrpcMethod,
+  defaultTierForGrpcMethod,
+  GRPC_BRIDGE_PROFILE,
+} from "./grpc-resource-mapper.js";
+

--- a/packages/bridge-grpc/src/types.ts
+++ b/packages/bridge-grpc/src/types.ts
@@ -1,0 +1,15 @@
+import type { BridgeProfile } from "@sint/core";
+
+export type GrpcCallPattern = "unary" | "client_stream" | "server_stream" | "bidi_stream";
+
+export interface GrpcMethodDescriptor {
+  readonly service: string;
+  readonly method: string;
+  readonly host?: string;
+  readonly pattern?: GrpcCallPattern;
+}
+
+export interface GrpcBridgeProfile extends BridgeProfile {
+  readonly protocol: "grpc";
+}
+

--- a/packages/bridge-grpc/tsconfig.json
+++ b/packages/bridge-grpc/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts", "__tests__/**/*.ts"]
+}
+

--- a/packages/bridge-grpc/vitest.config.ts
+++ b/packages/bridge-grpc/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["__tests__/**/*.test.ts"],
+    coverage: {
+      enabled: false,
+    },
+  },
+});
+

--- a/packages/conformance-tests/fixtures/protocol/well-known-sint.v0.2.example.json
+++ b/packages/conformance-tests/fixtures/protocol/well-known-sint.v0.2.example.json
@@ -8,23 +8,24 @@
     {
       "siteId": "warehouse-amr",
       "deploymentProfile": "warehouse-amr",
-      "bridges": ["mcp", "a2a", "ros2", "mqtt-sparkplug", "open-rmf"]
+      "bridges": ["mcp", "a2a", "ros2", "grpc", "mqtt-sparkplug", "open-rmf"]
     },
     {
       "siteId": "industrial-cell",
       "deploymentProfile": "industrial-cell",
-      "bridges": ["mcp", "a2a", "ros2", "opcua", "mqtt-sparkplug"]
+      "bridges": ["mcp", "a2a", "ros2", "grpc", "opcua", "mqtt-sparkplug"]
     },
     {
       "siteId": "edge-gateway",
       "deploymentProfile": "edge-gateway",
-      "bridges": ["mqtt-sparkplug", "opcua", "open-rmf"]
+      "bridges": ["grpc", "mqtt-sparkplug", "opcua", "open-rmf"]
     }
   ],
   "supportedBridges": [
     { "bridgeId": "mcp", "protocol": "mcp", "version": "1.x", "resourcePattern": "mcp://*/**" },
     { "bridgeId": "a2a", "protocol": "a2a", "version": "0.x", "resourcePattern": "a2a://*/**" },
     { "bridgeId": "ros2", "protocol": "ros2", "version": "jazzy+", "resourcePattern": "ros2:///**" },
+    { "bridgeId": "grpc", "protocol": "grpc", "version": "grpc-v1", "resourcePattern": "grpc://*/**" },
     { "bridgeId": "mavlink", "protocol": "mavlink", "version": "v2", "resourcePattern": "mavlink://*/**" },
     { "bridgeId": "mqtt-sparkplug", "protocol": "mqtt", "version": "sparkplug-b-v3", "resourcePattern": "mqtt-sparkplug:///**" },
     { "bridgeId": "opcua", "protocol": "opcua", "version": "1.05+", "resourcePattern": "opcua://*/**" },
@@ -39,6 +40,10 @@
   "complianceCrosswalk": {
     "path": "/v1/compliance/tier-crosswalk",
     "frameworks": ["nist-ai-rmf-1.0", "iso-iec-42001-2023", "eu-ai-act-2024-1689"]
+  },
+  "approvalTransports": {
+    "sse": "/v1/approvals/events",
+    "websocket": "/v1/approvals/ws"
   },
   "openapi": "/v1/openapi.json"
 }

--- a/packages/core/src/constants/profiles.ts
+++ b/packages/core/src/constants/profiles.ts
@@ -50,6 +50,18 @@ export const SINT_BRIDGE_PROFILES: readonly BridgeProfile[] = [
     notes: "Robot runtime ingress for AMR and industrial cells.",
   },
   {
+    bridgeId: "grpc",
+    protocol: "grpc",
+    version: "grpc-v1",
+    resourcePattern: "grpc://*/**",
+    defaultTierByAction: {
+      observe: ApprovalTier.T0_OBSERVE,
+      call: ApprovalTier.T2_ACT,
+      write: ApprovalTier.T2_ACT,
+    },
+    notes: "Generic service ingress for unary/stream RPC governance.",
+  },
+  {
     bridgeId: "mavlink",
     protocol: "mavlink",
     version: "v2",
@@ -105,21 +117,21 @@ export const SINT_SITE_PROFILES: readonly SiteProfile[] = [
   {
     siteId: "warehouse-amr",
     deploymentProfile: "warehouse-amr",
-    bridges: ["mcp", "a2a", "ros2", "mqtt-sparkplug", "open-rmf"],
+    bridges: ["mcp", "a2a", "ros2", "grpc", "mqtt-sparkplug", "open-rmf"],
     defaultEscalationTheta: 0.15,
     notes: "Human-shared warehouse environment with AMR fleets.",
   },
   {
     siteId: "industrial-cell",
     deploymentProfile: "industrial-cell",
-    bridges: ["mcp", "a2a", "ros2", "opcua", "mqtt-sparkplug"],
+    bridges: ["mcp", "a2a", "ros2", "grpc", "opcua", "mqtt-sparkplug"],
     defaultEscalationTheta: 0.2,
     notes: "Safety-fenced manipulator cell with PLC interlock dependencies.",
   },
   {
     siteId: "edge-gateway",
     deploymentProfile: "edge-gateway",
-    bridges: ["mqtt-sparkplug", "opcua", "open-rmf"],
+    bridges: ["grpc", "mqtt-sparkplug", "opcua", "open-rmf"],
     defaultEscalationTheta: 0.25,
     notes: "Local T0/T1 verification profile with central T2/T3 escalation.",
   },

--- a/packages/persistence/__tests__/pg-schema.test.ts
+++ b/packages/persistence/__tests__/pg-schema.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from "vitest";
+import { ensurePgSchema } from "../src/pg-schema.js";
+
+describe("ensurePgSchema", () => {
+  it("creates all required tables and indexes idempotently", async () => {
+    const query = vi.fn(async (_sql: string) => ({ rows: [] }));
+    const pool = { query } as unknown as import("pg").Pool;
+
+    await ensurePgSchema(pool);
+
+    expect(query).toHaveBeenCalled();
+    const sql = query.mock.calls.map(([statement]) => String(statement)).join("\n");
+
+    expect(sql).toContain("CREATE TABLE IF NOT EXISTS sint_ledger_events");
+    expect(sql).toContain("CREATE TABLE IF NOT EXISTS sint_tokens");
+    expect(sql).toContain("CREATE TABLE IF NOT EXISTS sint_revocations");
+    expect(sql).toContain("CREATE TABLE IF NOT EXISTS sint_rate_limit_counters");
+    expect(sql).toContain("CREATE INDEX IF NOT EXISTS idx_sint_ledger_agent_seq");
+    expect(sql).toContain("CREATE INDEX IF NOT EXISTS idx_sint_rate_limit_expires_at");
+  });
+});

--- a/packages/persistence/src/index.ts
+++ b/packages/persistence/src/index.ts
@@ -13,5 +13,6 @@ export { InMemoryRateLimitStore } from "./in-memory-rate-limit-store.js";
 export { PgLedgerStore } from "./pg-ledger-store.js";
 export { PgTokenStore } from "./pg-token-store.js";
 export { getPool, closePool, type PgPoolConfig } from "./pg-pool.js";
+export { ensurePgSchema } from "./pg-schema.js";
 export { RedisCache } from "./redis-cache.js";
 export { RedisRevocationBus } from "./redis-revocation-bus.js";

--- a/packages/persistence/src/pg-schema.ts
+++ b/packages/persistence/src/pg-schema.ts
@@ -1,0 +1,85 @@
+/**
+ * SINT Persistence — PostgreSQL schema bootstrap.
+ *
+ * Ensures required tables exist for production startup when
+ * running with SINT_STORE=postgres and/or SINT_CACHE=redis.
+ *
+ * @module @sint/persistence/pg-schema
+ */
+
+import type pg from "pg";
+
+/**
+ * Create required PostgreSQL tables and indexes if absent.
+ * Safe to call repeatedly across restarts.
+ */
+export async function ensurePgSchema(pool: pg.Pool): Promise<void> {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS sint_ledger_events (
+      id BIGSERIAL PRIMARY KEY,
+      event_id TEXT NOT NULL UNIQUE,
+      sequence_number BIGINT NOT NULL UNIQUE,
+      timestamp TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      token_id TEXT,
+      payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+      previous_hash TEXT NOT NULL,
+      hash TEXT NOT NULL
+    );
+  `);
+
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_sint_ledger_agent_seq
+      ON sint_ledger_events (agent_id, sequence_number);
+  `);
+
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_sint_ledger_event_type_seq
+      ON sint_ledger_events (event_type, sequence_number);
+  `);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS sint_tokens (
+      token_id TEXT PRIMARY KEY,
+      issuer TEXT NOT NULL,
+      subject TEXT NOT NULL,
+      resource TEXT NOT NULL,
+      actions JSONB NOT NULL,
+      constraints JSONB NOT NULL,
+      delegation_chain JSONB NOT NULL,
+      issued_at TEXT NOT NULL,
+      expires_at TEXT NOT NULL,
+      revocable BOOLEAN NOT NULL DEFAULT true,
+      signature TEXT NOT NULL
+    );
+  `);
+
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_sint_tokens_subject
+      ON sint_tokens (subject);
+  `);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS sint_revocations (
+      token_id TEXT PRIMARY KEY,
+      reason TEXT NOT NULL,
+      revoked_by TEXT NOT NULL,
+      revoked_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+  `);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS sint_rate_limit_counters (
+      bucket_key TEXT PRIMARY KEY,
+      count BIGINT NOT NULL DEFAULT 1,
+      expires_at TIMESTAMPTZ NOT NULL
+    );
+  `);
+
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_sint_rate_limit_expires_at
+      ON sint_rate_limit_counters (expires_at);
+  `);
+}
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       hono:
         specifier: ^4.7.0
         version: 4.12.8
+      ws:
+        specifier: ^8.18.0
+        version: 8.19.0
       zod:
         specifier: ^3.24.0
         version: 3.25.76
@@ -100,6 +103,9 @@ importers:
       '@types/node':
         specifier: ^22.13.0
         version: 22.19.15
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       ioredis:
         specifier: ^5.4.0
         version: 5.10.0
@@ -263,6 +269,19 @@ importers:
       '@sint/gate-policy-gateway':
         specifier: workspace:*
         version: link:../policy-gateway
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.15)(jsdom@25.0.1)(tsx@4.21.0)
+
+  packages/bridge-grpc:
+    dependencies:
+      '@sint/core':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       typescript:
         specifier: ^5.7.0
@@ -1477,6 +1496,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -3091,6 +3113,10 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.15
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.15)(tsx@4.21.0))':
     dependencies:

--- a/sdks/go/README.md
+++ b/sdks/go/README.md
@@ -1,4 +1,4 @@
-# SINT Go SDK (Minimal)
+# SINT Go SDK
 
 ## Usage
 
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"log"
 
-	"example.com/sint/sintclient"
+	"github.com/sint-ai/sint-protocol/sdks/go/sintclient"
 )
 
 func main() {
@@ -25,6 +25,10 @@ func main() {
 ## Surface
 
 - discovery and health
+- openapi
 - token issue and revoke
 - intercept (single and batch)
-- approvals list and resolve
+- approvals list/get/resolve
+- ledger query + proof
+- compliance crosswalk
+- economy route helper

--- a/sdks/go/go.mod
+++ b/sdks/go/go.mod
@@ -1,0 +1,4 @@
+module github.com/sint-ai/sint-protocol/sdks/go
+
+go 1.22
+

--- a/sdks/go/sintclient/client.go
+++ b/sdks/go/sintclient/client.go
@@ -69,6 +69,10 @@ func (c *Client) Health(out any) error {
 	return c.do(http.MethodGet, "/v1/health", nil, out)
 }
 
+func (c *Client) OpenAPI(out any) error {
+	return c.do(http.MethodGet, "/v1/openapi.json", nil, out)
+}
+
 func (c *Client) IssueToken(req map[string]any, out any) error {
 	return c.do(http.MethodPost, "/v1/tokens", req, out)
 }
@@ -90,10 +94,30 @@ func (c *Client) ApprovalsPending(out any) error {
 	return c.do(http.MethodGet, "/v1/approvals/pending", nil, out)
 }
 
+func (c *Client) Approval(requestID string, out any) error {
+	return c.do(http.MethodGet, "/v1/approvals/"+requestID, nil, out)
+}
+
 func (c *Client) ResolveApproval(requestID, status, by, reason string, out any) error {
 	payload := map[string]any{"status": status, "by": by}
 	if reason != "" {
 		payload["reason"] = reason
 	}
 	return c.do(http.MethodPost, "/v1/approvals/"+requestID+"/resolve", payload, out)
+}
+
+func (c *Client) Ledger(limit int, out any) error {
+	return c.do(http.MethodGet, fmt.Sprintf("/v1/ledger?limit=%d", limit), nil, out)
+}
+
+func (c *Client) LedgerProof(eventID string, out any) error {
+	return c.do(http.MethodGet, "/v1/ledger/"+eventID+"/proof", nil, out)
+}
+
+func (c *Client) ComplianceCrosswalk(out any) error {
+	return c.do(http.MethodGet, "/v1/compliance/tier-crosswalk", nil, out)
+}
+
+func (c *Client) EconomyRoute(req map[string]any, out any) error {
+	return c.do(http.MethodPost, "/v1/economy/route", req, out)
 }

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -1,4 +1,4 @@
-# SINT Python SDK (Minimal)
+# SINT Python SDK
 
 ## Usage
 
@@ -9,13 +9,19 @@ client = SintClient(base_url="http://localhost:3100", api_key="dev-local-key")
 
 print(client.discovery())
 print(client.health())
+print(client.openapi())
+print(client.compliance_crosswalk())
 ```
 
 ## Surface
 
 - discovery: `/.well-known/sint.json`
+- openapi: `/v1/openapi.json`
 - health: `/v1/health`
 - token issue/revoke
 - request intercept (single/batch)
-- approvals list/resolve
+- approvals list/get/resolve
+- approvals websocket URL helper
 - ledger query
+- ledger proof
+- economy route helper

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sint-sdk"
+version = "0.2.0"
+description = "Python SDK for SINT Gateway"
+readme = "README.md"
+requires-python = ">=3.9"
+authors = [{ name = "SINT Maintainers" }]
+license = { text = "MIT" }
+
+[tool.setuptools]
+py-modules = ["sint_client"]
+

--- a/sdks/python/sint_client.py
+++ b/sdks/python/sint_client.py
@@ -1,12 +1,13 @@
-"""Minimal Python SDK for SINT Gateway v0.2.
+"""Python SDK for SINT Gateway v0.2.
 
-This client is intentionally dependency-light and uses only Python stdlib.
+Dependency-light client using Python stdlib only.
 """
 
 from __future__ import annotations
 
 import json
 import urllib.request
+import urllib.error
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
@@ -16,7 +17,7 @@ class SintClient:
     base_url: str
     api_key: Optional[str] = None
 
-    def _request(self, method: str, path: str, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def _request(self, method: str, path: str, payload: Optional[Any] = None) -> Dict[str, Any]:
         url = f"{self.base_url.rstrip('/')}{path}"
         data = None
         headers = {"content-type": "application/json"}
@@ -28,12 +29,20 @@ class SintClient:
             data = json.dumps(payload).encode("utf-8")
 
         req = urllib.request.Request(url=url, method=method, headers=headers, data=data)
-        with urllib.request.urlopen(req) as res:  # nosec B310 - explicit endpoint control by caller
-            body = res.read().decode("utf-8")
-            return json.loads(body) if body else {}
+        try:
+            with urllib.request.urlopen(req) as res:  # nosec B310 - explicit endpoint control by caller
+                body = res.read().decode("utf-8")
+                return json.loads(body) if body else {}
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8")
+            message = body or f"HTTP {exc.code}"
+            raise RuntimeError(f"SINT gateway request failed ({exc.code}): {message}") from exc
 
     def discovery(self) -> Dict[str, Any]:
         return self._request("GET", "/.well-known/sint.json")
+
+    def openapi(self) -> Dict[str, Any]:
+        return self._request("GET", "/v1/openapi.json")
 
     def health(self) -> Dict[str, Any]:
         return self._request("GET", "/v1/health")
@@ -51,11 +60,14 @@ class SintClient:
     def intercept(self, request: Dict[str, Any]) -> Dict[str, Any]:
         return self._request("POST", "/v1/intercept", request)
 
-    def intercept_batch(self, requests: Dict[str, Any]) -> Dict[str, Any]:
+    def intercept_batch(self, requests: Any) -> Dict[str, Any]:
         return self._request("POST", "/v1/intercept/batch", requests)
 
     def approvals_pending(self) -> Dict[str, Any]:
         return self._request("GET", "/v1/approvals/pending")
+
+    def approval(self, request_id: str) -> Dict[str, Any]:
+        return self._request("GET", f"/v1/approvals/{request_id}")
 
     def resolve_approval(self, request_id: str, status: str, by: str, reason: Optional[str] = None) -> Dict[str, Any]:
         payload: Dict[str, Any] = {"status": status, "by": by}
@@ -65,3 +77,15 @@ class SintClient:
 
     def ledger(self, limit: int = 100) -> Dict[str, Any]:
         return self._request("GET", f"/v1/ledger?limit={limit}")
+
+    def ledger_proof(self, event_id: str) -> Dict[str, Any]:
+        return self._request("GET", f"/v1/ledger/{event_id}/proof")
+
+    def compliance_crosswalk(self) -> Dict[str, Any]:
+        return self._request("GET", "/v1/compliance/tier-crosswalk")
+
+    def economy_route(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return self._request("POST", "/v1/economy/route", payload)
+
+    def approvals_ws_url(self) -> str:
+        return f"{self.base_url.rstrip('/').replace('http://', 'ws://').replace('https://', 'wss://')}/v1/approvals/ws"


### PR DESCRIPTION
## Summary
- ship persistence baseline for production gateway startup with PostgreSQL schema bootstrap and Redis startup health checks
- add WebSocket approvals transport (`/v1/approvals/ws`) alongside SSE, plus discovery/OpenAPI exposure
- add new `@sint/bridge-grpc` package as gRPC interoperability wedge and wire bridge profiles in core constants
- expand Python and Go SDKs with parity methods for OpenAPI, approvals, ledger proof, compliance crosswalk, and economy routing
- add standards/docs assets (RFC baseline + Mermaid state diagrams + operator guides)
- convert roadmap checkboxes into labeled GitHub issues for Q2/Q3/Q4 execution tracking

## Validation
- `pnpm --filter @sint/persistence test`
- `pnpm --filter @sint/gateway-server test`
- `pnpm --filter @sint/conformance-tests exec vitest run src/canonical-fixtures-conformance.test.ts`
- `pnpm run build`

## Milestones
Closes #1
Closes #2
Closes #3
Closes #5
Closes #19
Closes #20
Closes #22
