### PR TITLE
feat(cli): ship sintctl operator CLI (Issue #49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ docker-compose up
 - Deployment profiles: [`docs/profiles/`](docs/profiles/)
 - Examples: [`examples/`](examples/) (hello-world, warehouse-amr, industrial-cell)
 - Multi-language SDKs: [`sdks/`](sdks/) (TypeScript, Python, Go)
+- Operator CLI: [`apps/sintctl/README.md`](apps/sintctl/README.md)
 - Persistence baseline guide: [`docs/guides/persistence-baseline.md`](docs/guides/persistence-baseline.md)
 - WebSocket approvals guide: [`docs/guides/websocket-approvals.md`](docs/guides/websocket-approvals.md)
 - gRPC bridge guide: [`docs/guides/grpc-bridge-skeleton.md`](docs/guides/grpc-bridge-skeleton.md)

--- a/apps/sintctl/README.md
+++ b/apps/sintctl/README.md
@@ -1,0 +1,45 @@
+# @sint/sintctl
+
+Operator CLI for SINT gateway workflows:
+
+- capability token issue/revoke
+- approval queue list/resolve
+- ledger querying
+- intercept policy test requests
+
+## Usage
+
+```bash
+pnpm --filter @sint/sintctl build
+node apps/sintctl/dist/cli.js --help
+```
+
+## Quickstart
+
+```bash
+# 1) Generate a root keypair
+sintctl keypair create
+
+# 2) Issue a token
+sintctl token issue \
+  --issuer <issuer-public-key> \
+  --subject <agent-public-key> \
+  --resource ros2:///cmd_vel \
+  --actions publish \
+  --private-key <issuer-private-key> \
+  --constraints-json '{"maxVelocityMps":0.5}'
+
+# 3) List pending approvals
+sintctl approvals list
+
+# 4) Resolve an approval
+sintctl approvals resolve --request-id <id> --status approved --by operator@warehouse
+
+# 5) Query ledger
+sintctl ledger query --agent-id <agent-public-key> --limit 20
+```
+
+## Global Options
+
+- `--gateway`: defaults to `http://localhost:3100`
+- `--api-key`: optional x-api-key header

--- a/apps/sintctl/__tests__/client.test.ts
+++ b/apps/sintctl/__tests__/client.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { buildQuery } from "../src/client.js";
+
+describe("buildQuery", () => {
+  it("encodes only defined params", () => {
+    const query = buildQuery({
+      agentId: "agent-1",
+      action: undefined,
+      resource: "ros2:///cmd_vel",
+      limit: "20",
+    });
+
+    expect(query).toContain("agentId=agent-1");
+    expect(query).toContain("resource=ros2%3A%2F%2F%2Fcmd_vel");
+    expect(query).toContain("limit=20");
+    expect(query).not.toContain("action=");
+  });
+});

--- a/apps/sintctl/build.mjs
+++ b/apps/sintctl/build.mjs
@@ -1,0 +1,18 @@
+import * as esbuild from "esbuild";
+import * as fs from "node:fs";
+
+await esbuild.build({
+  entryPoints: ["src/cli.ts"],
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  target: "node22",
+  outfile: "dist/cli.js",
+});
+
+let cliContent = fs.readFileSync("dist/cli.js", "utf8");
+cliContent = cliContent.replace(/^(#!.*\n)+/, "#!/usr/bin/env node\n");
+fs.writeFileSync("dist/cli.js", cliContent);
+fs.chmodSync("dist/cli.js", 0o755);
+
+console.log("esbuild bundle complete");

--- a/apps/sintctl/package.json
+++ b/apps/sintctl/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@sint/sintctl",
+  "version": "0.1.0",
+  "description": "SINT operator CLI for token, approval, ledger, and intercept workflows",
+  "type": "module",
+  "bin": {
+    "sintctl": "dist/cli.js"
+  },
+  "files": [
+    "dist/cli.js",
+    "dist/cli.d.ts",
+    "dist/cli.d.ts.map",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc --build && node build.mjs",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "test": "vitest run",
+    "test:watch": "vitest watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sint-ai/sint-protocol.git",
+    "directory": "apps/sintctl"
+  },
+  "homepage": "https://github.com/sint-ai/sint-protocol#sintctl",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "esbuild": "^0.24.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/apps/sintctl/src/cli.ts
+++ b/apps/sintctl/src/cli.ts
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+
+import { randomUUID } from "node:crypto";
+import { buildQuery, requestJson, type CliConfig } from "./client.js";
+
+type ParsedArgs = {
+  positionals: string[];
+  flags: Record<string, string | boolean>;
+};
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const positionals: string[] = [];
+  const flags: Record<string, string | boolean> = {};
+
+  for (let i = 0; i < argv.length; i++) {
+    const value = argv[i];
+    if (!value) {
+      continue;
+    }
+    if (!value.startsWith("--")) {
+      positionals.push(value);
+      continue;
+    }
+
+    const raw = value.slice(2);
+    const equalsIndex = raw.indexOf("=");
+    if (equalsIndex > -1) {
+      const key = raw.slice(0, equalsIndex);
+      const val = raw.slice(equalsIndex + 1);
+      flags[key] = val;
+      continue;
+    }
+
+    const next = argv[i + 1];
+    if (!next || next.startsWith("--")) {
+      flags[raw] = true;
+      continue;
+    }
+
+    flags[raw] = next;
+    i++;
+  }
+
+  return { positionals, flags };
+}
+
+function getStringFlag(flags: Record<string, string | boolean>, key: string, required = false): string | undefined {
+  const value = flags[key];
+  if (typeof value === "string") return value;
+  if (required) {
+    throw new Error(`Missing required flag: --${key}`);
+  }
+  return undefined;
+}
+
+function getBooleanFlag(flags: Record<string, string | boolean>, key: string): boolean {
+  const value = flags[key];
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") return value.toLowerCase() === "true";
+  return false;
+}
+
+function parseJsonFlag<T>(flags: Record<string, string | boolean>, key: string): T | undefined {
+  const value = getStringFlag(flags, key);
+  if (!value) return undefined;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    throw new Error(`Invalid JSON for --${key}`);
+  }
+}
+
+function printHelp(): void {
+  console.log(`SINT Operator CLI (sintctl)\n
+Usage:
+  sintctl [global options] <group> <command> [command options]
+
+Global options:
+  --gateway <url>           Gateway URL (default: http://localhost:3100)
+  --api-key <key>           Optional x-api-key for protected endpoints
+
+Commands:
+  token issue               Issue a capability token
+  token revoke              Revoke a token
+  approvals list            List pending approvals
+  approvals resolve         Resolve a pending approval
+  ledger query              Query ledger events
+  intercept run             Send a policy intercept request
+  keypair create            Generate keypair via gateway utility endpoint
+
+Examples:
+  sintctl token issue --issuer <pub> --subject <pub> --resource ros2:///cmd_vel --actions publish --private-key <priv>
+  sintctl approvals list
+  sintctl approvals resolve --request-id <id> --status approved --by operator@site
+  sintctl ledger query --agent-id <pub> --limit 20
+  sintctl intercept run --agent-id <pub> --token-id <id> --resource ros2:///cmd_vel --action publish --params-json '{"twist":{"linear":0.2}}'
+`);
+}
+
+function printJson(value: unknown): void {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+async function run(): Promise<void> {
+  const { positionals, flags } = parseArgs(process.argv.slice(2));
+
+  if (positionals.length === 0 || getBooleanFlag(flags, "help")) {
+    printHelp();
+    return;
+  }
+
+  const gatewayUrl = getStringFlag(flags, "gateway") ?? "http://localhost:3100";
+  const apiKey = getStringFlag(flags, "api-key");
+  const config: CliConfig = { gatewayUrl, apiKey };
+
+  const [group, command] = positionals;
+
+  if (group === "token" && command === "issue") {
+    const issuer = getStringFlag(flags, "issuer", true)!;
+    const subject = getStringFlag(flags, "subject", true)!;
+    const resource = getStringFlag(flags, "resource", true)!;
+    const actions = getStringFlag(flags, "actions", true)!
+      .split(",")
+      .map((x) => x.trim())
+      .filter(Boolean);
+    const privateKey = getStringFlag(flags, "private-key", true)!;
+
+    const expiresHours = Number(getStringFlag(flags, "expires-hours") ?? "12");
+    const expiresAt = new Date(Date.now() + expiresHours * 60 * 60 * 1000).toISOString();
+
+    const constraints = parseJsonFlag<Record<string, unknown>>(flags, "constraints-json") ?? {};
+    const revocable = !getBooleanFlag(flags, "not-revocable");
+
+    const payload = {
+      request: {
+        issuer,
+        subject,
+        resource,
+        actions,
+        constraints,
+        delegationChain: { parentTokenId: null, depth: 0, attenuated: false },
+        expiresAt,
+        revocable,
+      },
+      privateKey,
+    };
+
+    printJson(await requestJson(config, "POST", "/v1/tokens", payload));
+    return;
+  }
+
+  if (group === "token" && command === "revoke") {
+    const tokenId = getStringFlag(flags, "token-id", true)!;
+    const reason = getStringFlag(flags, "reason", true)!;
+    const revokedBy = getStringFlag(flags, "by", true)!;
+
+    printJson(await requestJson(config, "POST", "/v1/tokens/revoke", { tokenId, reason, revokedBy }));
+    return;
+  }
+
+  if (group === "approvals" && command === "list") {
+    printJson(await requestJson(config, "GET", "/v1/approvals/pending"));
+    return;
+  }
+
+  if (group === "approvals" && command === "resolve") {
+    const requestId = getStringFlag(flags, "request-id", true)!;
+    const status = getStringFlag(flags, "status", true)!;
+    const by = getStringFlag(flags, "by", true)!;
+    const reason = getStringFlag(flags, "reason");
+
+    if (status !== "approved" && status !== "denied") {
+      throw new Error("--status must be approved or denied");
+    }
+
+    printJson(await requestJson(config, "POST", `/v1/approvals/${requestId}/resolve`, { status, by, reason }));
+    return;
+  }
+
+  if (group === "ledger" && command === "query") {
+    const query = buildQuery({
+      agentId: getStringFlag(flags, "agent-id"),
+      eventType: getStringFlag(flags, "event-type"),
+      resource: getStringFlag(flags, "resource"),
+      action: getStringFlag(flags, "action"),
+      tier: getStringFlag(flags, "tier"),
+      from: getStringFlag(flags, "from"),
+      to: getStringFlag(flags, "to"),
+      limit: getStringFlag(flags, "limit"),
+    });
+    printJson(await requestJson(config, "GET", `/v1/ledger/query${query}`));
+    return;
+  }
+
+  if (group === "intercept" && command === "run") {
+    const requestId = getStringFlag(flags, "request-id") ?? randomUUID();
+    const agentId = getStringFlag(flags, "agent-id", true)!;
+    const tokenId = getStringFlag(flags, "token-id", true)!;
+    const resource = getStringFlag(flags, "resource", true)!;
+    const action = getStringFlag(flags, "action", true)!;
+
+    const params = parseJsonFlag<Record<string, unknown>>(flags, "params-json") ?? {};
+    const physicalContext = parseJsonFlag<Record<string, unknown>>(flags, "physical-context-json");
+    const executionContext = parseJsonFlag<Record<string, unknown>>(flags, "execution-context-json");
+
+    printJson(
+      await requestJson(config, "POST", "/v1/intercept", {
+        requestId,
+        timestamp: new Date().toISOString(),
+        agentId,
+        tokenId,
+        resource,
+        action,
+        params,
+        physicalContext,
+        executionContext,
+      }),
+    );
+    return;
+  }
+
+  if (group === "keypair" && command === "create") {
+    printJson(await requestJson(config, "POST", "/v1/keypair"));
+    return;
+  }
+
+  printHelp();
+  throw new Error(`Unknown command: ${positionals.join(" ")}`);
+}
+
+run().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`sintctl error: ${message}`);
+  process.exit(1);
+});

--- a/apps/sintctl/src/client.ts
+++ b/apps/sintctl/src/client.ts
@@ -1,0 +1,56 @@
+export type CliConfig = {
+  gatewayUrl: string;
+  apiKey?: string;
+};
+
+export function buildQuery(params: Record<string, string | undefined>): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value && value.length > 0) {
+      search.set(key, value);
+    }
+  }
+  const encoded = search.toString();
+  return encoded.length > 0 ? `?${encoded}` : "";
+}
+
+export async function requestJson(
+  config: CliConfig,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<unknown> {
+  const url = new URL(path, config.gatewayUrl.endsWith("/") ? config.gatewayUrl : `${config.gatewayUrl}/`);
+  const headers = new Headers();
+
+  if (body !== undefined) {
+    headers.set("Content-Type", "application/json");
+  }
+  if (config.apiKey) {
+    headers.set("x-api-key", config.apiKey);
+  }
+
+  const response = await fetch(url, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+
+  const text = await response.text();
+  const parsed = text.length > 0 ? tryParseJson(text) : undefined;
+
+  if (!response.ok) {
+    const detail = typeof parsed === "object" && parsed !== null ? JSON.stringify(parsed) : text;
+    throw new Error(`${method} ${path} failed (${response.status}): ${detail}`);
+  }
+
+  return parsed ?? { ok: true };
+}
+
+function tryParseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}

--- a/apps/sintctl/tsconfig.json
+++ b/apps/sintctl/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/apps/sintctl/vitest.config.ts
+++ b/apps/sintctl/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+  },
+});

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,22 +5,22 @@
 ## Q2 2026: Foundation & Adoption (April–June)
 
 ### Infrastructure
-- [ ] WebSocket approval streaming (replace SSE polling for lower latency)
-- [ ] PostgreSQL persistence adapter (production-grade, replace in-memory)
-- [ ] Redis persistence adapter (caching layer, session state)
-- [ ] Docker Hub published images (`sintprotocol/gateway`, `sintprotocol/dashboard`)
-- [ ] Pre-configured Docker Compose stacks for common deployments
+- [x] WebSocket approval streaming (replace SSE polling for lower latency)
+- [x] PostgreSQL persistence adapter (production-grade, replace in-memory)
+- [x] Redis persistence adapter (caching layer, session state)
+- [x] Docker Hub published images (`sintprotocol/gateway`, `sintprotocol/dashboard`)
+- [x] Pre-configured Docker Compose stacks for common deployments
 
 ### SDK & Developer Experience
-- [ ] Python SDK (`sint-python`) — bridge to robotics/ML ecosystem
-- [ ] CLI tool for token management, ledger queries, policy testing
+- [x] Python SDK (`sint-python`) — bridge to robotics/ML ecosystem
+- [x] CLI tool for token management, ledger queries, policy testing
 - [ ] Interactive policy playground (web-based rule testing)
 - [ ] Comprehensive API documentation site
 
 ### Integration
 - [ ] Gazebo simulation environment integration (ROS 2 bridge validation)
 - [ ] NVIDIA Isaac Sim connector (industrial robotics testing)
-- [ ] Claude Desktop integration guide (MCP proxy setup)
+- [x] Claude Desktop integration guide (MCP proxy setup)
 - [ ] Cursor integration guide
 
 ### Community

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "benchmark:ros2-report": "node ./scripts/generate-ros2-control-loop-report.mjs",
     "benchmark:report": "node ./scripts/generate-industrial-benchmark-report.mjs",
     "bench": "pnpm --filter @sint/gate-policy-gateway bench",
+    "sintctl": "pnpm --filter @sint/sintctl exec sintctl --help",
     "stack:dev": "bash ./scripts/stack-up.sh dev",
     "stack:edge": "bash ./scripts/stack-up.sh edge",
     "stack:prod-lite": "bash ./scripts/stack-up.sh prod-lite"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,18 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@22.19.15)(jsdom@25.0.1)(tsx@4.21.0)
 
+  apps/sintctl:
+    devDependencies:
+      esbuild:
+        specifier: ^0.24.0
+        version: 0.24.2
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.15)(jsdom@25.0.1)(tsx@4.21.0)
+
   capsules/inspection:
     dependencies:
       '@sint/core':


### PR DESCRIPTION
## Summary
- adds new `@sint/sintctl` CLI app for operator workflows
- supports token issue/revoke, approvals list/resolve, ledger query, intercept test run, and keypair generation
- adds package docs and a unit test for query handling
- updates root scripts/docs and marks roadmap CLI item complete

## Validation
- pnpm --filter @sint/sintctl test
- pnpm --filter @sint/sintctl build
- pnpm run build

Closes #49
