### PR TITLE
docs: ship Cursor + SINT MCP integration guide (Issue #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ docker-compose up
 - Persistence baseline guide: [`docs/guides/persistence-baseline.md`](docs/guides/persistence-baseline.md)
 - WebSocket approvals guide: [`docs/guides/websocket-approvals.md`](docs/guides/websocket-approvals.md)
 - gRPC bridge guide: [`docs/guides/grpc-bridge-skeleton.md`](docs/guides/grpc-bridge-skeleton.md)
+- Cursor integration guide: [`docs/guides/cursor-integration.md`](docs/guides/cursor-integration.md)
 - Benchmark report: [`docs/reports/industrial-benchmark-report.md`](docs/reports/industrial-benchmark-report.md)
 - ROS2 loop benchmark report: [`docs/reports/ros2-control-loop-benchmark.md`](docs/reports/ros2-control-loop-benchmark.md)
 - Hardware safety controller roadmap: [`docs/roadmaps/hardware-safety-controller-integration.md`](docs/roadmaps/hardware-safety-controller-integration.md)

--- a/docs/guides/cursor-integration.md
+++ b/docs/guides/cursor-integration.md
@@ -1,0 +1,85 @@
+# Cursor + SINT MCP Proxy Guide
+
+This guide shows how to place SINT in front of any Cursor MCP server so tool calls are tiered, approval-gated, and written to the evidence ledger.
+
+## 1) Build SINT
+
+```bash
+cd /path/to/sint-protocol
+pnpm install
+pnpm run build
+```
+
+## 2) Scan MCP tools first (recommended)
+
+```bash
+npx @sint/mcp-scanner --server filesystem --tools '[
+  {"name":"read_file","description":"reads files"},
+  {"name":"write_file","description":"writes files"},
+  {"name":"run_terminal_cmd","description":"runs shell commands"}
+]'
+```
+
+Use the report to set strict `SINT_MAX_TIER` and `SINT_REQUIRE_APPROVAL_TIER` values.
+
+## 3) Configure Cursor MCP with SINT proxy
+
+In your Cursor MCP config (project-level or global), add an MCP server entry that points Cursor to `apps/sint-mcp/dist/index.js`, then configure the real upstream MCP server via env vars.
+
+```json
+{
+  "mcpServers": {
+    "sint-filesystem": {
+      "command": "node",
+      "args": ["/absolute/path/to/sint-protocol/apps/sint-mcp/dist/index.js"],
+      "env": {
+        "SINT_UPSTREAM_COMMAND": "npx",
+        "SINT_UPSTREAM_ARGS": "-y @modelcontextprotocol/server-filesystem /absolute/path/to/workspace",
+        "SINT_MAX_TIER": "T2_ACT",
+        "SINT_REQUIRE_APPROVAL_TIER": "T3_COMMIT",
+        "SINT_API_KEY": "replace-with-strong-key"
+      }
+    }
+  }
+}
+```
+
+## 4) Start gateway + dashboard
+
+```bash
+pnpm stack:dev
+```
+
+Endpoints:
+- Gateway: `http://localhost:3100`
+- Dashboard: `http://localhost:3201`
+
+## 5) Verify approval + evidence flow
+
+1. Trigger a low-risk tool call from Cursor and verify auto-approval.
+2. Trigger a T3 command and confirm it appears in pending approvals.
+3. Approve/deny in dashboard and verify ledger events.
+
+You can also inspect the ledger directly:
+
+```bash
+curl http://localhost:3100/v1/ledger/query?limit=20
+```
+
+## Recommended Policy Profiles
+
+- Read-only coding assistant:
+  - `SINT_MAX_TIER=T0_OBSERVE`
+  - `SINT_REQUIRE_APPROVAL_TIER=T1_PREPARE`
+- Normal coding assistant (writes allowed, no shell):
+  - `SINT_MAX_TIER=T2_ACT`
+  - `SINT_REQUIRE_APPROVAL_TIER=T3_COMMIT`
+- Full-access with human-in-the-loop:
+  - `SINT_MAX_TIER=T3_COMMIT`
+  - `SINT_REQUIRE_APPROVAL_TIER=T3_COMMIT`
+
+## Related Guides
+
+- `docs/guides/claude-desktop-integration.md`
+- `docs/guides/websocket-approvals.md`
+- `docs/guides/docker-deployment.md`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,7 +21,7 @@
 - [ ] Gazebo simulation environment integration (ROS 2 bridge validation)
 - [ ] NVIDIA Isaac Sim connector (industrial robotics testing)
 - [x] Claude Desktop integration guide (MCP proxy setup)
-- [ ] Cursor integration guide
+- [x] Cursor integration guide
 
 ### Community
 - [ ] Developer documentation site (docs.sint.gg)


### PR DESCRIPTION
## Summary
- adds `docs/guides/cursor-integration.md` with end-to-end Cursor MCP proxy setup via SINT
- includes scanner-first hardening flow, policy tier recommendations, and runtime verification steps
- updates README docs index and marks roadmap Cursor guide item complete

## Validation
- pnpm run build

Closes #55
