### PR TITLE
chore(sync): post-merge README/docs/guardrail reconciliation

### DIFF
--- a/.github/workflows/runtime-change-guardrails.yml
+++ b/.github/workflows/runtime-change-guardrails.yml
@@ -26,13 +26,23 @@ jobs:
           echo "$CHANGED_FILES"
 
           RUNTIME_REGEX='^(PROTOCOL\.md|apps/gateway-server/|packages/(policy-gateway|capability-tokens|evidence-ledger|avatar|persistence|persistence-postgres|bridge-[^/]+)/)'
+          RUNTIME_FILES="$(echo "$CHANGED_FILES" | grep -E "$RUNTIME_REGEX" || true)"
           HAS_RUNTIME_CHANGE=0
-          if echo "$CHANGED_FILES" | grep -Eq "$RUNTIME_REGEX"; then
+          if [[ -n "$RUNTIME_FILES" ]]; then
             HAS_RUNTIME_CHANGE=1
           fi
 
           if [[ "$HAS_RUNTIME_CHANGE" -eq 0 ]]; then
             echo "No protocol/runtime changes detected. Guardrail passed."
+            exit 0
+          fi
+
+          # Metadata-only changes in runtime packages (README/LICENSE/package metadata)
+          # should not require conformance fixture updates.
+          NON_SUBSTANTIVE_REGEX='(^|/)(README\.md|LICENSE|package\.json|CHANGELOG\.md)$'
+          SUBSTANTIVE_RUNTIME_FILES="$(echo "$RUNTIME_FILES" | grep -Ev "$NON_SUBSTANTIVE_REGEX" || true)"
+          if [[ -z "$SUBSTANTIVE_RUNTIME_FILES" ]]; then
+            echo "Only metadata/runtime-doc files changed in guarded paths. Guardrail passed."
             exit 0
           fi
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # SINT Protocol
 [![CI](https://github.com/sint-ai/sint-protocol/actions/workflows/ci.yml/badge.svg)](https://github.com/sint-ai/sint-protocol/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/sint-ai/sint-protocol/blob/main/LICENSE)
-![Node.js >= 22](https://img.shields.io/badge/node-%3E%3D22-brightgreen)
-![Tests](https://img.shields.io/badge/tests-370-brightgreen)
-
-![Tests](https://img.shields.io/badge/tests-1200%2B%20passing-brightgreen)
 ![Node.js](https://img.shields.io/badge/node-%3E%3D22-blue)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue)
 ![License](https://img.shields.io/badge/license-Apache--2.0-blue)
@@ -47,7 +42,7 @@ AI agents can now control robots, execute code, move money, and operate machiner
 # Prerequisites: Node.js >= 22, pnpm >= 9
 pnpm install
 pnpm run build
-pnpm run test        # 1200+ passing tests across 30 workspace members
+pnpm run test        # full workspace test suite
 ```
 
 ### Start the Gateway Server
@@ -198,9 +193,9 @@ If you are an AI agent (Claude, GPT, Gemini, Cursor, etc.) working in this repo,
 | [`@sint/sdk`](sdks/typescript) | Zero-dependency public TypeScript SDK aligned to gateway v0.2 contracts | 9 |
 | [`@sint/conformance-tests`](packages/conformance-tests) | Security regression suite — all phases | — |
 
-**Total: 30 workspace members, 1200+ passing tests**
+**Total: 30 workspace members**
 
-> **Note:** Run `pnpm test` to get the exact count. The number grows as new bridges and conformance tests are added.
+> **Note:** Run `pnpm test` to get the current exact passing test count.
 
 ## Approval Tiers
 
@@ -414,7 +409,7 @@ docker-compose up
 - **Crypto:** @noble/ed25519, @noble/hashes (audited, zero-dependency)
 - **MCP SDK:** @modelcontextprotocol/sdk
 - **Dashboard:** React 19, Vite 6
-- **Testing:** Vitest (1200+ passing tests)
+- **Testing:** Vitest (run `pnpm test` for current count)
 - **Infra:** Docker, PostgreSQL 16+, Redis 7, GitHub Actions CI, Railway
 
 ## Docs & Artifacts
@@ -423,6 +418,7 @@ docker-compose up
 - SIP governance: [`docs/SIPS.md`](docs/SIPS.md)
 - Release notes: [`docs/RELEASE_NOTES_v0.2.md`](docs/RELEASE_NOTES_v0.2.md)
 - Conformance matrix: [`docs/CONFORMANCE_CERTIFICATION_MATRIX_v0.2.md`](docs/CONFORMANCE_CERTIFICATION_MATRIX_v0.2.md)
+- Getting started: [`docs/getting-started.md`](docs/getting-started.md)
 - Deployment profiles: [`docs/profiles/`](docs/profiles/)
 - Examples: [`examples/`](examples/) (hello-world, warehouse-amr, industrial-cell)
 - Multi-language SDKs: [`sdks/`](sdks/) (TypeScript, Python, Go)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,16 +1,14 @@
 # Getting Started with SINT Protocol
 
-This guide walks you through setting up SINT, issuing your first capability token, and integrating it into your application.
+This guide gets you from clone to a complete `token -> intercept -> approval -> ledger` flow in about 10 minutes.
 
 ## Prerequisites
 
-- **Node.js** 22+ ([download](https://nodejs.org))
-- **pnpm** 9+ ([install](https://pnpm.io))
-- **Git**
+- Node.js 22+
+- pnpm 9+
+- Docker Desktop (for one-command local stack)
 
-## 5-Minute Setup
-
-### 1. Clone and Install
+## 1) Install and Build
 
 ```bash
 git clone https://github.com/sint-ai/sint-protocol
@@ -19,438 +17,107 @@ pnpm install
 pnpm run build
 ```
 
-### 2. Start the Gateway
+## 2) Start a Production-Like Local Stack
 
 ```bash
-pnpm --filter @sint/gateway-server dev
+pnpm run stack:dev
 ```
 
-You should see:
-```
-[19:32:00] @sint/gateway-server: Server running on http://localhost:3100
-[19:32:00] @sint/gateway-server: Dashboard available on http://localhost:3201
-```
+Services:
+- Gateway: `http://localhost:3100`
+- Dashboard: `http://localhost:3201`
 
-### 3. Test Health
+Health checks:
 
 ```bash
 curl http://localhost:3100/v1/health
-# {"status": "ok"}
+curl http://localhost:3100/v1/ready
 ```
 
-✅ You're running SINT. Now let's use it.
+## 3) Create Keys
 
----
-
-## Issuing Your First Token
-
-### Step 1: Generate a Keypair
+Use `sintctl` (operator CLI) to generate two keypairs: issuer + subject.
 
 ```bash
-curl -X POST http://localhost:3100/v1/keypair \
-  -H "Content-Type: application/json" \
-  -d '{"bits": 256}' \
-| jq .
+# Issuer keypair
+node apps/sintctl/dist/cli.js keypair create > /tmp/issuer.json
 
-# Output:
-# {
-#   "publicKey": "z6Mkm7tgfcnYg...",
-#   "privateKey": "...",
-#   "did": "did:key:z6Mkm7tgfcnYg..."
-# }
+# Subject keypair
+node apps/sintctl/dist/cli.js keypair create > /tmp/subject.json
 ```
 
-Save these for the next step. In production, store the private key in a secrets manager (1Password, Vault, etc.).
-
-### Step 2: Issue a Token
+Extract keys:
 
 ```bash
-curl -X POST http://localhost:3100/v1/tokens \
-  -H "Content-Type: application/json" \
-  -d '{
-    "issuerPublicKey": "z6Mkm7tgfcnYg...",
-    "subjectDid": "did:key:z6Mki...",
-    "resources": ["file:///workspace/**"],
-    "actions": ["read", "write"],
-    "maxTier": 1,
-    "constraints": {
-      "maxRepetitionsPerWindow": 100
-    },
-    "ttlSeconds": 3600
-  }' \
-| jq .
-
-# Output:
-# {
-#   "id": "tok-19050000-...",
-#   "token": "eyJhbGc...",
-#   "expiresAt": 1712336400000
-# }
+ISSUER_PUB=$(jq -r '.publicKey' /tmp/issuer.json)
+ISSUER_PRIV=$(jq -r '.privateKey' /tmp/issuer.json)
+SUBJECT_PUB=$(jq -r '.publicKey' /tmp/subject.json)
 ```
 
-### Step 3: Test the Token
-
-Make a policy decision using the token:
+## 4) Issue a Capability Token
 
 ```bash
-curl -X POST http://localhost:3100/v1/intercept \
-  -H "Content-Type: application/json" \
-  -d '{
-    "tokenId": "tok-19050000-...",
-    "resource": "file:///workspace/output.txt",
-    "action": "write"
-  }' \
-| jq .
+node apps/sintctl/dist/cli.js token issue \
+  --issuer "$ISSUER_PUB" \
+  --subject "$SUBJECT_PUB" \
+  --resource ros2:///cmd_vel \
+  --actions publish \
+  --private-key "$ISSUER_PRIV" \
+  --constraints-json '{"maxVelocityMps":0.5}' \
+  > /tmp/token.json
 
-# Output:
-# {
-#   "action": "allow",
-#   "tier": 1,
-#   "ttl": 3599,
-#   "evidence": {
-#     "sessionId": "...",
-#     "timestamp": "2026-04-05T02:32:00Z"
-#   }
-# }
+TOKEN_ID=$(jq -r '.tokenId' /tmp/token.json)
 ```
 
-✅ Policy decision recorded. Check the approval dashboard at http://localhost:3201 to see the evidence log.
-
----
-
-## Integrating with MCP
-
-If you're using the Model Context Protocol (MCP) with Claude, GPT, or another LLM:
-
-### 1. Start the MCP Bridge
+## 5) Send an Intercept Request
 
 ```bash
-pnpm --filter @sint/mcp dev
-# MCP proxy listening on stdio
+node apps/sintctl/dist/cli.js intercept run \
+  --agent-id "$SUBJECT_PUB" \
+  --token-id "$TOKEN_ID" \
+  --resource ros2:///cmd_vel \
+  --action publish \
+  --params-json '{"twist":{"linear":0.2,"angular":0.0}}'
 ```
 
-### 2. Configure Your MCP Client
+Depending on policy/tier, this is either:
+- allowed immediately (`T0/T1`), or
+- queued for approval (`T2/T3`).
 
-In your `claude_desktop_config.json` (or MCP client config):
+## 6) Resolve Pending Approvals (if any)
 
-```json
-{
-  "mcpServers": {
-    "sint-gateway": {
-      "command": "node",
-      "args": ["path/to/@sint/mcp/dist/index.js"],
-      "env": {
-        "SINT_GATEWAY": "http://localhost:3100",
-        "SINT_API_KEY": "your-api-key"
-      }
-    }
-  }
-}
-```
-
-Now when your agent calls any MCP tool, it flows through the SINT Policy Gateway:
-
-```
-Agent: "Read /workspace/data.csv"
-  ↓
-SINT MCP Bridge: checks token + constraints
-  ↓
-PolicyGateway.intercept(): evaluates tier + approval
-  ↓
-MCP Tool: executes (if approved)
-  ↓
-EvidenceLedger: records decision + result
-```
-
----
-
-## Integrating with ROS 2
-
-If you're controlling robots or drones with ROS 2:
-
-### 1. Install the Bridge
+List queue:
 
 ```bash
-pnpm add @sint/bridge-ros2
+node apps/sintctl/dist/cli.js approvals list
 ```
 
-### 2. Intercept Topics
-
-```typescript
-import { ROSInterceptor } from "@sint/bridge-ros2";
-import { SintClient } from "@sint/client";
-
-const client = new SintClient({ baseUrl: "http://localhost:3100" });
-const interceptor = new ROSInterceptor({ client });
-
-// Intercept a publish to /cmd_vel
-const decision = await interceptor.intercept({
-  topic: "/cmd_vel",
-  action: "publish",
-  message: { linear: { x: 0.5 }, angular: { z: 0.1 } },
-  tokenId: "tok-...",
-});
-
-if (decision.action === "allow") {
-  // Safe to publish
-  publisher.publish(message);
-} else if (decision.action === "escalate") {
-  // Wait for human approval via dashboard
-  await waitForApproval(decision.requestId);
-}
-```
-
----
-
-## Delegating Tokens
-
-Delegation lets you issue a scoped token to a sub-agent, with strictly fewer permissions than your own token.
-
-### Example: Granting Read-Only Access
-
-You have a token with read+write access to `/workspace/**`. You want to delegate a read-only token to a subordinate agent.
+Resolve one request:
 
 ```bash
-curl -X POST http://localhost:3100/v1/tokens/delegate \
-  -H "Content-Type: application/json" \
-  -d '{
-    "parentTokenId": "tok-parent-...",
-    "delegateeDid": "did:key:z6Mkdeputy...",
-    "resources": ["file:///workspace/output/**"],
-    "actions": ["read"],
-    "maxTier": 0,
-    "ttlSeconds": 600
-  }' \
-| jq .
-
-# Output:
-# {
-#   "id": "tok-delegated-...",
-#   "token": "eyJhbGc...",
-#   "expiresAt": 1712336700000
-# }
+node apps/sintctl/dist/cli.js approvals resolve \
+  --request-id <REQUEST_ID> \
+  --status approved \
+  --by operator@site
 ```
 
-Key properties of delegation:
-- ✅ **Attenuation only** — you cannot escalate permissions
-- ✅ **Resource narrowing** — you can narrow the resource scope
-- ✅ **Tier lowering** — you can lower the max tier
-- ❌ **No escalation** — you cannot grant new resources or actions the parent doesn't have
-- ❌ **Max 3 hops** — delegation chains cannot exceed depth 3 (child → grandchild → great-grandchild, then stop)
+You can also resolve from the dashboard at `http://localhost:3201`.
 
----
-
-## Approval Workflows
-
-Not all actions are auto-approved. Tier T2 (ACT) and T3 (COMMIT) require human review.
-
-### Via Dashboard
-
-Visit http://localhost:3201 to see pending approvals in real-time. Click **Approve** or **Deny** to respond.
-
-### Via API
+## 7) Query the Evidence Ledger
 
 ```bash
-# List pending approvals
-curl http://localhost:3100/v1/approvals/pending \
-  -H "Authorization: Bearer $API_KEY" \
-| jq .
-
-# Approve a specific request
-curl -X POST http://localhost:3100/v1/approvals/req-id-123/resolve \
-  -H "Content-Type: application/json" \
-  -d '{
-    "decision": "approve",
-    "reason": "Verified safe by operator"
-  }'
-
-# Deny a request
-curl -X POST http://localhost:3100/v1/approvals/req-id-123/resolve \
-  -H "Content-Type: application/json" \
-  -d '{
-    "decision": "deny",
-    "reason": "Not authorized for this workspace"
-  }'
+node apps/sintctl/dist/cli.js ledger query --agent-id "$SUBJECT_PUB" --limit 20
 ```
 
-### SSE Streaming (Real-Time)
-
-If your application needs to watch for approval decisions in real-time:
-
-```typescript
-const eventSource = new EventSource(
-  "http://localhost:3100/v1/approvals/events?sessionId=agent-001"
-);
-
-eventSource.addEventListener("approval", (event) => {
-  const decision = JSON.parse(event.data);
-  console.log(`Approval resolved: ${decision.status}`);
-});
-```
-
----
-
-## Querying the Audit Log
-
-Every decision is recorded in the Evidence Ledger. Query it to understand what your agent has done.
-
-### By Session
+Or via HTTP directly:
 
 ```bash
-curl -X GET "http://localhost:3100/v1/ledger?sessionId=agent-001&limit=50" \
-  -H "Authorization: Bearer $API_KEY" \
-| jq .
-
-# Output:
-# {
-#   "events": [
-#     {
-#       "timestamp": "2026-04-05T02:32:00Z",
-#       "sessionId": "agent-001",
-#       "action": "write_file",
-#       "resource": "/workspace/output.txt",
-#       "decision": "allow",
-#       "tier": 1,
-#       "tokenId": "tok-...",
-#       "evidenceHash": "sha256:abc123..."
-#     },
-#     ...
-#   ]
-# }
+curl "http://localhost:3100/v1/ledger/query?agentId=$SUBJECT_PUB&limit=20"
 ```
 
-### By Tier
+## 8) Next Steps
 
-```bash
-curl -X GET "http://localhost:3100/v1/ledger?tier=2,3" \
-  -H "Authorization: Bearer $API_KEY" \
-| jq '.events | length'
-# 47 (47 T2+ decisions made by this agent)
-```
-
-### Export for SIEM
-
-```bash
-curl -X POST http://localhost:3100/v1/ledger/export \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $API_KEY" \
-  -d '{
-    "format": "syslog",
-    "filter": { "tier": 2, "decision": "deny" }
-  }' \
-  --output audit.syslog
-```
-
----
-
-## Emergency Stop (E-Stop)
-
-If an agent is behaving dangerously, you can instantly revoke all its tokens:
-
-```bash
-curl -X POST http://localhost:3100/v1/circuit-breaker/trip \
-  -H "Content-Type: application/json" \
-  -d '{
-    "agentId": "agent-001",
-    "reason": "Unexpected behavior detected"
-  }'
-
-# All new actions from agent-001 immediately return:
-# { "action": "deny", "reason": "Circuit breaker open" }
-```
-
-To resume:
-
-```bash
-curl -X POST http://localhost:3100/v1/circuit-breaker/reset \
-  -H "Content-Type: application/json" \
-  -d '{ "agentId": "agent-001" }'
-
-# The circuit enters HALF_OPEN state. The next request is allowed as a "probe".
-# If it succeeds, the circuit closes. If it fails, the circuit reopens.
-```
-
----
-
-## Deployment Profiles
-
-SINT ships with pre-configured profiles for different use cases.
-
-### Research Lab
-
-For development and experimentation:
-
-```bash
-export SINT_PROFILE=research
-pnpm run dev
-# No approval gate required for T1/T2; all decisions logged
-# Good for fast iteration
-```
-
-### Warehouse Automation
-
-For trusted environments:
-
-```bash
-export SINT_PROFILE=warehouse
-pnpm run start
-# T2 (ACT) approvals require single operator sign-off
-# Rate limiting per agent
-```
-
-### Manufacturing (Controlled Environment)
-
-For high-safety environments:
-
-```bash
-export SINT_PROFILE=manufacturing
-pnpm run start
-# T2+ approvals require M-of-N quorum (default: 2-of-3 operators)
-# All decisions recorded for traceability
-```
-
-### Healthcare / Critical Infrastructure
-
-For maximum safety:
-
-```bash
-export SINT_PROFILE=critical
-pnpm run start
-# T3 (COMMIT) approvals require 3-of-4 quorum
-# Hardware E-stop integrated
-# All ledger entries persisted to write-once storage
-```
-
----
-
-## Next Steps
-
-1. **Explore the dashboard** — http://localhost:3201
-2. **Read the spec** — [SINT Protocol v0.2 Specification](SINT_v0.2_SPEC.md)
-3. **Browse examples** — [examples/](../examples/)
-4. **Review the compliance matrix** — [Conformance Certification Matrix](CONFORMANCE_CERTIFICATION_MATRIX_v0.2.md)
-5. **Set up PostgreSQL persistence** — [Deployment Guide](deployment.md)
-
-## Support
-
-- **GitHub Issues** — https://github.com/sint-ai/sint-protocol/issues
-- **Discussions** — https://github.com/sint-ai/sint-protocol/discussions
-- **Discord** — [SINT Community](https://discord.gg/sint-protocol)
-
----
-
-## Safety & Compliance
-
-SINT is designed with reference to:
-- **IEC 62443** — Industrial Cybersecurity
-- **EU AI Act Article 13** — Transparency for AI Systems
-- **NIST AI RMF** — AI Risk Management Framework
-- **OWASP Agentic Top 10** — Agentic AI Security
-
-For compliance details, see [Conformance Certification Matrix](CONFORMANCE_CERTIFICATION_MATRIX_v0.2.md).
-
----
-
-## License
-
-Apache-2.0
+- MCP proxy hardening: `docs/guides/claude-desktop-integration.md`
+- Cursor MCP setup: `docs/guides/cursor-integration.md`
+- Deployment profiles: `docs/guides/docker-deployment.md`
+- Protocol reference: `docs/SINT_v0.2_SPEC.md`


### PR DESCRIPTION
## Summary
- reconciles docs and guardrail behavior after #92/#93/#94/#95 landed
- removes duplicate/stale README badges and hardcoded test count claims
- rewrites `docs/getting-started.md` to match current gateway + sintctl flow
- updates runtime guardrail logic to allow metadata-only package changes without forcing conformance/test deltas

## Validation
- pnpm run build

Supersedes #96
