### PR TITLE
feat(q2): policy playground + gateway API docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ pnpm run test        # full workspace test suite
 pnpm --filter @sint/gateway-server dev
 # → http://localhost:3100/v1/health
 # → http://localhost:3100/v1/ready
+# → http://localhost:3100/v1/docs
 ```
 
 ### Start Production-Like Stacks (One Command)
@@ -425,6 +426,7 @@ docker-compose up
 - Operator CLI: [`apps/sintctl/README.md`](apps/sintctl/README.md)
 - Persistence baseline guide: [`docs/guides/persistence-baseline.md`](docs/guides/persistence-baseline.md)
 - WebSocket approvals guide: [`docs/guides/websocket-approvals.md`](docs/guides/websocket-approvals.md)
+- API docs site guide: [`docs/guides/api-documentation-site.md`](docs/guides/api-documentation-site.md)
 - gRPC bridge guide: [`docs/guides/grpc-bridge-skeleton.md`](docs/guides/grpc-bridge-skeleton.md)
 - Cursor integration guide: [`docs/guides/cursor-integration.md`](docs/guides/cursor-integration.md)
 - Benchmark report: [`docs/reports/industrial-benchmark-report.md`](docs/reports/industrial-benchmark-report.md)

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -14,6 +14,7 @@ import { PendingApprovals } from "./components/PendingApprovals.js";
 import { AuditLog } from "./components/AuditLog.js";
 import { TierLegend } from "./components/TierLegend.js";
 import { ApprovalFeed } from "./components/ApprovalFeed.js";
+import { PolicyPlayground } from "./components/PolicyPlayground.js";
 import { LoginScreen } from "./components/LoginScreen.js";
 import { useAuth } from "./contexts/AuthContext.js";
 import { useApprovals } from "./hooks/useApprovals.js";
@@ -65,6 +66,8 @@ function Dashboard({ apiKey }: DashboardProps) {
           requests={pending}
           onResolved={handleApprovalResolved}
         />
+
+        <PolicyPlayground />
 
         <div className="dashboard-grid">
           <AuditLog ledger={ledger} loading={ledgerLoading} />

--- a/apps/dashboard/src/api/client.ts
+++ b/apps/dashboard/src/api/client.ts
@@ -13,6 +13,7 @@ import type {
   PendingApprovalsResponse,
   LedgerResponse,
   ResolveApprovalRequest,
+  InterceptRequest,
 } from "./types.js";
 
 /**
@@ -94,4 +95,12 @@ export async function getLedger(
 /** Generate a new Ed25519 keypair (dev utility). */
 export async function generateKeypair(): Promise<{ publicKey: string; privateKey: string }> {
   return fetchJSON("/v1/keypair", { method: "POST" });
+}
+
+/** Send one request through policy interception (playground/testing). */
+export async function interceptRequest(request: InterceptRequest): Promise<unknown> {
+  return fetchJSON("/v1/intercept", {
+    method: "POST",
+    body: JSON.stringify(request),
+  });
 }

--- a/apps/dashboard/src/api/types.ts
+++ b/apps/dashboard/src/api/types.ts
@@ -58,6 +58,19 @@ export interface ResolveApprovalRequest {
   reason?: string;
 }
 
+/** Playground/API request shape for policy intercept testing. */
+export interface InterceptRequest {
+  requestId: string;
+  timestamp: string;
+  agentId: string;
+  tokenId: string;
+  resource: string;
+  action: string;
+  params?: Record<string, unknown>;
+  physicalContext?: Record<string, unknown>;
+  executionContext?: Record<string, unknown>;
+}
+
 /** SSE approval event. */
 export interface ApprovalSSEEvent {
   type: "queued" | "resolved" | "timeout";

--- a/apps/dashboard/src/components/PolicyPlayground.tsx
+++ b/apps/dashboard/src/components/PolicyPlayground.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+import { interceptRequest } from "../api/client.js";
+import type { InterceptRequest } from "../api/types.js";
+
+const SAMPLE_REQUEST: InterceptRequest = {
+  requestId: "01905f7c-4e8a-7b3d-9a1e-f2c3d4e5f6b0",
+  timestamp: new Date().toISOString(),
+  agentId: "replace-with-agent-public-key",
+  tokenId: "replace-with-token-id",
+  resource: "ros2:///cmd_vel",
+  action: "publish",
+  params: {
+    twist: {
+      linear: 0.2,
+      angular: 0,
+    },
+  },
+};
+
+export function PolicyPlayground() {
+  const [requestJson, setRequestJson] = useState<string>(
+    JSON.stringify(SAMPLE_REQUEST, null, 2),
+  );
+  const [responseJson, setResponseJson] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function runIntercept() {
+    setError(null);
+    setLoading(true);
+    try {
+      const parsed = JSON.parse(requestJson) as InterceptRequest;
+      const result = await interceptRequest(parsed);
+      setResponseJson(JSON.stringify(result, null, 2));
+    } catch (err) {
+      setResponseJson("");
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function resetTemplate() {
+    setRequestJson(JSON.stringify({ ...SAMPLE_REQUEST, timestamp: new Date().toISOString() }, null, 2));
+    setResponseJson("");
+    setError(null);
+  }
+
+  return (
+    <section className="panel playground-panel">
+      <h2 className="panel-title">
+        Policy Playground
+        <span className="panel-count">/v1/intercept</span>
+      </h2>
+
+      <p className="playground-help text-muted">
+        Paste or edit a request payload, then run it through the live policy engine.
+        Use this for rule testing before wiring a new agent/tool/bridge.
+      </p>
+
+      <div className="playground-grid">
+        <div>
+          <label className="playground-label" htmlFor="playground-request">
+            Request JSON
+          </label>
+          <textarea
+            id="playground-request"
+            className="playground-textarea"
+            value={requestJson}
+            onChange={(e) => setRequestJson(e.target.value)}
+            spellCheck={false}
+          />
+
+          <div className="playground-actions">
+            <button className="btn btn-approve" onClick={runIntercept} disabled={loading}>
+              {loading ? "Running..." : "Run Intercept"}
+            </button>
+            <button className="btn btn-deny" onClick={resetTemplate} disabled={loading}>
+              Reset Template
+            </button>
+          </div>
+        </div>
+
+        <div>
+          <label className="playground-label" htmlFor="playground-response">
+            Response
+          </label>
+          <textarea
+            id="playground-response"
+            className="playground-textarea playground-textarea-readonly"
+            value={error ? `ERROR:\n${error}` : responseJson || "Run a request to see policy decision output."}
+            readOnly
+            spellCheck={false}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/dashboard/src/styles/dashboard.css
+++ b/apps/dashboard/src/styles/dashboard.css
@@ -285,6 +285,70 @@ code {
   font-size: 0.8rem;
 }
 
+/* ── Policy Playground ── */
+
+.playground-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.playground-help {
+  font-size: 0.85rem;
+}
+
+.playground-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 960px) {
+  .playground-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.playground-label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.playground-textarea {
+  width: 100%;
+  min-height: 220px;
+  resize: vertical;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  line-height: 1.5;
+  padding: 10px 12px;
+}
+
+.playground-textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.15);
+}
+
+.playground-textarea-readonly {
+  opacity: 0.95;
+}
+
+.playground-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+
 /* ── Overview Cards ── */
 
 .overview-cards {

--- a/apps/gateway-server/__tests__/api.test.ts
+++ b/apps/gateway-server/__tests__/api.test.ts
@@ -101,6 +101,26 @@ describe("Gateway Server API", () => {
     expect(body.paths["/v1/approvals/events"]).toBeDefined();
     expect(body.paths["/v1/approvals/ws"]).toBeDefined();
     expect(body.paths["/v1/compliance/tier-crosswalk"]).toBeDefined();
+    expect(body.paths["/v1/docs"]).toBeDefined();
+    expect(body.paths["/v1/docs/redoc"]).toBeDefined();
+  });
+
+  it("GET /v1/docs returns HTML docs landing page", async () => {
+    const res = await app.request("/v1/docs");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    const body = await res.text();
+    expect(body).toContain("SINT Gateway API Documentation");
+    expect(body).toContain("/v1/openapi.json");
+  });
+
+  it("GET /v1/docs/redoc returns Redoc UI shell", async () => {
+    const res = await app.request("/v1/docs/redoc");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    const body = await res.text();
+    expect(body).toContain("redoc");
+    expect(body).toContain("/v1/openapi.json");
   });
 
   it("GET /v1/compliance/tier-crosswalk returns tier mappings", async () => {

--- a/apps/gateway-server/src/routes/discovery.ts
+++ b/apps/gateway-server/src/routes/discovery.ts
@@ -130,11 +130,66 @@ export function discoveryRoutes(): Hono {
         "/v1/compliance/tier-crosswalk": {
           get: { summary: "SINT tier mapping to NIST AI RMF, ISO/IEC 42001, and EU AI Act controls" },
         },
+        "/v1/docs": { get: { summary: "API docs landing page" } },
+        "/v1/docs/redoc": { get: { summary: "Redoc API documentation UI" } },
       },
       components: {
         schemas: SINT_SCHEMA_CATALOG,
       },
     });
+  });
+
+  app.get("/v1/docs", (c) => {
+    return c.html(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>SINT Gateway API Docs</title>
+    <style>
+      body { font-family: Inter, Arial, sans-serif; margin: 0; background: #0b1324; color: #e7eefc; }
+      .wrap { max-width: 840px; margin: 56px auto; padding: 0 20px; }
+      .card { background: #121b30; border: 1px solid #24314f; border-radius: 12px; padding: 24px; }
+      a { color: #8ec6ff; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      h1 { margin: 0 0 6px 0; font-size: 28px; }
+      p { color: #b8c6e0; line-height: 1.55; }
+      .links { display: grid; gap: 10px; margin-top: 16px; }
+      .link { background: #0f1728; border: 1px solid #2a3859; border-radius: 10px; padding: 12px 14px; }
+      code { background: #1d2a45; padding: 2px 6px; border-radius: 6px; }
+    </style>
+  </head>
+  <body>
+    <main class="wrap">
+      <section class="card">
+        <h1>SINT Gateway API Documentation</h1>
+        <p>Interactive docs generated from the live OpenAPI surface.</p>
+        <div class="links">
+          <a class="link" href="/v1/docs/redoc">Open Redoc UI</a>
+          <a class="link" href="/v1/openapi.json">View raw OpenAPI JSON</a>
+          <a class="link" href="/.well-known/sint.json">View protocol discovery document</a>
+        </div>
+        <p style="margin-top:16px;">Tip: set <code>SINT_API_KEY</code> and test protected endpoints from your API client or <code>sintctl</code>.</p>
+      </section>
+    </main>
+  </body>
+</html>`);
+  });
+
+  app.get("/v1/docs/redoc", (c) => {
+    return c.html(`<!doctype html>
+<html>
+  <head>
+    <title>SINT Gateway API (Redoc)</title>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>body { margin: 0; }</style>
+  </head>
+  <body>
+    <redoc spec-url="/v1/openapi.json"></redoc>
+    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+  </body>
+</html>`);
   });
 
   return app;

--- a/docs/guides/api-documentation-site.md
+++ b/docs/guides/api-documentation-site.md
@@ -1,0 +1,28 @@
+# SINT API Documentation Site
+
+SINT Gateway now serves a built-in API documentation surface from the live OpenAPI schema.
+
+## Endpoints
+
+- Landing page: `GET /v1/docs`
+- Interactive docs (Redoc): `GET /v1/docs/redoc`
+- Raw schema: `GET /v1/openapi.json`
+
+## Local Usage
+
+Start gateway:
+
+```bash
+pnpm --filter @sint/gateway-server dev
+```
+
+Open docs:
+
+- http://localhost:3100/v1/docs
+- http://localhost:3100/v1/docs/redoc
+
+## Notes
+
+- The docs are generated from the same OpenAPI route used by tooling.
+- Protected endpoints still require auth (`X-API-Key`) when called from clients.
+- Keep OpenAPI paths in `apps/gateway-server/src/routes/discovery.ts` aligned with route changes.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,8 +14,8 @@
 ### SDK & Developer Experience
 - [x] Python SDK (`sint-python`) — bridge to robotics/ML ecosystem
 - [x] CLI tool for token management, ledger queries, policy testing
-- [ ] Interactive policy playground (web-based rule testing)
-- [ ] Comprehensive API documentation site
+- [x] Interactive policy playground (web-based rule testing)
+- [x] Comprehensive API documentation site
 
 ### Integration
 - [ ] Gazebo simulation environment integration (ROS 2 bridge validation)


### PR DESCRIPTION
## Summary
- add interactive Policy Playground in dashboard for live `/v1/intercept` testing
- add hosted gateway API docs endpoints (`/v1/docs`, `/v1/docs/redoc`)
- extend OpenAPI surface + API tests for docs endpoints
- update README and roadmap/docs artifacts

## Validation
- `pnpm --filter @sint/gateway-server test`
- `pnpm --filter @sint/dashboard build`
- `pnpm run build`

Closes #50
Closes #51
