### PR TITLE
feat(q2): Gazebo ROS2 integration for bridge validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,14 @@ pnpm --filter @sint/gateway-server dev
 pnpm run stack:dev
 pnpm run stack:edge
 pnpm run stack:prod-lite
+pnpm run stack:gazebo-validation
 ```
 
 Compose profiles:
 - [`docker/compose/dev.yml`](docker/compose/dev.yml)
 - [`docker/compose/edge.yml`](docker/compose/edge.yml)
 - [`docker/compose/prod-lite.yml`](docker/compose/prod-lite.yml)
+- [`docker/compose/gazebo-validation.yml`](docker/compose/gazebo-validation.yml)
 
 ### Developer Docs Site (`docs.sint.gg`)
 

--- a/docker/compose/gazebo-validation.yml
+++ b/docker/compose/gazebo-validation.yml
@@ -1,0 +1,84 @@
+version: "3.9"
+
+services:
+  gateway:
+    build:
+      context: ../..
+      dockerfile: apps/gateway-server/Dockerfile
+    ports:
+      - "3100:3100"
+    environment:
+      SINT_PORT: "3100"
+      SINT_STORE: postgres
+      SINT_CACHE: redis
+      DATABASE_URL: postgresql://sint:sint@postgres:5432/sint
+      REDIS_URL: redis://redis:6379
+      SINT_LOG_LEVEL: info
+      SINT_WS_ALLOW_QUERY_API_KEY: "true"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3100/v1/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: sint
+      POSTGRES_PASSWORD: sint
+      POSTGRES_DB: sint
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ../../packages/persistence/migrations:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U sint -d sint"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  redis:
+    image: redis:7-alpine
+    command: redis-server --appendonly yes
+    volumes:
+      - redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+
+  gazebo-sim:
+    image: osrf/ros:jazzy-desktop
+    command: >-
+      bash -lc "
+      source /opt/ros/jazzy/setup.bash &&
+      apt-get update && apt-get install -y ros-jazzy-gazebo-ros-pkgs &&
+      ros2 launch gazebo_ros empty_world.launch.py
+      "
+    network_mode: host
+
+  gazebo-cmdvel-publisher:
+    image: osrf/ros:jazzy-desktop
+    depends_on:
+      gateway:
+        condition: service_healthy
+    command: >-
+      bash -lc "
+      source /opt/ros/jazzy/setup.bash &&
+      sleep 8 &&
+      ros2 topic pub --rate 2 /model/warehouse_bot/cmd_vel geometry_msgs/msg/Twist
+      '{linear: {x: 0.3, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 0.0}}'
+      "
+    network_mode: host
+
+volumes:
+  pgdata:
+  redisdata:

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -39,6 +39,7 @@ export default defineConfig({
           { text: "Docker Deployment", link: "/guides/docker-deployment" },
           { text: "Persistence Baseline", link: "/guides/persistence-baseline" },
           { text: "WebSocket Approvals", link: "/guides/websocket-approvals" },
+          { text: "Gazebo ROS2 Validation", link: "/guides/gazebo-ros2-validation" },
           { text: "Secure MCP Deployments", link: "/guides/secure-mcp-deployments" },
           { text: "API Documentation Site", link: "/guides/api-documentation-site" },
           { text: "Claude Desktop Integration", link: "/guides/claude-desktop-integration" },

--- a/docs/guides/gazebo-ros2-validation.md
+++ b/docs/guides/gazebo-ros2-validation.md
@@ -1,0 +1,62 @@
+# Gazebo + ROS2 Validation Guide
+
+This guide provides a reproducible simulation path for validating SINT ROS2 bridge behavior before deploying to physical robots.
+
+## Scope
+
+The Gazebo validation profile focuses on control-path safety invariants:
+
+- Gazebo model-scoped topics (for example `/world/demo/model/warehouse_bot/cmd_vel`) are normalized to canonical SINT ROS2 resources.
+- Tier assignment remains equivalent to native ROS2 control topics.
+- Constraint enforcement (for example max velocity) remains deterministic.
+
+## Run the Validation Stack
+
+```bash
+pnpm run stack:gazebo-validation
+```
+
+This starts:
+
+- SINT gateway (`http://localhost:3100`)
+- PostgreSQL + Redis
+- Gazebo simulator container (`gazebo-sim`)
+- ROS2 publisher container sending `/model/warehouse_bot/cmd_vel`
+
+Compose profile:
+
+- `docker/compose/gazebo-validation.yml`
+
+## Verify Protocol Behavior
+
+1. Confirm gateway health:
+
+```bash
+curl http://localhost:3100/v1/health
+```
+
+2. Use dashboard policy playground (`/v1/intercept`) or `sintctl` to replay a Gazebo-scoped request with resource:
+
+```text
+ros2:///cmd_vel
+```
+
+3. Confirm expected result:
+
+- Assigned tier: `T2_act` (or `T3_commit` with escalation factors)
+- Action: `escalate` (or `deny` when constraints are violated)
+
+## Automated Conformance Evidence
+
+Run:
+
+```bash
+pnpm --filter @sint/conformance-tests test -- src/industrial-interoperability.test.ts
+```
+
+The test `Gazebo model-scoped cmd_vel maps to equivalent ROS2 control-tier semantics` verifies equivalence between canonical ROS2 and Gazebo-scoped control paths.
+
+## Notes
+
+- This profile is for pre-production safety validation and integration testing.
+- For production control loops, use dedicated hardware-in-the-loop and safety-controller checks.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,7 @@
 - [x] Comprehensive API documentation site
 
 ### Integration
-- [ ] Gazebo simulation environment integration (ROS 2 bridge validation)
+- [x] Gazebo simulation environment integration (ROS 2 bridge validation)
 - [ ] NVIDIA Isaac Sim connector (industrial robotics testing)
 - [x] Claude Desktop integration guide (MCP proxy setup)
 - [x] Cursor integration guide

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "stack:dev": "bash ./scripts/stack-up.sh dev",
     "stack:edge": "bash ./scripts/stack-up.sh edge",
     "stack:prod-lite": "bash ./scripts/stack-up.sh prod-lite",
+    "stack:gazebo-validation": "bash ./scripts/stack-up.sh gazebo-validation",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"

--- a/packages/bridge-ros2/__tests__/resource-mapper.test.ts
+++ b/packages/bridge-ros2/__tests__/resource-mapper.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from "vitest";
 import {
   topicToResourceUri,
+  gazeboTopicToResourceUri,
   serviceToResourceUri,
   actionToResourceUri,
   extractPhysicalContext,
@@ -26,6 +27,30 @@ describe("topicToResourceUri", () => {
 
   it("handles topic without leading slash", () => {
     expect(topicToResourceUri("sensor/lidar")).toBe("ros2:///sensor/lidar");
+  });
+
+  it("normalizes Gazebo model-scoped cmd_vel when enabled", () => {
+    expect(topicToResourceUri("/model/amr_17/cmd_vel", { gazeboNormalize: true }))
+      .toBe("ros2:///cmd_vel");
+  });
+
+  it("keeps Gazebo model-scoped topic unchanged by default", () => {
+    expect(topicToResourceUri("/model/amr_17/cmd_vel"))
+      .toBe("ros2:///model/amr_17/cmd_vel");
+  });
+});
+
+describe("gazeboTopicToResourceUri", () => {
+  it("maps Gazebo cmd_vel topic to canonical ROS2 cmd_vel resource", () => {
+    expect(gazeboTopicToResourceUri("/model/warehouse_bot/cmd_vel")).toBe(
+      "ros2:///cmd_vel",
+    );
+  });
+
+  it("maps Gazebo world/model joint command topic to canonical resource", () => {
+    expect(
+      gazeboTopicToResourceUri("/world/demo/model/arm_1/joint_commands"),
+    ).toBe("ros2:///joint_commands");
   });
 });
 

--- a/packages/bridge-ros2/src/index.ts
+++ b/packages/bridge-ros2/src/index.ts
@@ -1,5 +1,6 @@
 export {
   topicToResourceUri,
+  gazeboTopicToResourceUri,
   serviceToResourceUri,
   actionToResourceUri,
   extractPhysicalContext,

--- a/packages/bridge-ros2/src/ros2-resource-mapper.ts
+++ b/packages/bridge-ros2/src/ros2-resource-mapper.ts
@@ -17,6 +17,38 @@ import {
   extractPhysicalContextFromWrench,
 } from "./ros2-message-types.js";
 
+export interface TopicToResourceOptions {
+  /**
+   * Normalize common Gazebo-scoped control topics (e.g. `/model/amr/cmd_vel`)
+   * into canonical ROS2 control resources (e.g. `/cmd_vel`) so simulation and
+   * physical paths share equivalent policy tiering.
+   */
+  gazeboNormalize?: boolean;
+}
+
+const GAZEBO_CONTROL_TOPIC_SUFFIX =
+  /\/(cmd_vel|joint_commands|mode_change|plan|waypoints|navigate_to_pose)$/;
+
+function normalizeTopicName(topicName: string, options?: TopicToResourceOptions): string {
+  const normalized = topicName.startsWith("/") ? topicName : `/${topicName}`;
+  if (!options?.gazeboNormalize) {
+    return normalized;
+  }
+
+  const gazeboScoped =
+    normalized.startsWith("/model/") ||
+    normalized.startsWith("/world/");
+  if (!gazeboScoped) {
+    return normalized;
+  }
+
+  const suffix = normalized.match(GAZEBO_CONTROL_TOPIC_SUFFIX)?.[1];
+  if (!suffix) {
+    return normalized;
+  }
+  return `/${suffix}`;
+}
+
 /**
  * Map a ROS 2 topic name to a SINT resource URI.
  *
@@ -26,10 +58,25 @@ import {
  * topicToResourceUri("/camera/front") // => "ros2:///camera/front"
  * ```
  */
-export function topicToResourceUri(topicName: string): string {
-  // Strip leading slash if present, then add ros2:/// prefix
-  const normalized = topicName.startsWith("/") ? topicName.slice(1) : topicName;
-  return `ros2:///${normalized}`;
+export function topicToResourceUri(
+  topicName: string,
+  options?: TopicToResourceOptions,
+): string {
+  const normalized = normalizeTopicName(topicName, options);
+  return `ros2:///${normalized.slice(1)}`;
+}
+
+/**
+ * Map a Gazebo-scoped ROS2 topic to a canonical SINT resource URI.
+ *
+ * @example
+ * ```ts
+ * gazeboTopicToResourceUri("/model/amr_17/cmd_vel") // => "ros2:///cmd_vel"
+ * gazeboTopicToResourceUri("/world/demo/model/amr_17/joint_commands") // => "ros2:///joint_commands"
+ * ```
+ */
+export function gazeboTopicToResourceUri(topicName: string): string {
+  return topicToResourceUri(topicName, { gazeboNormalize: true });
 }
 
 /**

--- a/packages/conformance-tests/src/industrial-interoperability.test.ts
+++ b/packages/conformance-tests/src/industrial-interoperability.test.ts
@@ -15,7 +15,7 @@ import {
   RevocationStore,
 } from "@sint/gate-capability-tokens";
 import { PolicyGateway } from "@sint/gate-policy-gateway";
-import { topicToResourceUri } from "@sint/bridge-ros2";
+import { topicToResourceUri, gazeboTopicToResourceUri } from "@sint/bridge-ros2";
 import {
   rmfDispatchResourceUri,
   rmfOperationToAction,
@@ -222,5 +222,44 @@ describe("Industrial Interoperability Conformance", () => {
 
     expect(rmfDecision.assignedTier).toBe(ApprovalTier.T2_ACT);
     expect(rmfDecision.action).toBe("escalate");
+  });
+
+  it("Gazebo model-scoped cmd_vel maps to equivalent ROS2 control-tier semantics", async () => {
+    const rosToken = issueAndStore({
+      resource: "ros2://*",
+      actions: ["publish"],
+      constraints: { maxVelocityMps: 0.6 },
+    });
+
+    const canonicalDecision = await gateway.intercept({
+      requestId: generateUUIDv7(),
+      timestamp: nowISO8601(),
+      agentId: agent.publicKey,
+      tokenId: rosToken.tokenId,
+      resource: topicToResourceUri("/cmd_vel"),
+      action: "publish",
+      params: { command: "move_to_aisle", destination: "B-04" },
+      physicalContext: {
+        currentVelocityMps: 0.4,
+      },
+    });
+
+    const gazeboDecision = await gateway.intercept({
+      requestId: generateUUIDv7(),
+      timestamp: nowISO8601(),
+      agentId: agent.publicKey,
+      tokenId: rosToken.tokenId,
+      resource: gazeboTopicToResourceUri("/world/demo/model/warehouse_bot/cmd_vel"),
+      action: "publish",
+      params: { command: "move_to_aisle", destination: "B-04" },
+      physicalContext: {
+        currentVelocityMps: 0.4,
+      },
+    });
+
+    expect(gazeboDecision.assignedTier).toBe(canonicalDecision.assignedTier);
+    expect(gazeboDecision.action).toBe(canonicalDecision.action);
+    expect(gazeboDecision.assignedTier).toBe(ApprovalTier.T2_ACT);
+    expect(gazeboDecision.action).toBe("escalate");
   });
 });

--- a/scripts/stack-up.sh
+++ b/scripts/stack-up.sh
@@ -5,9 +5,9 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PROFILE="${1:-dev}"
 
 case "$PROFILE" in
-  dev|edge|prod-lite) ;;
+  dev|edge|prod-lite|gazebo-validation) ;;
   *)
-    echo "Usage: $0 [dev|edge|prod-lite]" >&2
+    echo "Usage: $0 [dev|edge|prod-lite|gazebo-validation]" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary
- add Gazebo validation compose profile: `docker/compose/gazebo-validation.yml`
- add `stack:gazebo-validation` and extend `stack-up.sh` profile support
- add Gazebo-aware ROS2 topic normalization helper (`gazeboTopicToResourceUri`) for canonical safety tiering
- add unit tests for Gazebo topic normalization in `@sint/bridge-ros2`
- add industrial conformance coverage proving Gazebo model-scoped `cmd_vel` maps to equivalent ROS2 control-tier behavior
- add operator guide: `docs/guides/gazebo-ros2-validation.md`

## Validation
- `pnpm --filter @sint/bridge-ros2 test -- resource-mapper.test.ts`
- `pnpm --filter @sint/bridge-ros2 build && pnpm --filter @sint/conformance-tests test -- src/industrial-interoperability.test.ts`
- `pnpm run docs:build`
- `pnpm run build`

Closes #52
