### PR TITLE
feat(q2): NVIDIA Isaac Sim connector integration baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ pnpm run stack:dev
 pnpm run stack:edge
 pnpm run stack:prod-lite
 pnpm run stack:gazebo-validation
+pnpm run stack:isaac-sim-validation
 ```
 
 Compose profiles:
@@ -68,6 +69,7 @@ Compose profiles:
 - [`docker/compose/edge.yml`](docker/compose/edge.yml)
 - [`docker/compose/prod-lite.yml`](docker/compose/prod-lite.yml)
 - [`docker/compose/gazebo-validation.yml`](docker/compose/gazebo-validation.yml)
+- [`docker/compose/isaac-sim-validation.yml`](docker/compose/isaac-sim-validation.yml)
 
 ### Developer Docs Site (`docs.sint.gg`)
 

--- a/docker/compose/isaac-sim-validation.yml
+++ b/docker/compose/isaac-sim-validation.yml
@@ -1,0 +1,85 @@
+version: "3.9"
+
+services:
+  gateway:
+    build:
+      context: ../..
+      dockerfile: apps/gateway-server/Dockerfile
+    ports:
+      - "3100:3100"
+    environment:
+      SINT_PORT: "3100"
+      SINT_STORE: postgres
+      SINT_CACHE: redis
+      DATABASE_URL: postgresql://sint:sint@postgres:5432/sint
+      REDIS_URL: redis://redis:6379
+      SINT_LOG_LEVEL: info
+      SINT_WS_ALLOW_QUERY_API_KEY: "true"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3100/v1/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: sint
+      POSTGRES_PASSWORD: sint
+      POSTGRES_DB: sint
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ../../packages/persistence/migrations:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U sint -d sint"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  redis:
+    image: redis:7-alpine
+    command: redis-server --appendonly yes
+    volumes:
+      - redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+
+  isaac-sim:
+    image: ${ISAAC_SIM_IMAGE:-nvcr.io/nvidia/isaac-sim:4.2.0}
+    command: ["bash", "-lc", "./runheadless.sh"]
+    environment:
+      ACCEPT_EULA: "Y"
+      PRIVACY_CONSENT: "Y"
+      DISPLAY: ${DISPLAY:-}
+      ROS_DOMAIN_ID: ${ROS_DOMAIN_ID:-20}
+    ports:
+      - "8211:8211"
+      - "49100:49100"
+
+  isaac-ros2-publisher:
+    image: osrf/ros:jazzy-desktop
+    depends_on:
+      gateway:
+        condition: service_healthy
+    command: >-
+      bash -lc "
+      source /opt/ros/jazzy/setup.bash &&
+      sleep 8 &&
+      ros2 topic pub --rate 2 /isaac/warehouse_bot/cmd_vel geometry_msgs/msg/Twist
+      '{linear: {x: 0.25, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 0.0}}'
+      "
+
+volumes:
+  pgdata:
+  redisdata:

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -40,6 +40,7 @@ export default defineConfig({
           { text: "Persistence Baseline", link: "/guides/persistence-baseline" },
           { text: "WebSocket Approvals", link: "/guides/websocket-approvals" },
           { text: "Gazebo ROS2 Validation", link: "/guides/gazebo-ros2-validation" },
+          { text: "Isaac Sim Integration", link: "/guides/isaac-sim-integration" },
           { text: "Secure MCP Deployments", link: "/guides/secure-mcp-deployments" },
           { text: "API Documentation Site", link: "/guides/api-documentation-site" },
           { text: "Claude Desktop Integration", link: "/guides/claude-desktop-integration" },

--- a/docs/guides/isaac-sim-integration.md
+++ b/docs/guides/isaac-sim-integration.md
@@ -1,0 +1,61 @@
+# NVIDIA Isaac Sim Integration Guide
+
+This guide defines the SINT validation path for NVIDIA Isaac Sim industrial simulation workflows.
+
+## Scope
+
+The Isaac Sim integration validates that ROS2 namespaced control topics preserve safety semantics when routed through SINT:
+
+- `/isaac/<robot>/cmd_vel` and `/robots/<robot>/joint_commands` map to canonical ROS2 control resources.
+- Tiering/approval behavior matches native ROS2 control paths.
+- Constraint and revocation behavior remains fail-closed.
+
+## Run Isaac Sim Validation Stack
+
+```bash
+pnpm run stack:isaac-sim-validation
+```
+
+Compose profile:
+
+- `docker/compose/isaac-sim-validation.yml`
+
+## Environment Notes
+
+- By default, compose expects `nvcr.io/nvidia/isaac-sim:4.2.0`.
+- Override image if your org uses a pinned internal mirror:
+
+```bash
+export ISAAC_SIM_IMAGE=<your-registry>/isaac-sim:<tag>
+```
+
+- NVIDIA NGC credentials may be required to pull Isaac Sim images.
+
+## Validation Checks
+
+1. Gateway health:
+
+```bash
+curl http://localhost:3100/v1/health
+```
+
+2. Replay/submit an Isaac namespaced resource through SINT as canonical ROS2 control action:
+
+```text
+ros2:///cmd_vel
+```
+
+3. Expect control-path behavior:
+
+- Assigned tier `T2_act` (or `T3_commit` with escalation factors)
+- Action `escalate` unless denied by constraints/policy
+
+## Conformance Evidence
+
+Run:
+
+```bash
+pnpm --filter @sint/conformance-tests test -- src/industrial-interoperability.test.ts
+```
+
+The test `Isaac Sim namespaced cmd_vel maps to equivalent ROS2 control-tier semantics` verifies equivalence with native ROS2 control behavior.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,7 +19,7 @@
 
 ### Integration
 - [x] Gazebo simulation environment integration (ROS 2 bridge validation)
-- [ ] NVIDIA Isaac Sim connector (industrial robotics testing)
+- [x] NVIDIA Isaac Sim connector (industrial robotics testing)
 - [x] Claude Desktop integration guide (MCP proxy setup)
 - [x] Cursor integration guide
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "stack:edge": "bash ./scripts/stack-up.sh edge",
     "stack:prod-lite": "bash ./scripts/stack-up.sh prod-lite",
     "stack:gazebo-validation": "bash ./scripts/stack-up.sh gazebo-validation",
+    "stack:isaac-sim-validation": "bash ./scripts/stack-up.sh isaac-sim-validation",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"

--- a/packages/bridge-ros2/__tests__/resource-mapper.test.ts
+++ b/packages/bridge-ros2/__tests__/resource-mapper.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect } from "vitest";
 import {
   topicToResourceUri,
   gazeboTopicToResourceUri,
+  isaacTopicToResourceUri,
   serviceToResourceUri,
   actionToResourceUri,
   extractPhysicalContext,
@@ -38,6 +39,11 @@ describe("topicToResourceUri", () => {
     expect(topicToResourceUri("/model/amr_17/cmd_vel"))
       .toBe("ros2:///model/amr_17/cmd_vel");
   });
+
+  it("normalizes Isaac namespaced cmd_vel when enabled", () => {
+    expect(topicToResourceUri("/isaac/ur10/cmd_vel", { isaacNormalize: true }))
+      .toBe("ros2:///cmd_vel");
+  });
 });
 
 describe("gazeboTopicToResourceUri", () => {
@@ -51,6 +57,20 @@ describe("gazeboTopicToResourceUri", () => {
     expect(
       gazeboTopicToResourceUri("/world/demo/model/arm_1/joint_commands"),
     ).toBe("ros2:///joint_commands");
+  });
+});
+
+describe("isaacTopicToResourceUri", () => {
+  it("maps Isaac namespaced cmd_vel to canonical resource", () => {
+    expect(isaacTopicToResourceUri("/isaac/warehouse_bot/cmd_vel")).toBe(
+      "ros2:///cmd_vel",
+    );
+  });
+
+  it("maps Isaac namespaced joint command topic to canonical resource", () => {
+    expect(isaacTopicToResourceUri("/robots/cell_bot_01/joint_commands")).toBe(
+      "ros2:///joint_commands",
+    );
   });
 });
 

--- a/packages/bridge-ros2/src/index.ts
+++ b/packages/bridge-ros2/src/index.ts
@@ -1,6 +1,7 @@
 export {
   topicToResourceUri,
   gazeboTopicToResourceUri,
+  isaacTopicToResourceUri,
   serviceToResourceUri,
   actionToResourceUri,
   extractPhysicalContext,

--- a/packages/bridge-ros2/src/ros2-resource-mapper.ts
+++ b/packages/bridge-ros2/src/ros2-resource-mapper.ts
@@ -24,10 +24,17 @@ export interface TopicToResourceOptions {
    * physical paths share equivalent policy tiering.
    */
   gazeboNormalize?: boolean;
+  /**
+   * Normalize common Isaac Sim namespaced ROS2 control topics
+   * (e.g. `/isaac/ur10/cmd_vel`) into canonical control resources.
+   */
+  isaacNormalize?: boolean;
 }
 
 const GAZEBO_CONTROL_TOPIC_SUFFIX =
   /\/(cmd_vel|joint_commands|mode_change|plan|waypoints|navigate_to_pose)$/;
+const ISAAC_NAMESPACED_CONTROL_TOPIC =
+  /^\/(isaac|sim|robots)\/[^/]+\/(cmd_vel|joint_commands|mode_change|plan|waypoints|navigate_to_pose)$/;
 
 function normalizeTopicName(topicName: string, options?: TopicToResourceOptions): string {
   const normalized = topicName.startsWith("/") ? topicName : `/${topicName}`;
@@ -49,6 +56,18 @@ function normalizeTopicName(topicName: string, options?: TopicToResourceOptions)
   return `/${suffix}`;
 }
 
+function normalizeIsaacTopicName(topicName: string, options?: TopicToResourceOptions): string {
+  const normalized = topicName.startsWith("/") ? topicName : `/${topicName}`;
+  if (!options?.isaacNormalize) {
+    return normalized;
+  }
+  const match = normalized.match(ISAAC_NAMESPACED_CONTROL_TOPIC);
+  if (!match?.[2]) {
+    return normalized;
+  }
+  return `/${match[2]}`;
+}
+
 /**
  * Map a ROS 2 topic name to a SINT resource URI.
  *
@@ -62,7 +81,10 @@ export function topicToResourceUri(
   topicName: string,
   options?: TopicToResourceOptions,
 ): string {
-  const normalized = normalizeTopicName(topicName, options);
+  const normalized = normalizeIsaacTopicName(
+    normalizeTopicName(topicName, options),
+    options,
+  );
   return `ros2:///${normalized.slice(1)}`;
 }
 
@@ -77,6 +99,19 @@ export function topicToResourceUri(
  */
 export function gazeboTopicToResourceUri(topicName: string): string {
   return topicToResourceUri(topicName, { gazeboNormalize: true });
+}
+
+/**
+ * Map an Isaac Sim namespaced ROS2 topic to a canonical SINT resource URI.
+ *
+ * @example
+ * ```ts
+ * isaacTopicToResourceUri("/isaac/ur10/cmd_vel") // => "ros2:///cmd_vel"
+ * isaacTopicToResourceUri("/robots/cell_bot_01/joint_commands") // => "ros2:///joint_commands"
+ * ```
+ */
+export function isaacTopicToResourceUri(topicName: string): string {
+  return topicToResourceUri(topicName, { isaacNormalize: true });
 }
 
 /**

--- a/packages/conformance-tests/src/industrial-interoperability.test.ts
+++ b/packages/conformance-tests/src/industrial-interoperability.test.ts
@@ -15,7 +15,11 @@ import {
   RevocationStore,
 } from "@sint/gate-capability-tokens";
 import { PolicyGateway } from "@sint/gate-policy-gateway";
-import { topicToResourceUri, gazeboTopicToResourceUri } from "@sint/bridge-ros2";
+import {
+  topicToResourceUri,
+  gazeboTopicToResourceUri,
+  isaacTopicToResourceUri,
+} from "@sint/bridge-ros2";
 import {
   rmfDispatchResourceUri,
   rmfOperationToAction,
@@ -261,5 +265,44 @@ describe("Industrial Interoperability Conformance", () => {
     expect(gazeboDecision.action).toBe(canonicalDecision.action);
     expect(gazeboDecision.assignedTier).toBe(ApprovalTier.T2_ACT);
     expect(gazeboDecision.action).toBe("escalate");
+  });
+
+  it("Isaac Sim namespaced cmd_vel maps to equivalent ROS2 control-tier semantics", async () => {
+    const rosToken = issueAndStore({
+      resource: "ros2://*",
+      actions: ["publish"],
+      constraints: { maxVelocityMps: 0.6 },
+    });
+
+    const canonicalDecision = await gateway.intercept({
+      requestId: generateUUIDv7(),
+      timestamp: nowISO8601(),
+      agentId: agent.publicKey,
+      tokenId: rosToken.tokenId,
+      resource: topicToResourceUri("/cmd_vel"),
+      action: "publish",
+      params: { command: "dock_to_station", destination: "Dock-3" },
+      physicalContext: {
+        currentVelocityMps: 0.35,
+      },
+    });
+
+    const isaacDecision = await gateway.intercept({
+      requestId: generateUUIDv7(),
+      timestamp: nowISO8601(),
+      agentId: agent.publicKey,
+      tokenId: rosToken.tokenId,
+      resource: isaacTopicToResourceUri("/isaac/warehouse_bot/cmd_vel"),
+      action: "publish",
+      params: { command: "dock_to_station", destination: "Dock-3" },
+      physicalContext: {
+        currentVelocityMps: 0.35,
+      },
+    });
+
+    expect(isaacDecision.assignedTier).toBe(canonicalDecision.assignedTier);
+    expect(isaacDecision.action).toBe(canonicalDecision.action);
+    expect(isaacDecision.assignedTier).toBe(ApprovalTier.T2_ACT);
+    expect(isaacDecision.action).toBe("escalate");
   });
 });

--- a/scripts/stack-up.sh
+++ b/scripts/stack-up.sh
@@ -5,9 +5,9 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PROFILE="${1:-dev}"
 
 case "$PROFILE" in
-  dev|edge|prod-lite|gazebo-validation) ;;
+  dev|edge|prod-lite|gazebo-validation|isaac-sim-validation) ;;
   *)
-    echo "Usage: $0 [dev|edge|prod-lite|gazebo-validation]" >&2
+    echo "Usage: $0 [dev|edge|prod-lite|gazebo-validation|isaac-sim-validation]" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary
- add Isaac Sim validation compose profile: `docker/compose/isaac-sim-validation.yml`
- add `stack:isaac-sim-validation` script and stack runner profile support
- add Isaac Sim ROS2 namespace normalization helper (`isaacTopicToResourceUri`) for canonical tiering behavior
- add mapper unit tests covering Isaac namespaced control topics
- add conformance scenario proving Isaac namespaced `cmd_vel` path matches native ROS2 control-tier semantics
- add integration guide: `docs/guides/isaac-sim-integration.md`

## Validation
- `pnpm --filter @sint/bridge-ros2 test -- resource-mapper.test.ts`
- `pnpm --filter @sint/bridge-ros2 build && pnpm --filter @sint/conformance-tests test -- src/industrial-interoperability.test.ts`
- `pnpm run docs:build`
- `pnpm run build`

Closes #53
