### PR TITLE
feat(q2): community adoption assets + April security bulletin

### DIFF
--- a/.github/ISSUE_TEMPLATE/first_contribution.yml
+++ b/.github/ISSUE_TEMPLATE/first_contribution.yml
@@ -1,0 +1,49 @@
+name: First Contribution
+about: Structured onboarding issue for first-time external contributors
+title: "first-contrib: <short task name>"
+labels: ["good first issue", "help wanted", "roadmap-q2"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing to SINT. This template is optimized for first-time contributors.
+  - type: input
+    id: scope
+    attributes:
+      label: Task scope
+      placeholder: "What should be changed?"
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Keep this concise and testable.
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation commands
+      placeholder: |
+        pnpm run build
+        pnpm run test
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: Useful file references
+      placeholder: "docs/guides/... , packages/..."
+  - type: dropdown
+    id: mentor
+    attributes:
+      label: Maintainer mentor needed?
+      options:
+        - Yes
+        - No
+    validations:
+      required: true

--- a/.github/workflows/security-bulletin-reminder.yml
+++ b/.github/workflows/security-bulletin-reminder.yml
@@ -1,0 +1,47 @@
+name: Security Bulletin Reminder
+
+on:
+  schedule:
+    - cron: "0 16 1 * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  open-reminder-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open monthly bulletin reminder issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const now = new Date();
+            const month = now.toLocaleString('en-US', { month: 'long', timeZone: 'UTC' });
+            const year = now.toLocaleString('en-US', { year: 'numeric', timeZone: 'UTC' });
+            const title = `Q2/Q3: Publish monthly SINT Security Bulletin (${month} ${year})`;
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            if (issues.some(i => i.title === title)) {
+              core.info('Reminder issue already exists.');
+              return;
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              labels: ['documentation', 'roadmap-tracking'],
+              body: [
+                'Publish this month\'s security bulletin in `docs/security-bulletins/`.',
+                '',
+                'Checklist:',
+                '- Add `<yyyy-mm>.md` from `TEMPLATE.md`',
+                '- Include security-relevant protocol/runtime changes',
+                '- Include operator action items and validation commands',
+                '- Link bulletin from docs navigation if needed',
+              ].join('\n'),
+            });

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ pnpm run docs:preview
 
 Docs source lives in [`docs/`](docs), VitePress config is in [`docs/.vitepress/config.mts`](docs/.vitepress/config.mts), and deployment is handled by [`docs-site.yml`](.github/workflows/docs-site.yml).
 
+Community/adoption assets:
+- [`docs/community/discord-launch-runbook.md`](docs/community/discord-launch-runbook.md)
+- [`docs/community/external-contributor-onboarding.md`](docs/community/external-contributor-onboarding.md)
+- [`docs/security-bulletins/2026-04.md`](docs/security-bulletins/2026-04.md)
+
 ### Run a Single Package
 
 ```bash

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -48,6 +48,20 @@ export default defineConfig({
         ],
       },
       {
+        text: "Community",
+        items: [
+          { text: "Discord Launch Runbook", link: "/community/discord-launch-runbook" },
+          { text: "External Contributor Onboarding", link: "/community/external-contributor-onboarding" },
+        ],
+      },
+      {
+        text: "Security Bulletins",
+        items: [
+          { text: "April 2026 Bulletin", link: "/security-bulletins/2026-04" },
+          { text: "Bulletin Template", link: "/security-bulletins/TEMPLATE" },
+        ],
+      },
+      {
         text: "Profiles",
         items: [
           { text: "Warehouse AMR Policy Template", link: "/profiles/warehouse-amr.policy.template" },

--- a/docs/community/discord-launch-runbook.md
+++ b/docs/community/discord-launch-runbook.md
@@ -1,0 +1,86 @@
+# Discord Community Launch Runbook
+
+Owner: Community + Maintainers
+Status: Launch-ready
+
+## Objective
+
+Launch and operate the SINT Discord server as the primary real-time community channel for:
+
+- Integrator support
+- Protocol Q&A
+- Security discussions
+- Contributor coordination
+
+## Server Structure
+
+## Categories and Channels
+
+- `START HERE`
+- `#welcome`
+- `#rules`
+- `#announcements`
+
+- `COMMUNITY`
+- `#introductions`
+- `#general`
+- `#show-and-tell`
+
+- `BUILD WITH SINT`
+- `#mcp-integration`
+- `#ros2-and-robotics`
+- `#industrial-iot`
+- `#policy-design`
+
+- `CONTRIBUTING`
+- `#good-first-issues`
+- `#contributor-onboarding`
+- `#maintainer-office-hours`
+
+- `SECURITY`
+- `#security-bulletins`
+- `#incident-reporting` (private mod intake)
+
+## Roles
+
+- `Maintainer`
+- `Moderator`
+- `Contributor`
+- `Design Partner`
+- `Security Researcher`
+- `Community Member`
+
+## Moderation Policy
+
+- Enforce a strict no-harassment, no-doxxing, no-malware-sharing policy.
+- Redirect vulnerability details to private security channels.
+- Require technical claims to include reproducible context when possible.
+
+Escalation ladder:
+
+1. Warning
+2. Timeout
+3. Temporary ban
+4. Permanent ban
+
+## Launch Day Checklist
+
+1. Finalize channels and permissions.
+2. Post `#welcome` and `#rules` copy.
+3. Publish invite link in README + launch posts.
+4. Seed `#good-first-issues` with 5 starter tasks.
+5. Schedule first office hours session.
+6. Announce first security bulletin date.
+
+## Week 1 Success Metrics
+
+- 100+ joined members
+- 20+ unique posters
+- 5+ integration support threads resolved
+- 1+ external contributor starts first PR
+
+## Operations Cadence
+
+- Daily: moderator review of flagged content
+- Weekly: office hours + issue triage summary
+- Monthly: post SINT security bulletin in `#security-bulletins`

--- a/docs/community/external-contributor-onboarding.md
+++ b/docs/community/external-contributor-onboarding.md
@@ -1,0 +1,50 @@
+# External Contributor Onboarding
+
+This guide is the fast path from "first visit" to "first merged PR".
+
+## Target Outcome
+
+A new contributor completes:
+
+1. Local setup
+2. One scoped issue
+3. One merged PR
+
+within 1-2 days.
+
+## Starter Path
+
+1. Fork and clone `sint-ai/sint-protocol`
+2. Install deps: `pnpm install`
+3. Validate baseline: `pnpm run build && pnpm run test`
+4. Pick one `good first issue` with clear acceptance criteria
+5. Create branch: `codex/<short-task-name>`
+6. Implement + update docs/tests
+7. Open PR using the repository template
+
+## Suggested First Issues
+
+- Docs corrections in guides/tutorials
+- New conformance fixture cases
+- Small bridge mapping improvements
+- Dashboard UX polish for approval/evidence views
+
+## Maintainer SLA
+
+- First response: within 24h
+- First review pass: within 48h
+- Merge-ready decision: within 72h
+
+## First PR Checklist
+
+- [ ] Scope matches issue acceptance criteria
+- [ ] Tests or fixtures updated where behavior changed
+- [ ] Docs updated for protocol/runtime-facing changes
+- [ ] `pnpm run build` passes
+- [ ] PR description links issue and validation commands
+
+## Contributor Recognition
+
+- Add contributor to release notes credits
+- Highlight first merged PR in monthly bulletin
+- Offer next-step issue with incremental complexity

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,8 @@ features:
 - Build static docs site: `pnpm run docs:build`
 - Core onboarding: [Getting Started](./getting-started.md)
 - Integration examples: [Tutorials](./tutorials/hello-world-agent.md)
+- Community launch runbook: [Discord Launch](./community/discord-launch-runbook.md)
+- Latest security bulletin: [April 2026](./security-bulletins/2026-04.md)
 
 ## Documentation Scope
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,24 @@
+# SINT Roadmap (Active Track)
+
+This file is the active roadmap index for docs navigation.
+
+## Q2 2026 — Foundation and Adoption
+
+- [x] WebSocket approval streaming
+- [x] PostgreSQL + Redis persistence baseline
+- [x] Docker images and compose stacks
+- [x] Policy playground + API docs surfaces
+- [x] Developer docs site launch (`docs.sint.gg`)
+- [x] Gazebo ROS2 validation profile
+- [x] NVIDIA Isaac Sim integration baseline
+- [ ] Discord community launch
+- [ ] First external contributor onboarding
+- [x] Monthly security bulletin publication
+
+## Q3/Q4 Planning
+
+See detailed plans in:
+
+- [Legacy phase plan](./roadmap-phases-legacy.md)
+- [Ecosystem outreach 2026](./roadmaps/ecosystem-outreach-2026.md)
+- [Hardware safety controller integration roadmap](./roadmaps/hardware-safety-controller-integration.md)

--- a/docs/security-bulletins/2026-04.md
+++ b/docs/security-bulletins/2026-04.md
@@ -1,0 +1,40 @@
+# SINT Security Bulletin — April 2026
+
+Published: 2026-04-05
+Scope: Protocol, runtime enforcement, and integration hardening updates.
+
+## Highlights
+
+- Shipped public protocol surfaces for discovery and schemas.
+- Expanded industrial interop validation: ROS2, Open-RMF, Sparkplug, OPC UA, gRPC equivalence fixtures.
+- Added docs and runtime surfaces for policy playground and API docs.
+- Added Gazebo and Isaac Sim validation profiles for robotics simulation safety testing.
+- Extended operator interface governance capabilities (memory + delegation + transparency views).
+
+## Security-Relevant Changes
+
+- Runtime paths continue fail-closed behavior under revocation and escalation checks.
+- Added conformance coverage for industrial equivalence and simulation-specific ROS2 mappings.
+- Reinforced approval/evidence observability via dashboard and gateway API surfaces.
+
+## Recommended Operator Actions
+
+1. Upgrade to latest `main` and rerun conformance fixtures.
+2. Validate your deployment profile policy templates (`warehouse-amr`, `industrial-cell`, `edge-gateway`).
+3. Re-check revocation + escalation drills in staging.
+4. If using simulation-first workflows, run Gazebo/Isaac validation compose profiles before production rollout.
+
+## Validation Commands
+
+```bash
+pnpm run build
+pnpm run test
+pnpm run docs:build
+pnpm --filter @sint/conformance-tests test -- src/industrial-interoperability.test.ts
+```
+
+## Forward Look (May 2026)
+
+- Community launch execution (Discord + external contributor path)
+- Security bulletin cadence automation
+- Additional conformance/certification fixtures for industrial buyer scenarios

--- a/docs/security-bulletins/TEMPLATE.md
+++ b/docs/security-bulletins/TEMPLATE.md
@@ -1,0 +1,33 @@
+# SINT Security Bulletin — `[Month Year]`
+
+Published: `[YYYY-MM-DD]`
+Scope: Protocol, runtime enforcement, and integration hardening updates.
+
+## Highlights
+
+- `[item]`
+- `[item]`
+- `[item]`
+
+## Security-Relevant Changes
+
+- `[item]`
+- `[item]`
+
+## Recommended Operator Actions
+
+1. `[action]`
+2. `[action]`
+3. `[action]`
+
+## Validation Commands
+
+```bash
+pnpm run build
+pnpm run test
+```
+
+## Forward Look (`[Next Month Year]`)
+
+- `[item]`
+- `[item]`


### PR DESCRIPTION
## Summary
- add Discord community launch runbook (`docs/community/discord-launch-runbook.md`)
- add external contributor onboarding guide (`docs/community/external-contributor-onboarding.md`)
- add first-contribution issue template (`.github/ISSUE_TEMPLATE/first_contribution.yml`)
- publish April 2026 SINT security bulletin and reusable template
- add monthly GitHub Actions reminder workflow for bulletin publication
- update docs navigation/README and restore active roadmap index file

## Validation
- `pnpm run docs:build`
- `pnpm run build`

Closes #59
Related to #57
Related to #58
