### PR TITLE
feat(a2a): skill-bound capability conformance fixture + subject binding

### DIFF
--- a/packages/conformance-tests/fixtures/industrial/a2a-skill-capability-enforcement.v1.json
+++ b/packages/conformance-tests/fixtures/industrial/a2a-skill-capability-enforcement.v1.json
@@ -1,0 +1,114 @@
+{
+  "fixtureId": "a2a-skill-capability-enforcement-v1",
+  "schemaVersion": "2026-04-06",
+  "description": "Canonical A2A fixture for skill-bound capability enforcement and deterministic evidence behavior.",
+  "agentCard": {
+    "url": "https://agents.example.com/fleet-manager",
+    "name": "Fleet Manager",
+    "version": "1.0.0",
+    "skills": [
+      { "id": "navigate", "name": "Navigate", "tags": ["physical", "movement"] },
+      { "id": "report", "name": "Report", "tags": ["read-only"] }
+    ]
+  },
+  "tokens": {
+    "reportOnly": {
+      "resource": "a2a://agents.example.com/report",
+      "actions": ["a2a.send"]
+    },
+    "navigate": {
+      "resource": "a2a://agents.example.com/navigate",
+      "actions": ["a2a.send"]
+    }
+  },
+  "cases": [
+    {
+      "name": "read-only report skill forwards and emits policy evidence",
+      "tokenRef": "reportOnly",
+      "agentRef": "primary",
+      "request": {
+        "id": "task-report-001",
+        "skillId": "report",
+        "message": {
+          "role": "user",
+          "parts": [{ "type": "text", "text": "Generate warehouse status report" }]
+        }
+      },
+      "expected": {
+        "interceptAction": "forward",
+        "assignedTier": "T0_observe",
+        "expectedEvidenceEvent": "policy.evaluated"
+      }
+    },
+    {
+      "name": "navigate request with report-only token fails closed on scope mismatch",
+      "tokenRef": "reportOnly",
+      "agentRef": "primary",
+      "request": {
+        "id": "task-nav-001",
+        "skillId": "navigate",
+        "message": {
+          "role": "user",
+          "parts": [{ "type": "text", "text": "Navigate robot to aisle B-12" }]
+        }
+      },
+      "expected": {
+        "interceptAction": "deny",
+        "policyViolated": "INSUFFICIENT_PERMISSIONS"
+      }
+    },
+    {
+      "name": "navigate request with matching token escalates at T2 and emits policy evidence",
+      "tokenRef": "navigate",
+      "agentRef": "primary",
+      "request": {
+        "id": "task-nav-002",
+        "skillId": "navigate",
+        "message": {
+          "role": "user",
+          "parts": [{ "type": "text", "text": "Navigate robot to aisle C-03" }]
+        }
+      },
+      "expected": {
+        "interceptAction": "escalate",
+        "assignedTier": "T2_act",
+        "expectedEvidenceEvent": "policy.evaluated"
+      }
+    },
+    {
+      "name": "revoked navigate token is denied before task forwarding",
+      "tokenRef": "navigate",
+      "agentRef": "primary",
+      "preRevoked": true,
+      "request": {
+        "id": "task-nav-003",
+        "skillId": "navigate",
+        "message": {
+          "role": "user",
+          "parts": [{ "type": "text", "text": "Navigate robot to aisle D-01" }]
+        }
+      },
+      "expected": {
+        "interceptAction": "deny",
+        "policyViolated": "TOKEN_REVOKED"
+      }
+    },
+    {
+      "name": "subject mismatch denies cross-agent token replay",
+      "tokenRef": "reportOnly",
+      "agentRef": "secondary",
+      "request": {
+        "id": "task-report-rogue-001",
+        "skillId": "report",
+        "message": {
+          "role": "user",
+          "parts": [{ "type": "text", "text": "Generate secure report" }]
+        }
+      },
+      "expected": {
+        "interceptAction": "deny",
+        "policyViolated": "TOKEN_SUBJECT_MISMATCH"
+      }
+    }
+  ]
+}

--- a/packages/conformance-tests/package.json
+++ b/packages/conformance-tests/package.json
@@ -7,7 +7,7 @@
     "build": "echo 'no build needed'",
     "test": "vitest run",
     "test:watch": "vitest watch",
-    "test:fixtures": "vitest run src/canonical-fixtures-conformance.test.ts src/security-iot-fixtures-conformance.test.ts src/economy-fixtures-conformance.test.ts src/autogen-interop-conformance.test.ts src/agentskill-authz-fixtures-conformance.test.ts src/action-ref-explainability-conformance.test.ts src/payment-governance-fixtures-conformance.test.ts",
+    "test:fixtures": "vitest run src/canonical-fixtures-conformance.test.ts src/a2a-fixtures-conformance.test.ts src/security-iot-fixtures-conformance.test.ts src/economy-fixtures-conformance.test.ts src/autogen-interop-conformance.test.ts src/agentskill-authz-fixtures-conformance.test.ts src/action-ref-explainability-conformance.test.ts src/payment-governance-fixtures-conformance.test.ts",
     "test:ros2-loop": "vitest run src/ros2-control-loop-latency.test.ts"
   },
   "devDependencies": {

--- a/packages/conformance-tests/src/a2a-fixtures-conformance.test.ts
+++ b/packages/conformance-tests/src/a2a-fixtures-conformance.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Canonical A2A fixture conformance checks.
+ *
+ * Ensures A2A skill-bound capability enforcement remains deterministic for:
+ * - skill scope matching
+ * - tiered escalation
+ * - token revocation fail-closed behavior
+ * - token subject/agent identity binding
+ */
+
+import { describe, expect, it } from "vitest";
+import type {
+  ApprovalTier,
+  SintCapabilityToken,
+  SintCapabilityTokenRequest,
+} from "@sint/core";
+import {
+  generateKeypair,
+  issueCapabilityToken,
+  RevocationStore,
+} from "@sint/gate-capability-tokens";
+import { PolicyGateway } from "@sint/gate-policy-gateway";
+import {
+  A2AInterceptor,
+  type A2AAgentCard,
+  type A2ASendTaskParams,
+} from "@sint/bridge-a2a";
+import { loadA2ASkillCapabilityEnforcementFixture } from "./fixture-loader.js";
+
+function futureISO(hoursFromNow: number): string {
+  const d = new Date(Date.now() + hoursFromNow * 3_600_000);
+  return d.toISOString().replace(/\.(\d{3})Z$/, ".$1000Z");
+}
+
+const fixture = loadA2ASkillCapabilityEnforcementFixture();
+const root = generateKeypair();
+const primaryAgent = generateKeypair();
+const secondaryAgent = generateKeypair();
+
+function issueToken(
+  request: Omit<SintCapabilityTokenRequest, "issuer" | "subject" | "delegationChain" | "expiresAt" | "revocable">,
+): SintCapabilityToken {
+  const issued = issueCapabilityToken(
+    {
+      issuer: root.publicKey,
+      subject: primaryAgent.publicKey,
+      delegationChain: { parentTokenId: null, depth: 0, attenuated: false },
+      expiresAt: futureISO(6),
+      revocable: true,
+      ...request,
+    },
+    root.privateKey,
+  );
+  if (!issued.ok) {
+    throw new Error(`Token issuance failed: ${issued.error}`);
+  }
+  return issued.value;
+}
+
+function createHarness() {
+  const revocationStore = new RevocationStore();
+  const events: Array<{ eventType: string; payload: Record<string, unknown> }> = [];
+  const tokenStore = new Map<string, SintCapabilityToken>();
+  const namedTokens = new Map<string, SintCapabilityToken>();
+
+  for (const [name, tokenTemplate] of Object.entries(fixture.tokens)) {
+    const token = issueToken({
+      resource: tokenTemplate.resource,
+      actions: [...tokenTemplate.actions],
+      constraints: {},
+    });
+    tokenStore.set(token.tokenId, token);
+    namedTokens.set(name, token);
+  }
+
+  const gateway = new PolicyGateway({
+    resolveToken: (tokenId) => tokenStore.get(tokenId),
+    revocationStore,
+    emitLedgerEvent: (event) => {
+      events.push({ eventType: event.eventType, payload: event.payload });
+    },
+  });
+
+  return { gateway, revocationStore, events, namedTokens };
+}
+
+describe("A2A Fixture Conformance", () => {
+  for (const scenario of fixture.cases) {
+    it(scenario.name, async () => {
+      const { gateway, revocationStore, events, namedTokens } = createHarness();
+      const token = namedTokens.get(scenario.tokenRef);
+      if (!token) {
+        throw new Error(`Fixture tokenRef missing: ${scenario.tokenRef}`);
+      }
+
+      if (scenario.preRevoked) {
+        revocationStore.revoke(token.tokenId, "fixture revocation", "conformance");
+      }
+
+      const agentId = scenario.agentRef === "primary"
+        ? primaryAgent.publicKey
+        : secondaryAgent.publicKey;
+
+      const interceptor = new A2AInterceptor(gateway, agentId, token.tokenId, {
+        agentCard: fixture.agentCard as A2AAgentCard,
+      });
+
+      const result = await interceptor.interceptSend(scenario.request as A2ASendTaskParams);
+      expect(result.action).toBe(scenario.expected.interceptAction);
+
+      if (scenario.expected.assignedTier) {
+        const sintMeta = result.task.metadata?.["sint"] as { assignedTier?: ApprovalTier } | undefined;
+        expect(sintMeta?.assignedTier).toBe(scenario.expected.assignedTier);
+      }
+
+      if (scenario.expected.policyViolated) {
+        expect(result.action).toBe("deny");
+        if (result.action === "deny") {
+          expect(result.policyViolated).toBe(scenario.expected.policyViolated);
+        }
+      }
+
+      if (scenario.expected.expectedEvidenceEvent) {
+        const emitted = events.some((event) => event.eventType === scenario.expected.expectedEvidenceEvent);
+        expect(emitted).toBe(true);
+      }
+    });
+  }
+});
+

--- a/packages/conformance-tests/src/fixture-loader.ts
+++ b/packages/conformance-tests/src/fixture-loader.ts
@@ -107,6 +107,48 @@ export interface HardwareSafetyHandshakeFixture {
   }>;
 }
 
+export interface A2ASkillCapabilityEnforcementFixture {
+  readonly fixtureId: string;
+  readonly schemaVersion: string;
+  readonly description: string;
+  readonly agentCard: {
+    readonly url: string;
+    readonly name: string;
+    readonly version: string;
+    readonly skills: readonly Array<{
+      readonly id: string;
+      readonly name: string;
+      readonly tags?: readonly string[];
+    }>;
+  };
+  readonly tokens: Record<string, TokenFixture>;
+  readonly cases: readonly Array<{
+    readonly name: string;
+    readonly tokenRef: string;
+    readonly agentRef: "primary" | "secondary";
+    readonly preRevoked?: boolean;
+    readonly request: {
+      readonly id: string;
+      readonly sessionId?: string;
+      readonly skillId?: string;
+      readonly message: {
+        readonly role: "user" | "agent";
+        readonly parts: readonly Array<
+          | { readonly type: "text"; readonly text: string }
+          | { readonly type: "data"; readonly data: Record<string, unknown> }
+        >;
+      };
+      readonly metadata?: Record<string, unknown>;
+    };
+    readonly expected: {
+      readonly interceptAction: "forward" | "deny" | "escalate";
+      readonly assignedTier?: ApprovalTier;
+      readonly policyViolated?: string;
+      readonly expectedEvidenceEvent?: string;
+    };
+  }>;
+}
+
 export interface WellKnownDiscoveryFixture {
   readonly name: string;
   readonly version: string;
@@ -472,6 +514,12 @@ export function loadOpcUaSafetyControlFixture(): OpcUaSafetyControlFixture {
 export function loadHardwareSafetyHandshakeFixture(): HardwareSafetyHandshakeFixture {
   return loadFixture<HardwareSafetyHandshakeFixture>(
     "industrial/hardware-safety-handshake.v1.json",
+  );
+}
+
+export function loadA2ASkillCapabilityEnforcementFixture(): A2ASkillCapabilityEnforcementFixture {
+  return loadFixture<A2ASkillCapabilityEnforcementFixture>(
+    "industrial/a2a-skill-capability-enforcement.v1.json",
   );
 }
 

--- a/packages/policy-gateway/__tests__/gateway.test.ts
+++ b/packages/policy-gateway/__tests__/gateway.test.ts
@@ -196,6 +196,21 @@ describe("PolicyGateway", () => {
     expect(decision.denial?.policyViolated).toBe("TOKEN_REVOKED");
   });
 
+  it("denies request when token subject does not match agent identity", async () => {
+    const token = issueAndStore();
+    const otherAgent = generateKeypair();
+
+    const decision = await gateway.intercept(
+      makeRequest({
+        agentId: otherAgent.publicKey,
+        tokenId: token.tokenId,
+      }),
+    );
+
+    expect(decision.action).toBe("deny");
+    expect(decision.denial?.policyViolated).toBe("TOKEN_SUBJECT_MISMATCH");
+  });
+
   // ── Wrong resource → deny ──
 
   it("denies request for unauthorized resource", async () => {

--- a/packages/policy-gateway/src/gateway.ts
+++ b/packages/policy-gateway/src/gateway.ts
@@ -375,6 +375,17 @@ export class PolicyGateway {
       return this.deny(requestId, timestamp, "TOKEN_NOT_FOUND", "Capability token not found");
     }
 
+    // 2a. Bind token subject to the requesting agent identity.
+    // Prevents cross-agent token replay when a valid token ID is leaked.
+    if (token.subject !== request.agentId) {
+      return this.deny(
+        requestId,
+        timestamp,
+        "TOKEN_SUBJECT_MISMATCH",
+        "Capability token subject does not match requesting agent identity",
+      );
+    }
+
     // 3. Check revocation status
     if (this.config.revocationStore) {
       const revocationResult = this.config.revocationStore.checkRevocation(token.tokenId);


### PR DESCRIPTION
## Summary
- add canonical A2A fixture `a2a-skill-capability-enforcement.v1.json` for skill-scope, tier, revocation, and subject-binding behavior
- add fixture-driven conformance test `a2a-fixtures-conformance.test.ts` and include it in `test:fixtures`
- harden gateway by enforcing token subject == requesting agent identity (`TOKEN_SUBJECT_MISMATCH`)
- add gateway unit test for cross-agent token replay denial

## Why
This implements Issue #104 by making A2A capability checks executable and deterministic at invocation boundaries while preserving evidence semantics.

## Validation
- `pnpm --filter @sint/gate-policy-gateway test`
- `pnpm --filter @sint/gate-policy-gateway build`
- `pnpm --filter @sint/conformance-tests test -- src/a2a-fixtures-conformance.test.ts`
- `pnpm --filter @sint/conformance-tests test:fixtures`

Closes #104
