### PR TITLE
feat(python-sdk): OpenAI Agents governance adapter + fail-closed integration guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -73,6 +73,7 @@ export default defineConfig({
           { text: "Warehouse AMR Policy Template", link: "/profiles/warehouse-amr.policy.template" },
           { text: "Industrial Cell Policy Template", link: "/profiles/industrial-cell.policy.template" },
           { text: "Edge Gateway Policy Template", link: "/profiles/edge-gateway.policy.template" },
+          { text: "OpenAI Agents Fail-Closed Template", link: "/profiles/openai-agents-fail-closed.policy.template" },
         ],
       },
       {

--- a/docs/guides/openai-agents-sdk-integration.md
+++ b/docs/guides/openai-agents-sdk-integration.md
@@ -1,0 +1,83 @@
+# OpenAI Agents SDK Governance Integration
+
+This guide shows how to connect OpenAI Agents SDK tool execution to SINT runtime governance.
+
+## What this adds
+
+- pre-tool-call authorization via `POST /v1/intercept`
+- typed runtime outcomes for agents code:
+  - `SintDeniedError`
+  - `SintApprovalRequiredError`
+  - `SintApprovalTimeoutError`
+  - `SintApprovalDeniedError`
+- suspend/resume approval handling for T2/T3 actions
+- request-scoped evidence retrieval for audits
+
+## Install
+
+```bash
+cd sdks/python
+pip install -e ".[dev]"
+```
+
+## Minimal adapter usage
+
+```python
+from sint import (
+    GatewayClient,
+    GatewayConfig,
+    OpenAIAgentsGovernanceAdapter,
+    SintRequest,
+    ApprovalResolution,
+)
+
+client = GatewayClient(GatewayConfig(base_url="http://localhost:3100", token="dev-local-key"))
+adapter = OpenAIAgentsGovernanceAdapter(client)
+```
+
+Use the adapter in your tool wrapper:
+
+```python
+decision = await adapter.authorize_tool_call(
+    request,
+    on_escalation=resolver,      # optional async callback for human approval
+    approval_timeout_s=30.0,     # fail-closed timeout path
+)
+```
+
+## Fail-closed default policy template
+
+Use `docs/profiles/openai-agents-fail-closed.policy.template.json` as a starting profile.
+
+Key guardrails:
+
+- irreversible tools -> `T3_commit` + explicit human approval
+- physical-state changes -> `T2_act` + escalation
+- timeouts resolve to deny (never fail-open)
+- token subject bound to runtime agent identity
+
+## End-to-end example
+
+See `sdks/python/examples/openai_agents_governance_flow.py`.
+
+Flow:
+
+1. create `SintRequest`
+2. intercept with `OpenAIAgentsGovernanceAdapter`
+3. resolve escalation via callback or external operator
+4. execute tool only after permit
+5. query evidence events for request ID
+
+## Migration notes
+
+- Existing OpenAI Agents tool functions can adopt SINT by wrapping execution with `authorize_tool_call`.
+- Do not mutate existing tool signatures first; add a central wrapper and migrate tool-by-tool.
+- Keep fallback behavior deny-by-default until each tool has explicit tier/resource mapping.
+- Rollback path: disable wrapper for a single tool while leaving SINT enabled for others.
+
+## Troubleshooting
+
+- `TOKEN_NOT_FOUND`: token ID is unknown to gateway token store.
+- `TOKEN_SUBJECT_MISMATCH`: token subject differs from request `agentId`.
+- `INSUFFICIENT_PERMISSIONS`: resource/action mismatch with token scope.
+- `Stale approval request` on resolve: token revoked/expired or approval request timed out.

--- a/docs/profiles/openai-agents-fail-closed.policy.template.json
+++ b/docs/profiles/openai-agents-fail-closed.policy.template.json
@@ -1,0 +1,66 @@
+{
+  "version": "1.0.0",
+  "name": "openai-agents-fail-closed",
+  "description": "Fail-closed starter policy profile for OpenAI Agents SDK tool governance with SINT.",
+  "defaults": {
+    "fallbackAction": "deny",
+    "approvalTimeoutMs": 30000,
+    "staleApprovalAction": "deny"
+  },
+  "rules": [
+    {
+      "resourcePattern": "mcp://*/read*",
+      "actions": ["call"],
+      "baseTier": "T0_observe",
+      "baseRisk": "T0_read"
+    },
+    {
+      "resourcePattern": "mcp://*/list*",
+      "actions": ["call"],
+      "baseTier": "T0_observe",
+      "baseRisk": "T0_read"
+    },
+    {
+      "resourcePattern": "mcp://*/write*",
+      "actions": ["call"],
+      "baseTier": "T1_prepare",
+      "baseRisk": "T1_write_low"
+    },
+    {
+      "resourcePattern": "mcp://*/update*",
+      "actions": ["call"],
+      "baseTier": "T1_prepare",
+      "baseRisk": "T1_write_low"
+    },
+    {
+      "resourcePattern": "mcp://*/move*",
+      "actions": ["call"],
+      "baseTier": "T2_act",
+      "baseRisk": "T2_stateful",
+      "escalateOnHumanPresence": true
+    },
+    {
+      "resourcePattern": "mcp://*/dispatch*",
+      "actions": ["call"],
+      "baseTier": "T2_act",
+      "baseRisk": "T2_stateful"
+    },
+    {
+      "resourcePattern": "mcp://*/delete*",
+      "actions": ["call"],
+      "baseTier": "T3_commit",
+      "baseRisk": "T3_irreversible"
+    },
+    {
+      "resourcePattern": "mcp://*/execute*",
+      "actions": ["call"],
+      "baseTier": "T3_commit",
+      "baseRisk": "T3_irreversible"
+    }
+  ],
+  "invariants": [
+    "No T2/T3 action can execute without explicit approval resolution",
+    "Approval timeout must resolve to denied",
+    "Token subject must equal request agent identity"
+  ]
+}

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -91,6 +91,36 @@ async with GatewayClient(config) as client:
     print(token["tokenId"])
 ```
 
+### OpenAI Agents SDK Governance Adapter
+
+`OpenAIAgentsGovernanceAdapter` wraps tool calls with SINT runtime checks.
+
+```python
+from sint import (
+    GatewayClient, GatewayConfig, OpenAIAgentsGovernanceAdapter,
+    ApprovalResolution, SintRequest
+)
+
+async with GatewayClient(GatewayConfig(base_url="http://localhost:3100")) as client:
+    adapter = OpenAIAgentsGovernanceAdapter(client)
+
+    async def resolver(request: SintRequest, decision):
+        # Hook this into your operator UI / pager workflow.
+        return ApprovalResolution(status="approved", by="operator@example.com")
+
+    decision = await adapter.authorize_tool_call(
+        request=my_request,
+        on_escalation=resolver,   # optional
+        approval_timeout_s=30.0,  # fail-closed timeout
+    )
+```
+
+Typed outcomes:
+- `SintDeniedError`
+- `SintApprovalRequiredError`
+- `SintApprovalTimeoutError`
+- `SintApprovalDeniedError`
+
 ### sint-scan CLI
 
 Classify MCP tools into SINT approval tiers (mirrors `@sint/bridge-mcp` logic):
@@ -181,3 +211,4 @@ pytest tests/ -v
 ## Examples
 
 - Warehouse AMR flow: [`examples/warehouse_amr_flow.py`](examples/warehouse_amr_flow.py)
+- OpenAI Agents governance flow: [`examples/openai_agents_governance_flow.py`](examples/openai_agents_governance_flow.py)

--- a/sdks/python/examples/openai_agents_governance_flow.py
+++ b/sdks/python/examples/openai_agents_governance_flow.py
@@ -1,0 +1,97 @@
+"""
+OpenAI Agents SDK + SINT governance flow example.
+
+Demonstrates:
+1) pre-tool-call authorization
+2) escalation suspend/resume via approval resolver
+3) evidence lookup for the request
+
+Run:
+  python examples/openai_agents_governance_flow.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+from sint import (
+    ApprovalResolution,
+    GatewayClient,
+    GatewayConfig,
+    OpenAIAgentsGovernanceAdapter,
+    SintApprovalDeniedError,
+    SintApprovalRequiredError,
+    SintApprovalTimeoutError,
+    SintDeniedError,
+    SintRequest,
+)
+
+
+async def main() -> None:
+    # Assumes local gateway-server running (see repo compose stacks).
+    config = GatewayConfig(
+        base_url="http://localhost:3100",
+        token="dev-local-key",
+        timeout=10,
+        max_retries=2,
+        retry_backoff_ms=150,
+    )
+
+    async with GatewayClient(config) as client:
+        adapter = OpenAIAgentsGovernanceAdapter(client)
+
+        request = SintRequest(
+            request_id="01905f7c-4e8a-7b3d-9a1e-f2c3d4e5f7a1",
+            timestamp=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "000Z",
+            agent_id="openai-agents-worker",
+            token_id="replace-with-valid-token-id",
+            resource="mcp://warehouse/moveRobot",
+            action="call",
+            params={"robotId": "amr-17", "destination": "A-12"},
+            execution_context={
+                "deploymentProfile": "warehouse-amr",
+                "bridgeProtocol": "a2a",
+                "siteId": "warehouse-west",
+            },
+        )
+
+        async def operator_resolver(_req: SintRequest, decision):
+            # Plug your human-in-the-loop workflow here (UI, pager, ticket, etc).
+            if decision.assigned_tier.value in ("T2_act", "T3_commit"):
+                return ApprovalResolution(
+                    status="approved",
+                    by="operator@warehouse-west",
+                    reason="Shift lead approved dispatch",
+                )
+            return ApprovalResolution(status="approved", by="system")
+
+        try:
+            decision = await adapter.authorize_tool_call(
+                request,
+                on_escalation=operator_resolver,
+                approval_timeout_s=30.0,
+            )
+            print("governance decision:", decision.action, "tier=", decision.assigned_tier.value)
+
+            # Tool execution would run here in a real OpenAI Agents tool function.
+            print("tool execution permitted -> execute downstream action")
+
+            evidence = await adapter.evidence_for_request(request.request_id, limit=200)
+            print("evidence events for request:", len(evidence))
+            for evt in evidence[:5]:
+                print(" -", evt.event_type, evt.event_id)
+
+        except SintDeniedError as e:
+            print("DENIED:", e.policy_violated, e.reason)
+        except SintApprovalRequiredError as e:
+            print("ESCALATED:", e.required_tier.value, "request_id=", e.approval_request_id)
+        except SintApprovalTimeoutError as e:
+            print("TIMEOUT:", e.approval_request_id, "after", e.timeout_s, "seconds")
+        except SintApprovalDeniedError as e:
+            print("APPROVAL DENIED:", e.approval_request_id, e.reason)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+

--- a/sdks/python/sint/__init__.py
+++ b/sdks/python/sint/__init__.py
@@ -15,6 +15,15 @@ from .types import (
 from .client import GatewayClient
 from .tokens import CapabilityTokenRequest, build_token_request
 from .scanner import scan_tool, scan_server, ToolScanResult, ServerScanReport
+from .openai_agents import (
+    ApprovalResolution,
+    OpenAIAgentsGovernanceAdapter,
+    SintApprovalDeniedError,
+    SintApprovalRequiredError,
+    SintApprovalTimeoutError,
+    SintDeniedError,
+    SintGovernanceError,
+)
 
 __version__ = "0.1.0"
 
@@ -36,4 +45,12 @@ __all__ = [
     "scan_server",
     "ToolScanResult",
     "ServerScanReport",
+    # openai agents adapter
+    "OpenAIAgentsGovernanceAdapter",
+    "ApprovalResolution",
+    "SintGovernanceError",
+    "SintDeniedError",
+    "SintApprovalRequiredError",
+    "SintApprovalTimeoutError",
+    "SintApprovalDeniedError",
 ]

--- a/sdks/python/sint/openai_agents.py
+++ b/sdks/python/sint/openai_agents.py
@@ -1,0 +1,223 @@
+"""
+SINT Protocol — OpenAI Agents SDK governance adapter.
+
+Provides a thin runtime governance layer for OpenAI Agents SDK tool calls:
+- pre-tool authorization via SINT gateway intercept
+- typed error mapping (deny / escalate / timeout)
+- suspend/resume approval helpers
+- request-scoped evidence lookup convenience
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Protocol
+
+from .client import GatewayClient
+from .types import LedgerEvent, PolicyDecision, SintRequest
+
+
+class SintGovernanceError(Exception):
+    """Base exception for SINT OpenAI Agents governance adapter failures."""
+
+
+class SintDeniedError(SintGovernanceError):
+    """Raised when the gateway denies a request."""
+
+    def __init__(self, decision: PolicyDecision) -> None:
+        reason = decision.denial.reason if decision.denial else "Denied by policy"
+        policy = decision.denial.policy_violated if decision.denial else "POLICY_DENY"
+        super().__init__(f"SINT denied request: {policy} — {reason}")
+        self.decision = decision
+        self.reason = reason
+        self.policy_violated = policy
+
+
+class SintApprovalRequiredError(SintGovernanceError):
+    """Raised when a request requires T2/T3 approval and no resolver is provided."""
+
+    def __init__(self, decision: PolicyDecision, request: SintRequest) -> None:
+        reason = decision.escalation.reason if decision.escalation else "Approval required"
+        super().__init__(f"SINT escalation required: {reason}")
+        self.decision = decision
+        self.request = request
+        self.reason = reason
+        self.approval_request_id = decision.approval_request_id
+        self.required_tier = decision.escalation.required_tier if decision.escalation else decision.assigned_tier
+        self.timeout_ms = decision.escalation.timeout_ms if decision.escalation else None
+
+
+class SintApprovalTimeoutError(SintGovernanceError):
+    """Raised when an escalation is not resolved within configured timeout."""
+
+    def __init__(self, approval_request_id: str | None, timeout_s: float) -> None:
+        req = approval_request_id or "<unknown>"
+        super().__init__(f"SINT approval timed out (request={req}, timeout_s={timeout_s})")
+        self.approval_request_id = approval_request_id
+        self.timeout_s = timeout_s
+
+
+class SintApprovalDeniedError(SintGovernanceError):
+    """Raised when an approval resolver explicitly denies the request."""
+
+    def __init__(self, approval_request_id: str | None, reason: str | None = None) -> None:
+        req = approval_request_id or "<unknown>"
+        suffix = f": {reason}" if reason else ""
+        super().__init__(f"SINT approval denied (request={req}){suffix}")
+        self.approval_request_id = approval_request_id
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class ApprovalResolution:
+    """Resolution payload for a suspended approval."""
+
+    status: str  # "approved" | "denied"
+    by: str
+    reason: str | None = None
+
+
+class ApprovalResolver(Protocol):
+    """Callback contract for escalation handling."""
+
+    async def __call__(
+        self,
+        request: SintRequest,
+        decision: PolicyDecision,
+    ) -> ApprovalResolution | None:
+        ...
+
+
+class OpenAIAgentsGovernanceAdapter:
+    """
+    Runtime governance adapter for OpenAI Agents SDK tool calls.
+
+    This class is transport-agnostic and can be used with any tool execution
+    runtime that constructs a `SintRequest` per call.
+    """
+
+    def __init__(self, client: GatewayClient) -> None:
+        self._client = client
+
+    async def authorize_tool_call(
+        self,
+        request: SintRequest,
+        *,
+        on_escalation: ApprovalResolver | None = None,
+        approval_timeout_s: float | None = None,
+        fail_closed_reviewer: str = "openai-agents/fail-closed",
+    ) -> PolicyDecision:
+        """
+        Authorize a tool call through SINT and resolve escalations when possible.
+
+        Behavior:
+        - allow/transform => returns PolicyDecision
+        - deny => raises SintDeniedError
+        - escalate:
+          - with resolver => resolve approval and return decision on approved
+          - without resolver => raise SintApprovalRequiredError
+          - with timeout => fail-closed denial on timeout + raise SintApprovalTimeoutError
+        """
+        decision = await self._client.intercept(request)
+
+        if decision.action in ("allow", "transform"):
+            return decision
+        if decision.action == "deny":
+            raise SintDeniedError(decision)
+
+        # decision.action == "escalate"
+        if on_escalation is None:
+            if approval_timeout_s is not None:
+                await asyncio.sleep(max(0.0, approval_timeout_s))
+                if decision.approval_request_id:
+                    # Fail closed by explicitly denying stale pending approvals.
+                    await self._client.resolve_approval(
+                        request_id=decision.approval_request_id,
+                        status="denied",
+                        by=fail_closed_reviewer,
+                        reason="Fail-closed timeout: approval not resolved in time",
+                    )
+                raise SintApprovalTimeoutError(decision.approval_request_id, approval_timeout_s)
+            raise SintApprovalRequiredError(decision, request)
+
+        resolution = await on_escalation(request, decision)
+        if resolution is None:
+            # Resolver intentionally suspended and did not provide a decision.
+            timeout_s = approval_timeout_s if approval_timeout_s is not None else 0.0
+            if approval_timeout_s is not None:
+                await asyncio.sleep(max(0.0, approval_timeout_s))
+                if decision.approval_request_id:
+                    await self._client.resolve_approval(
+                        request_id=decision.approval_request_id,
+                        status="denied",
+                        by=fail_closed_reviewer,
+                        reason="Fail-closed timeout after unresolved escalation callback",
+                    )
+            raise SintApprovalTimeoutError(decision.approval_request_id, timeout_s)
+
+        if not decision.approval_request_id:
+            raise SintApprovalRequiredError(decision, request)
+
+        if resolution.status not in ("approved", "denied"):
+            raise ValueError("ApprovalResolution.status must be 'approved' or 'denied'")
+
+        await self._client.resolve_approval(
+            request_id=decision.approval_request_id,
+            status=resolution.status,
+            by=resolution.by,
+            reason=resolution.reason,
+        )
+        if resolution.status != "approved":
+            raise SintApprovalDeniedError(decision.approval_request_id, resolution.reason)
+
+        return decision
+
+    async def resume_approved(
+        self,
+        approval_request_id: str,
+        *,
+        by: str,
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        """Resume a suspended workflow by approving a known approval request ID."""
+        return await self._client.resolve_approval(
+            request_id=approval_request_id,
+            status="approved",
+            by=by,
+            reason=reason,
+        )
+
+    async def resume_denied(
+        self,
+        approval_request_id: str,
+        *,
+        by: str,
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        """Resume a suspended workflow by denying a known approval request ID."""
+        return await self._client.resolve_approval(
+            request_id=approval_request_id,
+            status="denied",
+            by=by,
+            reason=reason,
+        )
+
+    async def evidence_for_request(self, request_id: str, limit: int = 200) -> list[LedgerEvent]:
+        """
+        Retrieve ledger events related to a specific request ID.
+
+        Since `/v1/ledger` is generic, this helper performs payload-level filtering.
+        """
+        events = await self._client.get_ledger_events(limit=limit)
+        matches: list[LedgerEvent] = []
+        for event in events:
+            payload = event.payload
+            if payload.get("requestId") == request_id:
+                matches.append(event)
+                continue
+            resolution = payload.get("resolution")
+            if isinstance(resolution, dict) and resolution.get("requestId") == request_id:
+                matches.append(event)
+        return matches
+

--- a/sdks/python/sint/types.py
+++ b/sdks/python/sint/types.py
@@ -174,6 +174,7 @@ class PolicyDecision(BaseModel):
     action: str  # "allow" | "deny" | "escalate" | "transform"
     assigned_tier: ApprovalTier = Field(..., alias="assignedTier")
     assigned_risk: RiskTier = Field(..., alias="assignedRisk")
+    approval_request_id: str | None = Field(None, alias="approvalRequestId")
     denial: DenialInfo | None = None
     escalation: EscalationInfo | None = None
     transformations: dict[str, Any] | None = None

--- a/sdks/python/tests/test_openai_agents_adapter.py
+++ b/sdks/python/tests/test_openai_agents_adapter.py
@@ -1,0 +1,189 @@
+"""Tests for sint.openai_agents governance adapter."""
+
+from __future__ import annotations
+
+import pytest
+
+from sint.openai_agents import (
+    ApprovalResolution,
+    OpenAIAgentsGovernanceAdapter,
+    SintApprovalDeniedError,
+    SintApprovalRequiredError,
+    SintApprovalTimeoutError,
+    SintDeniedError,
+)
+from sint.types import LedgerEvent, PolicyDecision, SintRequest
+
+
+class _FakeGatewayClient:
+    def __init__(
+        self,
+        decision: PolicyDecision,
+        ledger_events: list[LedgerEvent] | None = None,
+    ) -> None:
+        self._decision = decision
+        self._ledger_events = ledger_events or []
+        self.resolve_calls: list[dict[str, str | None]] = []
+
+    async def intercept(self, request: SintRequest) -> PolicyDecision:  # noqa: ARG002
+        return self._decision
+
+    async def resolve_approval(
+        self,
+        request_id: str,
+        status: str,
+        by: str,
+        reason: str | None = None,
+    ) -> dict[str, str | None]:
+        call = {
+            "request_id": request_id,
+            "status": status,
+            "by": by,
+            "reason": reason,
+        }
+        self.resolve_calls.append(call)
+        return call
+
+    async def get_ledger_events(self, limit: int = 200) -> list[LedgerEvent]:  # noqa: ARG002
+        return self._ledger_events
+
+
+def _request() -> SintRequest:
+    return SintRequest.model_validate({
+        "requestId": "01905f7c-0000-7000-8000-000000000011",
+        "timestamp": "2026-04-06T12:00:00.000000Z",
+        "agentId": "a" * 64,
+        "tokenId": "01905f7c-0000-7000-8000-000000000012",
+        "resource": "mcp://filesystem/readFile",
+        "action": "call",
+        "params": {"path": "/tmp/demo.txt"},
+    })
+
+
+def _decision(action: str, *, with_approval_id: bool = False) -> PolicyDecision:
+    payload = {
+        "requestId": "01905f7c-0000-7000-8000-000000000011",
+        "timestamp": "2026-04-06T12:00:00.000000Z",
+        "action": action,
+        "assignedTier": "T2_act" if action == "escalate" else "T1_prepare",
+        "assignedRisk": "T2_stateful" if action == "escalate" else "T1_write_low",
+    }
+    if action == "deny":
+        payload["denial"] = {
+            "reason": "Policy denied",
+            "policyViolated": "INSUFFICIENT_PERMISSIONS",
+        }
+    if action == "escalate":
+        payload["escalation"] = {
+            "requiredTier": "T2_act",
+            "reason": "Human approval required",
+            "timeoutMs": 1000,
+            "fallbackAction": "deny",
+        }
+        if with_approval_id:
+            payload["approvalRequestId"] = "req-approve-001"
+    return PolicyDecision.model_validate(payload)
+
+
+@pytest.mark.asyncio
+async def test_authorize_allow_returns_decision() -> None:
+    client = _FakeGatewayClient(_decision("allow"))
+    adapter = OpenAIAgentsGovernanceAdapter(client)  # type: ignore[arg-type]
+    result = await adapter.authorize_tool_call(_request())
+    assert result.action == "allow"
+
+
+@pytest.mark.asyncio
+async def test_authorize_deny_raises_typed_error() -> None:
+    client = _FakeGatewayClient(_decision("deny"))
+    adapter = OpenAIAgentsGovernanceAdapter(client)  # type: ignore[arg-type]
+    with pytest.raises(SintDeniedError) as exc:
+        await adapter.authorize_tool_call(_request())
+    assert exc.value.policy_violated == "INSUFFICIENT_PERMISSIONS"
+
+
+@pytest.mark.asyncio
+async def test_escalation_without_resolver_raises_required() -> None:
+    client = _FakeGatewayClient(_decision("escalate", with_approval_id=True))
+    adapter = OpenAIAgentsGovernanceAdapter(client)  # type: ignore[arg-type]
+    with pytest.raises(SintApprovalRequiredError) as exc:
+        await adapter.authorize_tool_call(_request())
+    assert exc.value.approval_request_id == "req-approve-001"
+
+
+@pytest.mark.asyncio
+async def test_escalation_timeout_fail_closed_denies_queue() -> None:
+    client = _FakeGatewayClient(_decision("escalate", with_approval_id=True))
+    adapter = OpenAIAgentsGovernanceAdapter(client)  # type: ignore[arg-type]
+    with pytest.raises(SintApprovalTimeoutError):
+        await adapter.authorize_tool_call(_request(), approval_timeout_s=0.0)
+
+    assert client.resolve_calls[0]["request_id"] == "req-approve-001"
+    assert client.resolve_calls[0]["status"] == "denied"
+
+
+@pytest.mark.asyncio
+async def test_escalation_with_approved_resolution_returns_decision() -> None:
+    client = _FakeGatewayClient(_decision("escalate", with_approval_id=True))
+    adapter = OpenAIAgentsGovernanceAdapter(client)  # type: ignore[arg-type]
+
+    async def resolver(_req: SintRequest, _decision: PolicyDecision) -> ApprovalResolution:
+        return ApprovalResolution(status="approved", by="operator@example.com", reason="approved for demo")
+
+    decision = await adapter.authorize_tool_call(_request(), on_escalation=resolver)
+    assert decision.action == "escalate"
+    assert client.resolve_calls[0]["status"] == "approved"
+
+
+@pytest.mark.asyncio
+async def test_escalation_with_denied_resolution_raises_typed_error() -> None:
+    client = _FakeGatewayClient(_decision("escalate", with_approval_id=True))
+    adapter = OpenAIAgentsGovernanceAdapter(client)  # type: ignore[arg-type]
+
+    async def resolver(_req: SintRequest, _decision: PolicyDecision) -> ApprovalResolution:
+        return ApprovalResolution(status="denied", by="operator@example.com", reason="unsafe")
+
+    with pytest.raises(SintApprovalDeniedError):
+        await adapter.authorize_tool_call(_request(), on_escalation=resolver)
+    assert client.resolve_calls[0]["status"] == "denied"
+
+
+@pytest.mark.asyncio
+async def test_evidence_for_request_filters_by_payload_request_id() -> None:
+    events = [
+        LedgerEvent.model_validate({
+            "eventId": "e1",
+            "sequenceNumber": "1",
+            "timestamp": "2026-04-06T12:00:00.000000Z",
+            "eventType": "policy.evaluated",
+            "agentId": "a" * 64,
+            "payload": {"requestId": "target-1"},
+            "previousHash": "0" * 64,
+            "hash": "1" * 64,
+        }),
+        LedgerEvent.model_validate({
+            "eventId": "e2",
+            "sequenceNumber": "2",
+            "timestamp": "2026-04-06T12:00:01.000000Z",
+            "eventType": "approval.granted",
+            "agentId": "a" * 64,
+            "payload": {"resolution": {"requestId": "target-1", "status": "approved"}},
+            "previousHash": "1" * 64,
+            "hash": "2" * 64,
+        }),
+        LedgerEvent.model_validate({
+            "eventId": "e3",
+            "sequenceNumber": "3",
+            "timestamp": "2026-04-06T12:00:02.000000Z",
+            "eventType": "policy.evaluated",
+            "agentId": "a" * 64,
+            "payload": {"requestId": "other"},
+            "previousHash": "2" * 64,
+            "hash": "3" * 64,
+        }),
+    ]
+    client = _FakeGatewayClient(_decision("allow"), ledger_events=events)
+    adapter = OpenAIAgentsGovernanceAdapter(client)  # type: ignore[arg-type]
+    matched = await adapter.evidence_for_request("target-1")
+    assert [e.event_id for e in matched] == ["e1", "e2"]
+


### PR DESCRIPTION
## Summary
Implements Issue #105 by shipping a production-ready Python adapter for OpenAI Agents SDK runtime governance.

### Added
- `sint.openai_agents` adapter module with:
  - pre-tool authorization via gateway intercept
  - typed error mapping (`SintDeniedError`, `SintApprovalRequiredError`, `SintApprovalTimeoutError`, `SintApprovalDeniedError`)
  - suspend/resume approval helpers (`resume_approved`, `resume_denied`)
  - request-scoped evidence lookup helper (`evidence_for_request`)
- `PolicyDecision.approval_request_id` field in Python types to capture gateway escalation IDs
- runnable example: `sdks/python/examples/openai_agents_governance_flow.py`
- new SDK tests: `sdks/python/tests/test_openai_agents_adapter.py`
- fail-closed profile template: `docs/profiles/openai-agents-fail-closed.policy.template.json`
- migration/integration guide: `docs/guides/openai-agents-sdk-integration.md`
- docs discoverability updates in root README, VitePress sidebar, and Python SDK README

## Acceptance Criteria Mapping
- Demo flow (token -> intercept -> approval -> ledger): covered by adapter + runnable example
- Typed error mapping: implemented and tested
- Docs/troubleshooting/rollback: added in integration guide

## Validation
- `python3 -m compileall sdks/python/sint sdks/python/tests sdks/python/examples`
- `pnpm run docs:build`

Note: `pytest` runtime is not installed in this environment (`python3 -m pytest` unavailable), so tests are added but not executed locally in this run.

Closes #105
