### PR TITLE
feat(sintctl): standalone conformance certification command

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ docker-compose up
 - Examples: [`examples/`](examples/) (hello-world, warehouse-amr, industrial-cell)
 - Multi-language SDKs: [`sdks/`](sdks/) (TypeScript, Python, Go)
 - Operator CLI: [`apps/sintctl/README.md`](apps/sintctl/README.md)
+- Standalone certification tool guide: [`docs/guides/standalone-certification-tool.md`](docs/guides/standalone-certification-tool.md)
 - Persistence baseline guide: [`docs/guides/persistence-baseline.md`](docs/guides/persistence-baseline.md)
 - WebSocket approvals guide: [`docs/guides/websocket-approvals.md`](docs/guides/websocket-approvals.md)
 - API docs site guide: [`docs/guides/api-documentation-site.md`](docs/guides/api-documentation-site.md)

--- a/apps/sintctl/README.md
+++ b/apps/sintctl/README.md
@@ -6,6 +6,7 @@ Operator CLI for SINT gateway workflows:
 - approval queue list/resolve
 - ledger querying
 - intercept policy test requests
+- standalone conformance certification runs
 
 ## Usage
 
@@ -37,9 +38,27 @@ sintctl approvals resolve --request-id <id> --status approved --by operator@ware
 
 # 5) Query ledger
 sintctl ledger query --agent-id <agent-public-key> --limit 20
+
+# 6) Run standalone certification fixture suite
+sintctl certify run --output docs/reports/standalone-conformance-certification.json
 ```
 
 ## Global Options
 
 - `--gateway`: defaults to `http://localhost:3100`
 - `--api-key`: optional x-api-key header
+
+## Standalone Certification Tool
+
+`sintctl certify run` executes the canonical conformance fixture suite:
+
+```bash
+pnpm --filter @sint/sintctl build
+node apps/sintctl/dist/cli.js certify run
+```
+
+By default it writes a machine-readable summary artifact to:
+
+- `docs/reports/standalone-conformance-certification.json`
+
+Override output path with `--output <path>`.

--- a/apps/sintctl/__tests__/certification.test.ts
+++ b/apps/sintctl/__tests__/certification.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCertificationSummary,
+  defaultCertificationOutputPath,
+} from "../src/certification.js";
+
+describe("certification summary helpers", () => {
+  it("builds pass summary when exit code is 0", () => {
+    const summary = buildCertificationSummary({
+      outputPath: "/tmp/report.json",
+      exitCode: 0,
+      command: ["pnpm", "--filter", "@sint/conformance-tests", "test:fixtures"],
+      gatewayUrl: "http://localhost:3100",
+    });
+
+    expect(summary.success).toBe(true);
+    expect(summary.evidence.status).toBe("passed");
+    expect(summary.fixtureTestCommand).toBe(
+      "pnpm --filter @sint/conformance-tests test:fixtures",
+    );
+  });
+
+  it("builds failed summary when exit code is non-zero", () => {
+    const summary = buildCertificationSummary({
+      outputPath: "/tmp/report.json",
+      exitCode: 1,
+      command: ["pnpm", "--filter", "@sint/conformance-tests", "test:fixtures"],
+    });
+
+    expect(summary.success).toBe(false);
+    expect(summary.evidence.status).toBe("failed");
+    expect(summary.evidence.exitCode).toBe(1);
+  });
+
+  it("uses docs report default path", () => {
+    const outputPath = defaultCertificationOutputPath("/repo");
+    expect(outputPath).toBe(
+      "/repo/docs/reports/standalone-conformance-certification.json",
+    );
+  });
+});

--- a/apps/sintctl/src/certification.ts
+++ b/apps/sintctl/src/certification.ts
@@ -1,0 +1,78 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+export interface CertificationRunOptions {
+  readonly rootDir: string;
+  readonly outputPath?: string;
+  readonly gatewayUrl?: string;
+}
+
+export interface CertificationSummary {
+  readonly tool: "sintctl";
+  readonly mode: "standalone-conformance";
+  readonly generatedAt: string;
+  readonly success: boolean;
+  readonly command: readonly string[];
+  readonly outputPath: string;
+  readonly fixtureTestCommand: string;
+  readonly gatewayUrl?: string;
+  readonly evidence: {
+    readonly exitCode: number;
+    readonly status: "passed" | "failed";
+  };
+}
+
+export function defaultCertificationOutputPath(rootDir: string): string {
+  return resolve(rootDir, "docs/reports/standalone-conformance-certification.json");
+}
+
+export function buildCertificationSummary(params: {
+  readonly outputPath: string;
+  readonly exitCode: number;
+  readonly command: readonly string[];
+  readonly gatewayUrl?: string;
+}): CertificationSummary {
+  return {
+    tool: "sintctl",
+    mode: "standalone-conformance",
+    generatedAt: new Date().toISOString(),
+    success: params.exitCode === 0,
+    command: params.command,
+    outputPath: params.outputPath,
+    fixtureTestCommand: "pnpm --filter @sint/conformance-tests test:fixtures",
+    gatewayUrl: params.gatewayUrl,
+    evidence: {
+      exitCode: params.exitCode,
+      status: params.exitCode === 0 ? "passed" : "failed",
+    },
+  };
+}
+
+export function runStandaloneCertification(
+  options: CertificationRunOptions,
+): CertificationSummary {
+  const rootDir = options.rootDir;
+  const outputPath = options.outputPath
+    ? resolve(rootDir, options.outputPath)
+    : defaultCertificationOutputPath(rootDir);
+
+  const command = ["pnpm", "--filter", "@sint/conformance-tests", "test:fixtures"] as const;
+  const run = spawnSync(command[0], [...command.slice(1)], {
+    cwd: rootDir,
+    stdio: "inherit",
+  });
+
+  const exitCode = typeof run.status === "number" ? run.status : 1;
+  const summary = buildCertificationSummary({
+    outputPath,
+    exitCode,
+    command,
+    gatewayUrl: options.gatewayUrl,
+  });
+
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+
+  return summary;
+}

--- a/apps/sintctl/src/cli.ts
+++ b/apps/sintctl/src/cli.ts
@@ -2,6 +2,7 @@
 
 import { randomUUID } from "node:crypto";
 import { buildQuery, requestJson, type CliConfig } from "./client.js";
+import { runStandaloneCertification } from "./certification.js";
 
 type ParsedArgs = {
   positionals: string[];
@@ -87,6 +88,7 @@ Commands:
   ledger query              Query ledger events
   intercept run             Send a policy intercept request
   keypair create            Generate keypair via gateway utility endpoint
+  certify run               Run standalone conformance certification suite
 
 Examples:
   sintctl token issue --issuer <pub> --subject <pub> --resource ros2:///cmd_vel --actions publish --private-key <priv>
@@ -94,6 +96,7 @@ Examples:
   sintctl approvals resolve --request-id <id> --status approved --by operator@site
   sintctl ledger query --agent-id <pub> --limit 20
   sintctl intercept run --agent-id <pub> --token-id <id> --resource ros2:///cmd_vel --action publish --params-json '{"twist":{"linear":0.2}}'
+  sintctl certify run --output docs/reports/standalone-conformance-certification.json
 `);
 }
 
@@ -242,6 +245,20 @@ async function run(): Promise<void> {
     if (toolScope) params.set("toolScope", toolScope);
     const qs = params.toString();
     printJson(await requestJson(config, "GET", `/v1/registry/tokens${qs ? `?${qs}` : ""}`));
+    return;
+  }
+
+  if (group === "certify" && command === "run") {
+    const outputPath = getStringFlag(flags, "output");
+    const summary = runStandaloneCertification({
+      rootDir: process.cwd(),
+      outputPath,
+      gatewayUrl: gatewayUrl,
+    });
+    printJson(summary);
+    if (!summary.success) {
+      process.exit(1);
+    }
     return;
   }
 

--- a/docs/CONFORMANCE_CERTIFICATION_MATRIX_v0.2.md
+++ b/docs/CONFORMANCE_CERTIFICATION_MATRIX_v0.2.md
@@ -28,6 +28,7 @@ This matrix tracks canonical fixture coverage for major interoperability paths.
 | AgentSkill delegated-authority boundary | gateway + capability token validation | `packages/conformance-tests/fixtures/interop/agentskill-delegated-authority.v1.json` | `packages/conformance-tests/src/agentskill-authz-fixtures-conformance.test.ts` | Subject/scope binding enforced; revocation+expiry TOCTOU fail-closed; required attestation denial deterministic |
 | `action_ref` identity equivalence + explainability | cross-engine governance comparability profile | `packages/conformance-tests/fixtures/interop/action-ref-explainability.v1.json` | `packages/conformance-tests/src/action-ref-explainability-conformance.test.ts` | Same request identity yields stable `action_ref`; verdict divergence requires complete machine-readable decision context |
 | Economic Layer payment governance | budget + settlement safety profile | `packages/conformance-tests/fixtures/economy/payment-governance.v1.json` | `packages/conformance-tests/src/payment-governance-fixtures-conformance.test.ts` | Daily/rolling caps, recipient allowlist, receipt replay rejection, and reserve/commit mismatch checks are deterministic |
+| Standalone certification execution | `@sint/sintctl` certify command | N/A (executes canonical fixture pack) | `apps/sintctl/src/certification.ts`, `apps/sintctl/__tests__/certification.test.ts` | External operators can run one command and produce machine-readable certification summary evidence |
 
 ## Operational Certification Artifacts
 
@@ -69,6 +70,7 @@ This matrix tracks canonical fixture coverage for major interoperability paths.
   - `packages/conformance-tests/fixtures/iot/mqtt-gateway-session.v1.json`
 - Executable fixture conformance gate:
   - `pnpm --filter @sint/conformance-tests run test:fixtures`
+  - `node apps/sintctl/dist/cli.js certify run`
   - `pnpm --filter @sint/bridge-iot run test:fixtures`
   - `pnpm --filter @sint/sdk run test:contracts`
   - `pnpm --filter @sint/persistence-postgres run test:fixtures`

--- a/docs/guides/standalone-certification-tool.md
+++ b/docs/guides/standalone-certification-tool.md
@@ -1,0 +1,36 @@
+# Standalone Conformance Certification Tool
+
+SINT ships a standalone certification command via `sintctl`:
+
+```bash
+node apps/sintctl/dist/cli.js certify run
+```
+
+This command executes:
+
+```bash
+pnpm --filter @sint/conformance-tests test:fixtures
+```
+
+and writes a machine-readable summary report to:
+
+- `docs/reports/standalone-conformance-certification.json` (default)
+
+You can override output location:
+
+```bash
+node apps/sintctl/dist/cli.js certify run --output /tmp/sint-cert-report.json
+```
+
+## Output Summary
+
+The summary includes:
+
+- tool/mode metadata
+- UTC generation timestamp
+- pass/fail status
+- executed command
+- report path
+- exit code evidence
+
+Use this artifact in buyer certification packets and CI evidence bundles.

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ features:
 - Build static docs site: `pnpm run docs:build`
 - Core onboarding: [Getting Started](./getting-started.md)
 - Integration examples: [Tutorials](./tutorials/hello-world-agent.md)
+- Standalone certification tool: [Guide](./guides/standalone-certification-tool.md)
 - Community launch runbook: [Discord Launch](./community/discord-launch-runbook.md)
 - EU AI Act mapping: [Compliance/EU AI Act](./compliance/eu-ai-act-mapping.md)
 - ISO 13482 alignment: [Compliance/ISO 13482](./compliance/iso-13482-alignment.md)


### PR DESCRIPTION
## Summary
- add `sintctl certify run` command to execute standalone conformance fixture suite
- write machine-readable certification summary artifact (default: `docs/reports/standalone-conformance-certification.json`)
- add certification helper module and unit tests
- document usage in `apps/sintctl/README.md` + new guide + docs index/README/conformance matrix links

## Validation
- `pnpm --filter @sint/sintctl test`
- `pnpm --filter @sint/sintctl build`
- `node apps/sintctl/dist/cli.js certify run --output /tmp/sint-cert-report.json`

Closes #61
