### PR TITLE
Q3: NIST submission package automation and playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,8 @@ docker-compose up
 - Hardware safety controller roadmap: [`docs/roadmaps/hardware-safety-controller-integration.md`](docs/roadmaps/hardware-safety-controller-integration.md)
 - Hardware safety handshake fixture: [`packages/conformance-tests/fixtures/industrial/hardware-safety-handshake.v1.json`](packages/conformance-tests/fixtures/industrial/hardware-safety-handshake.v1.json)
 - Certification bundle summary: [`docs/reports/certification-bundle-summary.md`](docs/reports/certification-bundle-summary.md)
+- NIST submission playbook: [`docs/guides/nist-submission-playbook.md`](docs/guides/nist-submission-playbook.md)
+- NIST submission bundle report: [`docs/reports/nist-submission-bundle.md`](docs/reports/nist-submission-bundle.md)
 
 ## Design Principles
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -44,6 +44,7 @@ export default defineConfig({
           { text: "Secure MCP Deployments", link: "/guides/secure-mcp-deployments" },
           { text: "API Documentation Site", link: "/guides/api-documentation-site" },
           { text: "AutoGen Interop Fixtures", link: "/guides/autogen-interop-fixtures" },
+          { text: "NIST Submission Playbook", link: "/guides/nist-submission-playbook" },
           { text: "Claude Desktop Integration", link: "/guides/claude-desktop-integration" },
           { text: "Cursor Integration", link: "/guides/cursor-integration" },
         ],
@@ -77,6 +78,7 @@ export default defineConfig({
           { text: "Industrial Benchmark Report", link: "/reports/industrial-benchmark-report" },
           { text: "ROS2 Control-Loop Benchmark", link: "/reports/ros2-control-loop-benchmark" },
           { text: "Certification Bundle Summary", link: "/reports/certification-bundle-summary" },
+          { text: "NIST Submission Bundle", link: "/reports/nist-submission-bundle" },
         ],
       },
       {

--- a/docs/guides/nist-submission-playbook.md
+++ b/docs/guides/nist-submission-playbook.md
@@ -1,0 +1,58 @@
+# NIST Submission Playbook (AI Agent Standards Initiative)
+
+This playbook packages SINT artifacts for submission to the NIST AI Agent Standards Initiative.
+
+## Scope
+
+The generated bundle is an operator-review packet. It does not send email automatically.
+
+## Prerequisites
+
+- Repository checked out and up to date
+- Node.js 22+
+- `pnpm` installed
+
+## Generate the Bundle
+
+```bash
+pnpm run nist:bundle
+```
+
+This command generates:
+
+- `docs/reports/nist-submission-bundle.json`
+- `docs/reports/nist-submission-bundle.md`
+
+Each artifact in the packet includes:
+
+- existence check
+- SHA-256 checksum
+- generation timestamp
+
+## Included Artifacts
+
+The default bundle verifies:
+
+- `docs/specs/nist-ai-rmf-crosswalk.md`
+- `docs/SINT_v0.2_SPEC.md`
+- `docs/SPAI_2026_ABSTRACT.md`
+- `docs/CONFORMANCE_CERTIFICATION_MATRIX_v0.2.md`
+- `docs/reports/certification-bundle-summary.json`
+- `docs/reports/certification-bundle-summary.md`
+- `docs/reports/industrial-benchmark-report.json`
+- `docs/reports/industrial-benchmark-report.md`
+- `docs/reports/ros2-control-loop-benchmark.json`
+- `docs/reports/ros2-control-loop-benchmark.md`
+
+## Operator Submission Steps
+
+1. Run `pnpm run nist:bundle`.
+2. Confirm `Result: READY` in `docs/reports/nist-submission-bundle.md`.
+3. Review the checksum table for completeness.
+4. Attach the listed artifacts and send the packet to `ai-inquiries@nist.gov`.
+5. Record submission timestamp and Git commit SHA in your internal tracking issue.
+
+## Notes
+
+- The generated files are deterministic for a fixed commit.
+- If any artifact is missing, the bundle is marked `INCOMPLETE`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,10 +36,12 @@ features:
 - Core onboarding: [Getting Started](./getting-started.md)
 - Integration examples: [Tutorials](./tutorials/hello-world-agent.md)
 - Standalone certification tool: [Guide](./guides/standalone-certification-tool.md)
+- NIST submission playbook: [Guide](./guides/nist-submission-playbook.md)
 - Community launch runbook: [Discord Launch](./community/discord-launch-runbook.md)
 - EU AI Act mapping: [Compliance/EU AI Act](./compliance/eu-ai-act-mapping.md)
 - ISO 13482 alignment: [Compliance/ISO 13482](./compliance/iso-13482-alignment.md)
 - Formal threat model: [Security/Formal Threat Model](./security/formal-threat-model.md)
+- NIST submission bundle report: [Report](./reports/nist-submission-bundle.md)
 - Latest security bulletin: [April 2026](./security-bulletins/2026-04.md)
 
 ## Documentation Scope

--- a/docs/reports/nist-submission-bundle.json
+++ b/docs/reports/nist-submission-bundle.json
@@ -1,0 +1,64 @@
+{
+  "generatedAt": "2026-04-07T06:44:11.786Z",
+  "gitSha": null,
+  "success": true,
+  "targetProgram": "NIST AI Agent Standards Initiative",
+  "submissionChannel": "ai-inquiries@nist.gov",
+  "repository": "https://github.com/sint-ai/sint-protocol",
+  "artifacts": [
+    {
+      "path": "docs/specs/nist-ai-rmf-crosswalk.md",
+      "exists": true,
+      "sha256": "c0f2cd1f4c1bf2c4edb08d2852c446e6ed14219dc889c0108b6da856827e96ad"
+    },
+    {
+      "path": "docs/SINT_v0.2_SPEC.md",
+      "exists": true,
+      "sha256": "a79a7f8a395679e5e7080a716e26e54bad5a55905ab324788a3dac22aa202adb"
+    },
+    {
+      "path": "docs/SPAI_2026_ABSTRACT.md",
+      "exists": true,
+      "sha256": "8b67b9457c0670e0f474da82e0df622d151728b370392a6a8f52a732375b8ca7"
+    },
+    {
+      "path": "docs/CONFORMANCE_CERTIFICATION_MATRIX_v0.2.md",
+      "exists": true,
+      "sha256": "c28a1644583b4989520f3fea06c9019bb81403479b4322391de24ea64e81e61e"
+    },
+    {
+      "path": "docs/reports/certification-bundle-summary.json",
+      "exists": true,
+      "sha256": "ac878f735b4fdae9422b3654670bd9da0a77284c5cd31f092ce2335655936516"
+    },
+    {
+      "path": "docs/reports/certification-bundle-summary.md",
+      "exists": true,
+      "sha256": "9c41101e4acd361003fbb1e01df0bb98279d8db5f8cf3de482902a2eea51bd68"
+    },
+    {
+      "path": "docs/reports/industrial-benchmark-report.json",
+      "exists": true,
+      "sha256": "bcc89aa2d9d2f668b85971b6a42e78d70e26cd7240052edae518af5394c6733f"
+    },
+    {
+      "path": "docs/reports/industrial-benchmark-report.md",
+      "exists": true,
+      "sha256": "ef4b207c2a31df0c65cc21f6d79cf11cb7e6b156bf11d0aad343ecca8d89cee4"
+    },
+    {
+      "path": "docs/reports/ros2-control-loop-benchmark.json",
+      "exists": true,
+      "sha256": "2503633d7a096a41395e984a005849121d5d362c2c1cbc7b2b2188fbfca0110e"
+    },
+    {
+      "path": "docs/reports/ros2-control-loop-benchmark.md",
+      "exists": true,
+      "sha256": "674505d8ee8da180a2ec358b56f68a3874ec1db238caba46f7dd83f88c5f1d98"
+    }
+  ],
+  "notes": [
+    "This bundle is a submission packet draft for NIST review.",
+    "Final submission requires operator review and outbound email dispatch."
+  ]
+}

--- a/docs/reports/nist-submission-bundle.md
+++ b/docs/reports/nist-submission-bundle.md
@@ -1,0 +1,31 @@
+# NIST Submission Bundle
+
+Generated: 2026-04-07T06:44:11.786Z
+Commit: local
+Result: READY
+
+## Target
+
+- Program: NIST AI Agent Standards Initiative
+- Channel: ai-inquiries@nist.gov
+- Repository: https://github.com/sint-ai/sint-protocol
+
+## Artifact Checklist
+
+| Artifact | Present | SHA-256 |
+|---|---|---|
+| `docs/specs/nist-ai-rmf-crosswalk.md` | yes | c0f2cd1f4c1bf2c4edb08d2852c446e6ed14219dc889c0108b6da856827e96ad |
+| `docs/SINT_v0.2_SPEC.md` | yes | a79a7f8a395679e5e7080a716e26e54bad5a55905ab324788a3dac22aa202adb |
+| `docs/SPAI_2026_ABSTRACT.md` | yes | 8b67b9457c0670e0f474da82e0df622d151728b370392a6a8f52a732375b8ca7 |
+| `docs/CONFORMANCE_CERTIFICATION_MATRIX_v0.2.md` | yes | c28a1644583b4989520f3fea06c9019bb81403479b4322391de24ea64e81e61e |
+| `docs/reports/certification-bundle-summary.json` | yes | ac878f735b4fdae9422b3654670bd9da0a77284c5cd31f092ce2335655936516 |
+| `docs/reports/certification-bundle-summary.md` | yes | 9c41101e4acd361003fbb1e01df0bb98279d8db5f8cf3de482902a2eea51bd68 |
+| `docs/reports/industrial-benchmark-report.json` | yes | bcc89aa2d9d2f668b85971b6a42e78d70e26cd7240052edae518af5394c6733f |
+| `docs/reports/industrial-benchmark-report.md` | yes | ef4b207c2a31df0c65cc21f6d79cf11cb7e6b156bf11d0aad343ecca8d89cee4 |
+| `docs/reports/ros2-control-loop-benchmark.json` | yes | 2503633d7a096a41395e984a005849121d5d362c2c1cbc7b2b2188fbfca0110e |
+| `docs/reports/ros2-control-loop-benchmark.md` | yes | 674505d8ee8da180a2ec358b56f68a3874ec1db238caba46f7dd83f88c5f1d98 |
+
+## Notes
+
+- This bundle is a submission packet draft for NIST review.
+- Final submission requires operator review and outbound email dispatch.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,6 +40,7 @@ See detailed plans in:
 
 - [x] Secure MCP deployments guide (`docs/guides/secure-mcp-deployments.md`)
 - [x] NIST AI RMF crosswalk document (`docs/specs/nist-ai-rmf-crosswalk.md`)
+- [x] NIST submission bundle generator + playbook (`pnpm run nist:bundle`)
 - [ ] PR to `modelcontextprotocol/servers` — SINT as reference security middleware
 - [ ] NIST submission to ai-inquiries@nist.gov (crosswalk + conformance suite + SPAI abstract)
 - [ ] SPAI 2026 abstract submitted (deadline: May 7, 2026)

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "demo": "pnpm --filter @sint/conformance-tests exec vitest run src/e2e-demo.test.ts --reporter=verbose",
     "cert:fixtures": "pnpm --filter ./packages/policy-gateway build && pnpm --filter ./packages/conformance-tests run test:fixtures && pnpm --filter ./packages/bridge-iot run test:fixtures && pnpm --filter ./sdks/typescript run test:contracts && pnpm --filter ./packages/persistence-postgres run test:fixtures",
     "cert:bundle": "node ./scripts/generate-certification-bundle.mjs",
+    "nist:bundle": "node ./scripts/generate-nist-submission-bundle.mjs",
     "benchmark:industrial": "pnpm --filter @sint/conformance-tests exec vitest run src/industrial-interoperability.test.ts src/industrial-benchmark-scenarios.test.ts --reporter=verbose",
     "benchmark:ros2-loop": "pnpm --filter @sint/conformance-tests exec vitest run src/ros2-control-loop-latency.test.ts --reporter=verbose",
     "benchmark:ros2-report": "node ./scripts/generate-ros2-control-loop-report.mjs",

--- a/scripts/generate-nist-submission-bundle.mjs
+++ b/scripts/generate-nist-submission-bundle.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const reportDir = path.join(repoRoot, "docs", "reports");
+const summaryJsonPath = path.join(reportDir, "nist-submission-bundle.json");
+const summaryMdPath = path.join(reportDir, "nist-submission-bundle.md");
+
+mkdirSync(reportDir, { recursive: true });
+
+const requiredArtifacts = [
+  "docs/specs/nist-ai-rmf-crosswalk.md",
+  "docs/SINT_v0.2_SPEC.md",
+  "docs/SPAI_2026_ABSTRACT.md",
+  "docs/CONFORMANCE_CERTIFICATION_MATRIX_v0.2.md",
+  "docs/reports/certification-bundle-summary.json",
+  "docs/reports/certification-bundle-summary.md",
+  "docs/reports/industrial-benchmark-report.json",
+  "docs/reports/industrial-benchmark-report.md",
+  "docs/reports/ros2-control-loop-benchmark.json",
+  "docs/reports/ros2-control-loop-benchmark.md",
+];
+
+function sha256File(absPath) {
+  const content = readFileSync(absPath);
+  return createHash("sha256").update(content).digest("hex");
+}
+
+const artifacts = requiredArtifacts.map((relPath) => {
+  const abs = path.join(repoRoot, relPath);
+  const present = existsSync(abs);
+  return {
+    path: relPath,
+    exists: present,
+    sha256: present ? sha256File(abs) : null,
+  };
+});
+
+const summary = {
+  generatedAt: new Date().toISOString(),
+  gitSha: process.env.GITHUB_SHA ?? null,
+  success: artifacts.every((a) => a.exists),
+  targetProgram: "NIST AI Agent Standards Initiative",
+  submissionChannel: "ai-inquiries@nist.gov",
+  repository: "https://github.com/sint-ai/sint-protocol",
+  artifacts,
+  notes: [
+    "This bundle is a submission packet draft for NIST review.",
+    "Final submission requires operator review and outbound email dispatch.",
+  ],
+};
+
+writeFileSync(summaryJsonPath, JSON.stringify(summary, null, 2) + "\n", "utf8");
+
+const md = [
+  "# NIST Submission Bundle",
+  "",
+  `Generated: ${summary.generatedAt}`,
+  summary.gitSha ? `Commit: ${summary.gitSha}` : "Commit: local",
+  `Result: ${summary.success ? "READY" : "INCOMPLETE"}`,
+  "",
+  "## Target",
+  "",
+  `- Program: ${summary.targetProgram}`,
+  `- Channel: ${summary.submissionChannel}`,
+  `- Repository: ${summary.repository}`,
+  "",
+  "## Artifact Checklist",
+  "",
+  "| Artifact | Present | SHA-256 |",
+  "|---|---|---|",
+  ...summary.artifacts.map((a) => `| \`${a.path}\` | ${a.exists ? "yes" : "no"} | ${a.sha256 ?? "-"} |`),
+  "",
+  "## Notes",
+  "",
+  ...summary.notes.map((n) => `- ${n}`),
+  "",
+].join("\n");
+
+writeFileSync(summaryMdPath, md, "utf8");
+
+console.log(`[nist-bundle] wrote ${path.relative(repoRoot, summaryJsonPath)}`);
+console.log(`[nist-bundle] wrote ${path.relative(repoRoot, summaryMdPath)}`);


### PR DESCRIPTION
## Summary
- add scripts/generate-nist-submission-bundle.mjs to produce deterministic NIST submission packet metadata
- add pnpm run nist:bundle command and publish operator-facing playbook
- add generated submission bundle JSON/MD reports with checksum inventory
- wire docs navigation/README/roadmap links for discoverability

## Validation
- pnpm run nist:bundle
- pnpm run docs:build

Closes #60
