### PR TITLE
[codex] Fix CI blockers and make SINT MCP installable

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -84,6 +84,23 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Publish MCP server
+        run: |
+          pkg="apps/sint-mcp"
+          name=$(node -p "require('./$pkg/package.json').name")
+          version=$(node -p "require('./$pkg/package.json').version")
+          echo "Publishing $name@$version..."
+          if (cd "$pkg" && npm publish --access public --provenance); then
+            echo "✓ $name"
+          elif npm view "$name@$version" > /dev/null 2>&1; then
+            echo "✓ $name (already published)"
+          else
+            echo "::error::Failed to publish $name@$version"
+            exit 1
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Verify installation
         run: |
           cd /tmp
@@ -97,6 +114,24 @@ jobs:
           done
           npm install @pshkv/core@${{ steps.version.outputs.version }} --prefer-online
           node -e "const c = require('@pshkv/core'); console.log('✓ @pshkv/core loads OK, exports:', Object.keys(c).length, 'items')"
+
+      - name: Verify MCP server installation
+        run: |
+          cd /tmp
+          mcp_version=$(node -p "require('${GITHUB_WORKSPACE}/apps/sint-mcp/package.json').version")
+          for i in $(seq 1 6); do
+            if npm install @sint/mcp@"$mcp_version" --prefer-online 2>/dev/null; then
+              break
+            fi
+            echo "Registry not ready yet for @sint/mcp, retrying in 10s... ($i/6)"
+            sleep 10
+          done
+          npm install @sint/mcp@"$mcp_version" --prefer-online
+          npx @sint/mcp --stdio >/tmp/sint-mcp-verify.log 2>&1 &
+          MCP_PID=$!
+          sleep 2
+          kill "$MCP_PID" >/dev/null 2>&1 || true
+          cat /tmp/sint-mcp-verify.log
 
       - name: Create GitHub Release summary
         run: |
@@ -119,3 +154,4 @@ jobs:
           echo "- \`@pshkv/bridge-a2a\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`@pshkv/bridge-economy\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`@pshkv/token-registry\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`@sint/mcp\`" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:22-bookworm-slim
+
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+
+WORKDIR /app
+
+RUN corepack enable
+
+# Copy the minimal workspace surface needed to build and run @sint/mcp.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json tsconfig.base.json ./
+COPY apps/sint-mcp ./apps/sint-mcp
+COPY packages ./packages
+
+RUN pnpm install --frozen-lockfile && pnpm --filter @sint/mcp build
+
+USER node
+
+CMD ["node", "apps/sint-mcp/dist/index.cjs", "--stdio"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # SINT Protocol
 [![CI](https://github.com/sint-ai/sint-protocol/actions/workflows/ci.yml/badge.svg)](https://github.com/sint-ai/sint-protocol/actions/workflows/ci.yml)
+[![Glama](https://glama.ai/mcp/servers/sint-ai/sint-protocol/badges/card.svg)](https://glama.ai/mcp/servers/sint-ai/sint-protocol)
 ![Node.js](https://img.shields.io/badge/node-%3E%3D22-blue)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue)
 ![License](https://img.shields.io/badge/license-Apache--2.0-blue)

--- a/apps/sint-mcp/README.md
+++ b/apps/sint-mcp/README.md
@@ -30,7 +30,7 @@ Every downstream tool is exposed to the agent as `serverName__toolName` (e.g. `f
 npx @sint/mcp
 
 # Streamable HTTP
-npx @sint/mcp --http --port 3200
+npx @sint/mcp --sse --port 3200
 ```
 
 Configure with a `sint-mcp.config.json` in your working directory:
@@ -62,7 +62,7 @@ Configure with a `sint-mcp.config.json` in your working directory:
   "mcpServers": {
     "sint": {
       "command": "npx",
-      "args": ["-y", "@pshkv/mcp", "--config", "/path/to/sint-mcp.config.json"]
+      "args": ["-y", "@sint/mcp", "--config", "/path/to/sint-mcp.config.json"]
     }
   }
 }
@@ -77,7 +77,7 @@ All options can be set via config file, environment variable, or CLI flag. Prior
 | `servers` | — | — | `{}` | Downstream server configs (see below) |
 | `defaultPolicy` | `--policy` | `SINT_MCP_POLICY` | `cautious` | `permissive` \| `cautious` \| `strict` |
 | `approvalTimeoutMs` | `--timeout` | `SINT_MCP_APPROVAL_TIMEOUT` | `120000` | How long to wait for human approval |
-| `transport` | `--stdio` / `--http` | `SINT_MCP_TRANSPORT` | `stdio` | `stdio` \| `http` |
+| `transport` | `--stdio` / `--sse` | `SINT_MCP_TRANSPORT` | `stdio` | `stdio` \| `sse` |
 | `port` | `--port` | `SINT_MCP_PORT` | `3200` | HTTP port (http transport only) |
 | `agentPrivateKey` | — | `SINT_AGENT_PRIVATE_KEY` | auto-generated | Agent Ed25519 private key (hex) |
 

--- a/apps/sint-mcp/build.mjs
+++ b/apps/sint-mcp/build.mjs
@@ -1,0 +1,27 @@
+import * as esbuild from "esbuild";
+import * as fs from "node:fs";
+
+await esbuild.build({
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  platform: "node",
+  format: "cjs",
+  target: "node22",
+  outfile: "dist/index.cjs",
+});
+
+let cliContent = fs.readFileSync("dist/index.cjs", "utf8");
+cliContent = cliContent.replace(/^(#!.*\n)+/, "#!/usr/bin/env node\n");
+fs.writeFileSync("dist/index.cjs", cliContent);
+fs.chmodSync("dist/index.cjs", 0o755);
+
+await esbuild.build({
+  entryPoints: ["src/server.ts"],
+  bundle: true,
+  platform: "node",
+  format: "cjs",
+  target: "node22",
+  outfile: "dist/server.cjs",
+});
+
+console.log("esbuild bundle complete");

--- a/apps/sint-mcp/package.json
+++ b/apps/sint-mcp/package.json
@@ -1,25 +1,28 @@
 {
-  "name": "@pshkv/mcp",
+  "name": "@sint/mcp",
   "version": "0.1.0",
   "description": "SINT MCP — Security-first multi-MCP proxy server with policy enforcement",
   "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/index.cjs",
   "bin": {
-    "sint-mcp": "./dist/index.js"
+    "sint-mcp": "./dist/index.cjs"
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "default": "./dist/index.cjs"
     },
     "./server": {
-      "types": "./dist/server.d.ts",
-      "import": "./dist/server.js"
+      "default": "./dist/server.cjs"
     }
   },
+  "files": [
+    "dist/index.cjs",
+    "dist/server.cjs",
+    "README.md",
+    "sint-mcp.config.example.json"
+  ],
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && node build.mjs",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
@@ -27,7 +30,13 @@
     "test": "vitest run",
     "test:watch": "vitest watch"
   },
-  "dependencies": {
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@pshkv/bridge-mcp": "workspace:*",
     "@pshkv/core": "workspace:*",
@@ -36,11 +45,10 @@
     "@pshkv/gate-policy-gateway": "workspace:*",
     "@pshkv/interface-bridge": "workspace:*",
     "@pshkv/memory": "workspace:*",
-    "zod": "^3.24.0"
-  },
-  "devDependencies": {
+    "esbuild": "^0.25.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "vitest": "^3.0.0",
+    "zod": "^3.24.0"
   }
 }

--- a/docs/DOMAIN_ARCHITECTURE.md
+++ b/docs/DOMAIN_ARCHITECTURE.md
@@ -79,6 +79,7 @@ If SINT evolves into a full agentic OS (model companies start owning layers):
    - Upload logo (orange N icon from sint.gg)
    - Add one-liner: "The open-source governance layer for AI agents — scan MCP servers, enforce policy bundles, prove compliance."
    - Add homepage: https://sint.gg
+   - Use the repo-root `Dockerfile` for the Glama build spec so the server can be inspected and released
    - Fix the installable status: needs `@sint/mcp` published to npm
 
 ## npm publish (do from Mac Mini)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,7 +192,7 @@ importers:
         version: 3.2.4(@types/node@22.19.15)(jsdom@25.0.1)(tsx@4.21.0)
 
   apps/sint-mcp:
-    dependencies:
+    devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@3.25.76)
@@ -217,10 +217,9 @@ importers:
       '@pshkv/memory':
         specifier: workspace:*
         version: link:../../packages/memory
-      zod:
-        specifier: ^3.24.0
-        version: 3.25.76
-    devDependencies:
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -230,6 +229,9 @@ importers:
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@22.19.15)(jsdom@25.0.1)(tsx@4.21.0)
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
 
   apps/sint-mcp-scanner:
     devDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - "packages/*"
   - "!packages/mcp-scanner"
   - "apps/*"
+  - "!apps/*-standalone"
   - "examples/*"
   - "capsules/*"
   - "sdks/typescript"


### PR DESCRIPTION
## Summary
- exclude standalone scanner artifacts from the pnpm workspace graph to unblock CI
- make `apps/sint-mcp` a self-contained npm package published as `@sint/mcp`
- add npm release workflow support for publishing and verifying the MCP server package
- enable GitHub Pages for the repository so the docs deploy workflow can complete

## Root cause
There were two separate issues in the repo:

1. CI on `main` was failing during workspace discovery because two standalone scanner folders under `apps/` both declared the package name `sint-scan`, and `pnpm-workspace.yaml` included every app directory.
2. The MCP server looked installable in the repo, but it was not actually publishable or installable from npm. The package name in `apps/sint-mcp` did not match the public docs (`@sint/mcp`), and the package still depended on `workspace:*` runtime dependencies, which causes clean npm installs to fail with `EUNSUPPORTEDPROTOCOL`.

The docs workflow was also failing separately because GitHub Pages had never been enabled for the repository, so `actions/configure-pages` returned `Not Found` even though the docs build itself succeeded.

## What changed
- excluded `apps/*-standalone` from the pnpm workspace graph
- renamed the MCP package to `@sint/mcp`
- switched the MCP package to an esbuild-generated self-contained runtime bundle
- narrowed the npm package contents to the actual installable runtime files
- fixed the README install snippets so they match the actual CLI flags and package name
- extended the npm release workflow to publish and verify `@sint/mcp`
- enabled GitHub Pages for the repo and reran the failed docs workflow

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run benchmark:report`
- `pnpm run docs:build`
- `pnpm --filter @sint/mcp test`
- clean-room install test: `npm pack` + `npm install` of `apps/sint-mcp` in a fresh temp directory + launch of `sint-mcp`
- reran the failed Docs Site workflow successfully
