### PR TITLE
[codex] Fix npm publish version checks

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,10 +32,6 @@ jobs:
       - name: Run tests (gate)
         run: pnpm run test
 
-      - name: Extract version from tag
-        id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
-
       - name: Publish core packages (dependency order)
         run: |
           PACKAGES=(
@@ -104,15 +100,16 @@ jobs:
       - name: Verify installation
         run: |
           cd /tmp
+          core_version=$(node -p "require('${GITHUB_WORKSPACE}/packages/core/package.json').version")
           # Wait for npm CDN propagation (up to 60s)
           for i in $(seq 1 6); do
-            if npm install @pshkv/core@${{ steps.version.outputs.version }} --prefer-online 2>/dev/null; then
+            if npm install @pshkv/core@"$core_version" --prefer-online 2>/dev/null; then
               break
             fi
             echo "Registry not ready yet, retrying in 10s... ($i/6)"
             sleep 10
           done
-          npm install @pshkv/core@${{ steps.version.outputs.version }} --prefer-online
+          npm install @pshkv/core@"$core_version" --prefer-online
           node -e "const c = require('@pshkv/core'); console.log('✓ @pshkv/core loads OK, exports:', Object.keys(c).length, 'items')"
 
       - name: Verify MCP server installation
@@ -135,11 +132,12 @@ jobs:
 
       - name: Create GitHub Release summary
         run: |
-          echo "## Published v${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          core_version=$(node -p "require('${GITHUB_WORKSPACE}/packages/core/package.json').version")
+          echo "## Published v${core_version}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Install:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "npm install @pshkv/core@${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "npm install @pshkv/core@${core_version}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Published packages:" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This removes the publish workflow's dependency on the Git tag text for package verification.

Why:
- `apps/sint-mcp` and the workspace packages are still versioned at `0.1.0`.
- The workflow was trying to verify `@pshkv/core@<tag version>`, which breaks as soon as the tag and package versions diverge.
- That blocked us from cutting a new release tag after merging the CI/installability fixes.

What changed:
- Verify core installs against the actual version in `packages/core/package.json`.
- Reuse that package version in the release summary.
- Leave the tag as a release trigger only.

Validation:
- `git diff --check`
