### PR TITLE
[codex] Publish sint-mcp unscoped

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -117,14 +117,14 @@ jobs:
           cd /tmp
           mcp_version=$(node -p "require('${GITHUB_WORKSPACE}/apps/sint-mcp/package.json').version")
           for i in $(seq 1 6); do
-            if npm install @sint/mcp@"$mcp_version" --prefer-online 2>/dev/null; then
+            if npm install sint-mcp@"$mcp_version" --prefer-online 2>/dev/null; then
               break
             fi
-            echo "Registry not ready yet for @sint/mcp, retrying in 10s... ($i/6)"
+            echo "Registry not ready yet for sint-mcp, retrying in 10s... ($i/6)"
             sleep 10
           done
-          npm install @sint/mcp@"$mcp_version" --prefer-online
-          npx @sint/mcp --stdio >/tmp/sint-mcp-verify.log 2>&1 &
+          npm install sint-mcp@"$mcp_version" --prefer-online
+          npx sint-mcp --stdio >/tmp/sint-mcp-verify.log 2>&1 &
           MCP_PID=$!
           sleep 2
           kill "$MCP_PID" >/dev/null 2>&1 || true
@@ -152,4 +152,4 @@ jobs:
           echo "- \`@pshkv/bridge-a2a\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`@pshkv/bridge-economy\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`@pshkv/token-registry\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`@sint/mcp\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`sint-mcp\`" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ WORKDIR /app
 
 RUN corepack enable
 
-# Copy the minimal workspace surface needed to build and run @sint/mcp.
+# Copy the minimal workspace surface needed to build and run sint-mcp.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json tsconfig.base.json ./
 COPY apps/sint-mcp ./apps/sint-mcp
 COPY packages ./packages
 
-RUN pnpm install --frozen-lockfile && pnpm --filter @sint/mcp build
+RUN pnpm install --frozen-lockfile && pnpm --filter sint-mcp build
 
 USER node
 

--- a/apps/sint-mcp/README.md
+++ b/apps/sint-mcp/README.md
@@ -27,10 +27,10 @@ Every downstream tool is exposed to the agent as `serverName__toolName` (e.g. `f
 
 ```bash
 # stdio (Claude Desktop, Claude Code, etc.)
-npx @sint/mcp
+npx sint-mcp
 
 # Streamable HTTP
-npx @sint/mcp --sse --port 3200
+npx sint-mcp --sse --port 3200
 ```
 
 Configure with a `sint-mcp.config.json` in your working directory:
@@ -62,7 +62,7 @@ Configure with a `sint-mcp.config.json` in your working directory:
   "mcpServers": {
     "sint": {
       "command": "npx",
-      "args": ["-y", "@sint/mcp", "--config", "/path/to/sint-mcp.config.json"]
+      "args": ["-y", "sint-mcp", "--config", "/path/to/sint-mcp.config.json"]
     }
   }
 }

--- a/apps/sint-mcp/package.json
+++ b/apps/sint-mcp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sint/mcp",
+  "name": "sint-mcp",
   "version": "0.1.0",
   "description": "SINT MCP — Security-first multi-MCP proxy server with policy enforcement",
   "type": "module",
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "tsc --build && node build.mjs",
     "dev": "tsx watch src/index.ts",
-    "start": "node dist/index.js",
+    "start": "node dist/index.cjs",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist *.tsbuildinfo",
     "test": "vitest run",

--- a/apps/sint-mcp/src/index.ts
+++ b/apps/sint-mcp/src/index.ts
@@ -7,9 +7,9 @@
  * SINT policy on every tool call.
  *
  * Usage:
- *   npx @sint/mcp                           # stdio, default config
- *   npx @sint/mcp --sse --port 3200         # SSE remote
- *   npx @sint/mcp --config ./config.json    # custom config
+ *   npx sint-mcp                            # stdio, default config
+ *   npx sint-mcp --sse --port 3200         # SSE remote
+ *   npx sint-mcp --config ./config.json     # custom config
  *
  * @module @sint/mcp
  */


### PR DESCRIPTION
This switches the MCP proxy package from the scoped `@sint/mcp` name to the unscoped `sint-mcp` name.

Why:
- npm rejected publishes for `@sint/mcp` with `404 Not Found` at the registry layer.
- The package builds and installs fine locally, but the scope is not publishable from this npm setup.
- An unscoped package avoids the registry scope issue and lets the release workflow publish successfully.

What changed:
- Renamed the package to `sint-mcp`.
- Updated publish verification and release summary text in the npm workflow.
- Updated the MCP install snippets to use `npx sint-mcp`.
- Fixed the package `start` entrypoint to match the bundled `.cjs` output.

Validation:
- `git diff --check`
- clean-room `npm pack` + install + `npx sint-mcp --stdio`
