### PR TITLE
[codex] Add MCP package repository metadata

### DIFF
--- a/apps/sint-mcp/package.json
+++ b/apps/sint-mcp/package.json
@@ -33,6 +33,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sint-ai/sint-protocol",
+    "directory": "apps/sint-mcp"
+  },
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
The MCP publish workflow now gets through the registry publish step, but npm provenance rejects `sint-mcp` because the package metadata lacks a repository URL.

What changed:
- Added `repository.url` and `repository.directory` to `apps/sint-mcp/package.json`.

Why:
- npm provenance validates package metadata against the GitHub source URL.
- The previous publish failed with `E422` because `repository.url` was empty.

Validation:
- `git diff --check`
