### PR TITLE
Fix npm release verification for ESM core

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -110,7 +110,7 @@ jobs:
             sleep 10
           done
           npm install @pshkv/core@"$core_version" --prefer-online
-          node -e "const c = require('@pshkv/core'); console.log('✓ @pshkv/core loads OK, exports:', Object.keys(c).length, 'items')"
+          node -e "import('@pshkv/core').then((c) => console.log('✓ @pshkv/core loads OK, exports:', Object.keys(c).length, 'items'))"
 
       - name: Verify MCP server installation
         run: |


### PR DESCRIPTION
The v0.2.3 publish run successfully published sint-mcp, but failed afterward because the verification step used CommonJS require() against the ESM-only @pshkv/core package. This switches the verification to dynamic import() so future release runs can complete green.