### PR TITLE
Improve MCP tool definitions for Glama scoring

### DIFF
--- a/apps/sint-mcp/src/tools/delegation-tools.ts
+++ b/apps/sint-mcp/src/tools/delegation-tools.ts
@@ -34,37 +34,64 @@ export function getDelegationToolDefinitions(): Array<{
     {
       name: "sint__delegate_to_agent",
       description:
-        "Issue an attenuated capability token to a sub-agent, granting it a reduced tool scope. Depth is parent.depth + 1; max depth 3. Returns the new tokenId.",
+        "Issue a delegated capability token to a sub-agent with narrower scope than the current token. Use this when one agent should perform a bounded sub-task without inheriting full access. Returns a JSON object containing the new token ID, delegated scope, depth, and expiry.",
       inputSchema: {
         type: "object",
         properties: {
-          subagentId: { type: "string", description: "Public key of the sub-agent to delegate to" },
+          subagentId: {
+            type: "string",
+            description: "Public key or stable identifier of the sub-agent receiving the delegated token",
+            examples: ["agent:reviewer-01", "ed25519:def456..."],
+          },
           toolScope: {
             type: "array",
             items: { type: "string" },
-            description: "Resource URI patterns the sub-agent may access (must be a subset of caller's scope)",
+            description: "Resource URI patterns the sub-agent may access; must be a subset of the caller's scope",
+            examples: [["mcp://filesystem/reports/*"], ["mcp://github/repos/sint-ai/sint-protocol/issues/*"]],
           },
-          expiresInHours: { type: "number", description: "Token lifetime in hours (default: 4)" },
-          maxCallsPerMinute: { type: "number", description: "Optional rate limit for sub-agent" },
+          expiresInHours: {
+            type: "number",
+            description: "Delegated token lifetime in hours; defaults to 4",
+            minimum: 1,
+            examples: [1, 4, 24],
+          },
+          maxCallsPerMinute: {
+            type: "number",
+            description: "Optional per-minute rate limit applied to the delegated token",
+            minimum: 1,
+            examples: [10, 60],
+          },
         },
         required: ["subagentId", "toolScope"],
+        additionalProperties: false,
       },
     },
     {
       name: "sint__list_delegations",
-      description: "List the active delegation tree rooted at the current operator token. Returns a JSON array of DelegationNode objects.",
-      inputSchema: { type: "object", properties: {}, required: [] },
+      description:
+        "List the active delegation tree rooted at the current token. Use this to audit which sub-agents currently hold delegated access, how deep the tree is, and what scope has been passed down. Returns a JSON array of delegation nodes.",
+      inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
     },
     {
       name: "sint__revoke_delegation_tree",
-      description: "Revoke an entire delegation subtree rooted at the given tokenId. All descendant tokens are cascade-revoked.",
+      description:
+        "Cascade-revoke a delegated token and all of its descendants. Use this for incident response or cleanup when an entire delegated execution branch should stop immediately. Returns a JSON summary describing how many tokens were revoked and why.",
       inputSchema: {
         type: "object",
         properties: {
-          rootTokenId: { type: "string", description: "Root tokenId of the subtree to revoke" },
-          reason: { type: "string", description: "Reason for revocation" },
+          rootTokenId: {
+            type: "string",
+            description: "Root delegated token ID whose entire subtree should be revoked",
+            examples: ["tok_01hxyz..."],
+          },
+          reason: {
+            type: "string",
+            description: "Reason recorded for the cascade revocation",
+            examples: ["Sub-agent exceeded its brief", "Incident response containment"],
+          },
         },
         required: ["rootTokenId"],
+        additionalProperties: false,
       },
     },
   ];

--- a/apps/sint-mcp/src/tools/interface-tools.ts
+++ b/apps/sint-mcp/src/tools/interface-tools.ts
@@ -31,109 +31,157 @@ export function getInterfaceToolDefinitions(): Array<{
     {
       name: "sint__interface_status",
       description:
-        "Return current operator interface state: mode, listening/speaking flags, active HUD panels, memory context size, and session ID",
-      inputSchema: { type: "object", properties: {}, required: [] },
+        "Inspect the current operator interface state before sending operator-facing updates. Use this to confirm the active mode, HUD panels, speaking/listening flags, and session context. Returns a JSON snapshot of the current interface state.",
+      inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
     },
     {
       name: "sint__recall_memory",
-      description: "Search the memory bank for entries matching a query string. Returns matching entries as JSON.",
+      description:
+        "Search the operator memory bank for relevant stored context. Use this before asking for human input again or when you need prior decisions, notes, or context by keyword. Returns matching memory entries as JSON.",
       inputSchema: {
         type: "object",
         properties: {
-          query: { type: "string", description: "Search query to match against memory entries" },
-          limit: { type: "number", description: "Maximum number of results to return (default: 10)" },
+          query: {
+            type: "string",
+            description: "Search string used to match memory keys, tags, or content",
+            examples: ["deployment approval", "customer abc", "incident 42"],
+          },
+          limit: {
+            type: "number",
+            description: "Maximum number of matches to return; defaults to 10",
+            minimum: 1,
+            examples: [5, 10, 25],
+          },
         },
         required: ["query"],
+        additionalProperties: false,
       },
     },
     {
       name: "sint__speak",
-      description: "Schedule TTS voice output to the operator with a configurable priority level",
+      description:
+        "Send text-to-speech output to the operator interface. Use this for spoken alerts or short status updates that need immediate attention; prefer concise text because the content is voiced aloud. Returns a JSON confirmation with the spoken text and priority.",
       inputSchema: {
         type: "object",
         properties: {
-          text: { type: "string", description: "Text to speak aloud to the operator" },
+          text: {
+            type: "string",
+            description: "Short text that will be spoken aloud to the operator",
+            examples: ["Approval needed for production deploy", "Battery level critical"],
+          },
           priority: {
             type: "string",
             enum: ["low", "normal", "urgent"],
-            description: "Voice output priority (default: normal)",
+            description: "Voice output priority; defaults to normal",
           },
         },
         required: ["text"],
+        additionalProperties: false,
       },
     },
     {
       name: "sint__show_hud",
-      description: "Update a HUD panel with new data. Emits an operator.hud.updated event.",
+      description:
+        "Show or refresh one HUD panel in the operator interface. Use this to surface approvals, audit details, context, or memory on screen; this updates the live interface but does not persist business data. Returns a JSON confirmation describing which panel was updated.",
       inputSchema: {
         type: "object",
         properties: {
           panel: {
             type: "string",
             enum: ["approvals", "audit", "context", "memory"],
-            description: "Which HUD panel to update",
+            description: "HUD panel to display or refresh",
           },
-          data: { description: "Data to display in the panel (any JSON value)" },
+          data: {
+            description: "Optional JSON payload for the panel; useful for supplying custom context alongside the panel change",
+          },
         },
         required: ["panel"],
+        additionalProperties: false,
       },
     },
     {
       name: "sint__store_memory",
-      description: "Store an entry in the memory bank with optional tags and persistence",
+      description:
+        "Store structured context in the operator memory bank for later retrieval. Use this for durable notes, human preferences, incident breadcrumbs, or other context worth recalling later. Returns a JSON confirmation with the stored key and persistence state.",
       inputSchema: {
         type: "object",
         properties: {
-          key: { type: "string", description: "Unique key for the memory entry" },
-          value: { description: "Value to store (any JSON value)" },
+          key: {
+            type: "string",
+            description: "Stable unique key for the memory entry",
+            examples: ["incident-42/root-cause", "customer/acme/preference"],
+          },
+          value: {
+            description: "Any JSON value to persist under the key",
+          },
           tags: {
             type: "array",
             items: { type: "string" },
-            description: "Optional tags for categorisation and search",
+            description: "Optional tags used for categorization and later search",
+            examples: [["incident", "prod"], ["customer", "billing"]],
           },
           persist: {
             type: "boolean",
-            description: "Whether to persist beyond this session (default: false)",
+            description: "Whether the entry should persist beyond the current session; defaults to false",
           },
         },
         required: ["key", "value"],
+        additionalProperties: false,
       },
     },
     {
       name: "sint__notify",
-      description: "Send a proactive notification to the operator, optionally with an actionable button",
+      description:
+        "Send a proactive notification to the operator interface, optionally with one follow-up action button. Use this for alerts or prompts that should remain visible in the UI; this is better than sint__speak when the operator needs something clickable or persistent. Returns a JSON confirmation with the notification timestamp.",
       inputSchema: {
         type: "object",
         properties: {
-          message: { type: "string", description: "Notification message text" },
+          message: {
+            type: "string",
+            description: "Visible notification text shown to the operator",
+            examples: ["Approval queue has 2 blocked actions", "GPU temperature exceeded threshold"],
+          },
           action: {
             type: "object",
             description: "Optional action button attached to the notification",
             properties: {
-              label: { type: "string", description: "Button label" },
-              tool: { type: "string", description: "MCP tool name to invoke on click" },
-              args: { description: "Arguments to pass to the tool" },
+              label: {
+                type: "string",
+                description: "Button label shown in the notification UI",
+                examples: ["Review approvals", "Open audit"],
+              },
+              tool: {
+                type: "string",
+                description: "MCP tool name to invoke when the button is clicked",
+                examples: ["sint__pending", "sint__approve"],
+              },
+              args: {
+                description: "Arguments passed to the MCP tool when the action button is clicked",
+              },
             },
             required: ["label", "tool", "args"],
+            additionalProperties: false,
           },
         },
         required: ["message"],
+        additionalProperties: false,
       },
     },
     {
       name: "sint__interface_mode",
       description:
-        "Change the operator interface display mode: hud, compact, voice-only, or silent",
+        "Change how the operator interface presents information. Use this when the situation calls for a denser HUD, a minimal compact view, spoken output only, or silence. Returns a JSON confirmation with the new mode and timestamp.",
       inputSchema: {
         type: "object",
         properties: {
           mode: {
             type: "string",
             enum: ["hud", "compact", "voice-only", "silent"],
-            description: "Target interface mode",
+            description: "Target operator interface mode",
           },
         },
         required: ["mode"],
+        additionalProperties: false,
       },
     },
   ];

--- a/apps/sint-mcp/src/tools/sint-tools.ts
+++ b/apps/sint-mcp/src/tools/sint-tools.ts
@@ -23,116 +23,194 @@ export function getSintToolDefinitions(): Array<{
   return [
     {
       name: "sint__status",
-      description: "Show SINT MCP status: connected servers, agent identity, queue size, and system health",
-      inputSchema: { type: "object", properties: {}, required: [] },
+      description:
+        "Inspect the current SINT runtime state before taking action. Use this to confirm the server is healthy, see how many downstream servers are connected, and check pending approvals. Returns a JSON status summary with server counts, aggregated tools, pending approvals, and ledger size.",
+      inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
     },
     {
       name: "sint__servers",
-      description: "List all downstream MCP servers with connection status, tool counts, and health",
-      inputSchema: { type: "object", properties: {}, required: [] },
+      description:
+        "List all configured downstream MCP servers and their live connection state. Use this when you need to know which servers are connected, how many tools they expose, or whether an upstream integration is unavailable. Returns a JSON array of server health summaries.",
+      inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
     },
     {
       name: "sint__whoami",
-      description: "Show current agent identity: public key, active token, session info",
-      inputSchema: { type: "object", properties: {}, required: [] },
+      description:
+        "Show the active SINT identity for the current session. Use this before issuing tokens, approving requests, or debugging delegation so you can confirm the acting public key and token context. Returns a JSON object with the current public key, token ID, and role.",
+      inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
     },
     {
       name: "sint__pending",
-      description: "List all pending approval requests awaiting human review",
-      inputSchema: { type: "object", properties: {}, required: [] },
+      description:
+        "List approval requests that are blocked waiting for review. Use this before calling sint__approve or sint__deny so you can inspect request IDs, affected resources, actions, and expiration times. Returns a JSON array of pending approval summaries.",
+      inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
     },
     {
       name: "sint__approve",
-      description: "Approve a pending escalated action by its request ID",
+      description:
+        "Approve one pending escalated action after a human or operator review. Use this only with a requestId returned by sint__pending; approval releases the blocked action for execution. Returns a confirmation message, or an error if the request does not exist.",
       inputSchema: {
         type: "object",
         properties: {
-          requestId: { type: "string", description: "The approval request ID to approve" },
-          by: { type: "string", description: "Identifier of the approver (default: current agent)" },
+          requestId: {
+            type: "string",
+            description: "Approval request ID returned by sint__pending",
+            examples: ["apr_01hxyz..."],
+          },
+          by: {
+            type: "string",
+            description: "Human or operator identifier recorded as the approver; defaults to the current agent identity",
+            examples: ["alice@example.com", "ops-console"],
+          },
         },
         required: ["requestId"],
+        additionalProperties: false,
       },
     },
     {
       name: "sint__deny",
-      description: "Deny a pending escalated action by its request ID",
+      description:
+        "Reject one pending escalated action so it cannot proceed. Use this after review when the request is unsafe, out of policy, or no longer needed. Returns a confirmation message, or an error if the request ID is unknown.",
       inputSchema: {
         type: "object",
         properties: {
-          requestId: { type: "string", description: "The approval request ID to deny" },
-          reason: { type: "string", description: "Reason for denial" },
-          by: { type: "string", description: "Identifier of the denier (default: current agent)" },
+          requestId: {
+            type: "string",
+            description: "Approval request ID returned by sint__pending",
+            examples: ["apr_01hxyz..."],
+          },
+          reason: {
+            type: "string",
+            description: "Human-readable reason recorded in the audit trail and returned to the caller",
+            examples: ["Outside approved maintenance window"],
+          },
+          by: {
+            type: "string",
+            description: "Human or operator identifier recorded as the denying actor; defaults to the current agent identity",
+            examples: ["alice@example.com", "ops-console"],
+          },
         },
         required: ["requestId"],
+        additionalProperties: false,
       },
     },
     {
       name: "sint__audit",
-      description: "Query the SINT evidence ledger for recent decisions and events",
+      description:
+        "Read recent events from the SINT evidence ledger for debugging, compliance review, or operator context. Use this to inspect approvals, revocations, notifications, and other recorded actions without mutating state. Returns a JSON array of the most recent ledger events.",
       inputSchema: {
         type: "object",
         properties: {
-          limit: { type: "number", description: "Max events to return (default: 20)" },
+          limit: {
+            type: "number",
+            description: "Maximum number of newest ledger events to return; defaults to 20",
+            minimum: 1,
+            examples: [10, 50],
+          },
         },
         required: [],
+        additionalProperties: false,
       },
     },
     {
       name: "sint__add_server",
-      description: "Dynamically add a new downstream MCP server at runtime",
+      description:
+        "Register and connect a new downstream MCP server while SINT is running. Use this to aggregate a new stdio server into the proxy without restarting the process. Returns a confirmation message including the discovered tool count when the connection succeeds.",
       inputSchema: {
         type: "object",
         properties: {
-          name: { type: "string", description: "Unique name for the server" },
-          command: { type: "string", description: "Command to spawn the server" },
+          name: {
+            type: "string",
+            description: "Unique short name used as the server prefix for aggregated tools",
+            examples: ["filesystem", "github"],
+          },
+          command: {
+            type: "string",
+            description: "Executable used to start the downstream stdio server",
+            examples: ["npx", "node"],
+          },
           args: {
             type: "array",
             items: { type: "string" },
-            description: "Arguments for the command",
+            description: "Optional command arguments passed to the downstream server process",
+            examples: [["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]],
           },
         },
         required: ["name", "command"],
+        additionalProperties: false,
       },
     },
     {
       name: "sint__remove_server",
-      description: "Remove a downstream MCP server by name",
+      description:
+        "Disconnect and remove one downstream MCP server from the running proxy. Use this to disable an integration cleanly when it is unhealthy, no longer needed, or should stop exposing tools. Returns a confirmation message after removal.",
       inputSchema: {
         type: "object",
         properties: {
-          name: { type: "string", description: "Name of the server to remove" },
+          name: {
+            type: "string",
+            description: "Server name as listed by sint__servers",
+            examples: ["filesystem", "github"],
+          },
         },
         required: ["name"],
+        additionalProperties: false,
       },
     },
     {
       name: "sint__issue_token",
-      description: "Issue a new capability token with restricted scope (admin). Returns tokenId on success.",
+      description:
+        "Issue a new attenuated capability token for another subject. Use this for controlled delegation or integration setup when a new actor needs scoped access to a resource and action set. Returns a JSON object with the new token ID, subject, resource, actions, and expiry.",
       inputSchema: {
         type: "object",
         properties: {
-          subject: { type: "string", description: "Public key of the token subject" },
-          resource: { type: "string", description: "Resource URI pattern (e.g. 'mcp://filesystem/*')" },
+          subject: {
+            type: "string",
+            description: "Public key or subject identifier that will own the new token",
+            examples: ["ed25519:abc123...", "agent:planner-01"],
+          },
+          resource: {
+            type: "string",
+            description: "Resource URI pattern the token may access",
+            examples: ["mcp://filesystem/*", "mcp://github/repos/sint-ai/*"],
+          },
           actions: {
             type: "array",
             items: { type: "string" },
-            description: "Allowed actions (e.g. ['call', 'exec.run'])",
+            description: "Allowed actions for the token on that resource",
+            examples: [["call"], ["call", "exec.run"]],
           },
-          expiresInHours: { type: "number", description: "Token lifetime in hours (default: 24)" },
+          expiresInHours: {
+            type: "number",
+            description: "Token lifetime in hours; defaults to 24",
+            minimum: 1,
+            examples: [1, 24, 168],
+          },
         },
         required: ["subject", "resource", "actions"],
+        additionalProperties: false,
       },
     },
     {
       name: "sint__revoke_token",
-      description: "Revoke an active capability token by its ID (admin)",
+      description:
+        "Revoke an active capability token so it can no longer authorize actions. Use this when access should end immediately because of policy change, incident response, or delegation cleanup. Returns a confirmation message and records the revocation in the ledger.",
       inputSchema: {
         type: "object",
         properties: {
-          tokenId: { type: "string", description: "ID of the token to revoke" },
-          reason: { type: "string", description: "Reason for revocation" },
+          tokenId: {
+            type: "string",
+            description: "Token ID to revoke",
+            examples: ["tok_01hxyz..."],
+          },
+          reason: {
+            type: "string",
+            description: "Reason recorded in the revocation store and ledger",
+            examples: ["Compromised credentials", "Delegation no longer needed"],
+          },
         },
         required: ["tokenId"],
+        additionalProperties: false,
       },
     },
   ];

--- a/glama.json
+++ b/glama.json
@@ -25,87 +25,87 @@
   "tools": [
     {
       "name": "sint__status",
-      "description": "Show SINT MCP status: connected servers, agent identity, queue size, and system health"
+      "description": "Inspect the current SINT runtime state before taking action. Returns a JSON summary with server connectivity, aggregated tool counts, pending approvals, and ledger size."
     },
     {
       "name": "sint__servers",
-      "description": "List all downstream MCP servers with connection status, tool counts, and health"
+      "description": "List configured downstream MCP servers and their live connection state. Returns a JSON array with server names, health, and discovered tool counts."
     },
     {
       "name": "sint__whoami",
-      "description": "Show current agent identity: public key, active token, session info"
+      "description": "Show the active SINT identity for the current session. Returns the acting public key, token ID, and role."
     },
     {
       "name": "sint__pending",
-      "description": "List all pending approval requests awaiting human review"
+      "description": "List approval requests currently blocked for review. Use this before sint__approve or sint__deny; returns a JSON array of request IDs, resources, actions, reasons, and expiry times."
     },
     {
       "name": "sint__approve",
-      "description": "Approve a pending escalated action by its request ID"
+      "description": "Approve one pending escalated action after review. Requires a requestId from sint__pending and returns confirmation or an error if the request is missing."
     },
     {
       "name": "sint__deny",
-      "description": "Deny a pending escalated action by its request ID"
+      "description": "Reject one pending escalated action so it cannot proceed. Requires a requestId from sint__pending and optionally records a denial reason."
     },
     {
       "name": "sint__audit",
-      "description": "Query the SINT evidence ledger for recent decisions and events"
+      "description": "Read recent events from the SINT evidence ledger for debugging, compliance review, or operator context. Returns a JSON array of recent ledger events."
     },
     {
       "name": "sint__add_server",
-      "description": "Dynamically add a new downstream MCP server at runtime"
+      "description": "Register and connect a new downstream MCP server while SINT is running. Requires a unique server name and startup command, and returns the discovered tool count on success."
     },
     {
       "name": "sint__remove_server",
-      "description": "Remove a downstream MCP server by name"
+      "description": "Disconnect and remove one downstream MCP server from the running proxy. Requires the server name as listed by sint__servers."
     },
     {
       "name": "sint__issue_token",
-      "description": "Issue a new capability token with specified permissions and constraints"
+      "description": "Issue a new attenuated capability token for another subject. Requires subject, resource, and actions, and returns token metadata including tokenId and expiry."
     },
     {
       "name": "sint__revoke_token",
-      "description": "Revoke an active capability token"
+      "description": "Revoke an active capability token so it can no longer authorize actions. Requires tokenId and records the reason in the audit trail."
     },
     {
       "name": "sint__interface_status",
-      "description": "Show operator interface session state and mode"
+      "description": "Inspect the current operator interface state. Returns a JSON snapshot with mode, HUD panel state, and session context."
     },
     {
       "name": "sint__recall_memory",
-      "description": "Recall stored agent memory by key or search"
+      "description": "Search the operator memory bank for relevant stored context. Requires a query string and returns matching memory entries as JSON."
     },
     {
       "name": "sint__store_memory",
-      "description": "Store a key-value memory entry for agent persistence"
+      "description": "Store structured context in the operator memory bank for later retrieval. Requires key and value, with optional tags and persistence."
     },
     {
       "name": "sint__speak",
-      "description": "Send a message to the operator interface"
+      "description": "Send text-to-speech output to the operator interface. Requires short text and optionally a priority level."
     },
     {
       "name": "sint__show_hud",
-      "description": "Display a HUD overlay on the operator interface"
+      "description": "Show or refresh one HUD panel in the operator interface. Requires a target panel and optionally includes JSON data for that panel."
     },
     {
       "name": "sint__notify",
-      "description": "Send a notification to the operator"
+      "description": "Send a proactive notification to the operator interface, optionally with one action button that invokes another MCP tool."
     },
     {
       "name": "sint__interface_mode",
-      "description": "Switch operator interface mode (autonomous, supervised, manual)"
+      "description": "Change how the operator interface presents information. Requires one of hud, compact, voice-only, or silent."
     },
     {
       "name": "sint__delegate_to_agent",
-      "description": "Delegate a task to another agent with scoped capability token"
+      "description": "Issue a delegated capability token to a sub-agent with narrower scope than the current token. Returns token metadata including depth and expiry."
     },
     {
       "name": "sint__list_delegations",
-      "description": "List active delegation chains from this agent"
+      "description": "List the active delegation tree rooted at the current token. Returns a JSON array of delegation nodes and scope relationships."
     },
     {
       "name": "sint__revoke_delegation_tree",
-      "description": "Revoke an entire delegation subtree by root token"
+      "description": "Cascade-revoke a delegated token and all of its descendants. Requires the root delegated token ID and optionally a revocation reason."
     }
   ]
 }


### PR DESCRIPTION
Expands SINT MCP tool descriptions and JSON Schemas so Glama has richer behavior, purpose, parameter, and usage guidance to score.

Changes include:
- clearer tool descriptions that explain when to use each tool and what it returns
- tighter parameter schemas with additionalProperties=false
- examples and minimums for key numeric and string inputs
- aligned Glama metadata descriptions for the same tools