### PR TITLE
Polish low-score MCP tool metadata

### DIFF
--- a/apps/sint-mcp/src/tools/delegation-tools.ts
+++ b/apps/sint-mcp/src/tools/delegation-tools.ts
@@ -69,8 +69,8 @@ export function getDelegationToolDefinitions(): Array<{
     {
       name: "sint__list_delegations",
       description:
-        "List the active delegation tree rooted at the current token. Use this to audit which sub-agents currently hold delegated access, how deep the tree is, and what scope has been passed down. Returns a JSON array of delegation nodes.",
-      inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
+        "List the active delegation tree rooted at the current token. Use this to audit which sub-agents currently hold delegated access, how deep the tree is, and what scope has been passed down. This tool is read-only and returns a JSON array of delegation nodes.",
+      inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false, examples: [{}] },
     },
     {
       name: "sint__revoke_delegation_tree",

--- a/apps/sint-mcp/src/tools/interface-tools.ts
+++ b/apps/sint-mcp/src/tools/interface-tools.ts
@@ -37,125 +37,151 @@ export function getInterfaceToolDefinitions(): Array<{
     {
       name: "sint__recall_memory",
       description:
-        "Search the operator memory bank for relevant stored context. Use this before asking for human input again or when you need prior decisions, notes, or context by keyword. Returns matching memory entries as JSON.",
+        "Search the operator memory bank for relevant stored context. Use this before asking for human input again or when you need prior decisions, notes, or context by keyword. This tool does not mutate memory and returns matching entries as JSON.",
       inputSchema: {
         type: "object",
         properties: {
           query: {
+            title: "Search query",
             type: "string",
             description: "Search string used to match memory keys, tags, or content",
+            minLength: 1,
             examples: ["deployment approval", "customer abc", "incident 42"],
           },
           limit: {
+            title: "Result limit",
             type: "number",
             description: "Maximum number of matches to return; defaults to 10",
             minimum: 1,
+            default: 10,
             examples: [5, 10, 25],
           },
         },
         required: ["query"],
         additionalProperties: false,
+        examples: [{ query: "incident 42", limit: 5 }],
       },
     },
     {
       name: "sint__speak",
       description:
-        "Send text-to-speech output to the operator interface. Use this for spoken alerts or short status updates that need immediate attention; prefer concise text because the content is voiced aloud. Returns a JSON confirmation with the spoken text and priority.",
+        "Send text-to-speech output to the operator interface. Use this for spoken alerts or short status updates that need immediate attention; prefer concise text because the content is voiced aloud. Returns a JSON confirmation with the spoken text, priority, and timestamp.",
       inputSchema: {
         type: "object",
         properties: {
           text: {
+            title: "Spoken text",
             type: "string",
             description: "Short text that will be spoken aloud to the operator",
+            minLength: 1,
             examples: ["Approval needed for production deploy", "Battery level critical"],
           },
           priority: {
+            title: "Priority",
             type: "string",
             enum: ["low", "normal", "urgent"],
             description: "Voice output priority; defaults to normal",
+            default: "normal",
           },
         },
         required: ["text"],
         additionalProperties: false,
+        examples: [{ text: "Approval needed for production deploy", priority: "urgent" }],
       },
     },
     {
       name: "sint__show_hud",
       description:
-        "Show or refresh one HUD panel in the operator interface. Use this to surface approvals, audit details, context, or memory on screen; this updates the live interface but does not persist business data. Returns a JSON confirmation describing which panel was updated.",
+        "Show or refresh one HUD panel in the operator interface. Use this to surface approvals, audit details, context, or memory on screen; this updates the live interface but does not persist business data. Returns a JSON confirmation describing which panel was updated and when.",
       inputSchema: {
         type: "object",
         properties: {
           panel: {
+            title: "HUD panel",
             type: "string",
             enum: ["approvals", "audit", "context", "memory"],
             description: "HUD panel to display or refresh",
           },
           data: {
+            title: "Panel payload",
             description: "Optional JSON payload for the panel; useful for supplying custom context alongside the panel change",
           },
         },
         required: ["panel"],
         additionalProperties: false,
+        examples: [{ panel: "approvals" }, { panel: "context", data: { stage: "deploy", owner: "ops" } }],
       },
     },
     {
       name: "sint__store_memory",
       description:
-        "Store structured context in the operator memory bank for later retrieval. Use this for durable notes, human preferences, incident breadcrumbs, or other context worth recalling later. Returns a JSON confirmation with the stored key and persistence state.",
+        "Store structured context in the operator memory bank for later retrieval. Use this for durable notes, human preferences, incident breadcrumbs, or other context worth recalling later. Returns a JSON confirmation with the stored key, persistence state, and any ledger event identifier.",
       inputSchema: {
         type: "object",
         properties: {
           key: {
+            title: "Memory key",
             type: "string",
             description: "Stable unique key for the memory entry",
+            minLength: 1,
             examples: ["incident-42/root-cause", "customer/acme/preference"],
           },
           value: {
+            title: "Memory value",
             description: "Any JSON value to persist under the key",
           },
           tags: {
+            title: "Tags",
             type: "array",
             items: { type: "string" },
             description: "Optional tags used for categorization and later search",
             examples: [["incident", "prod"], ["customer", "billing"]],
           },
           persist: {
+            title: "Persist beyond session",
             type: "boolean",
             description: "Whether the entry should persist beyond the current session; defaults to false",
+            default: false,
           },
         },
         required: ["key", "value"],
         additionalProperties: false,
+        examples: [{ key: "incident-42/root-cause", value: { service: "gateway", summary: "Token scope mismatch" }, tags: ["incident", "prod"], persist: true }],
       },
     },
     {
       name: "sint__notify",
       description:
-        "Send a proactive notification to the operator interface, optionally with one follow-up action button. Use this for alerts or prompts that should remain visible in the UI; this is better than sint__speak when the operator needs something clickable or persistent. Returns a JSON confirmation with the notification timestamp.",
+        "Send a proactive notification to the operator interface, optionally with one follow-up action button. Use this for alerts or prompts that should remain visible in the UI; this is better than sint__speak when the operator needs something clickable or persistent. Returns a JSON confirmation with the notification timestamp and echoed message.",
       inputSchema: {
         type: "object",
         properties: {
           message: {
+            title: "Notification message",
             type: "string",
             description: "Visible notification text shown to the operator",
+            minLength: 1,
             examples: ["Approval queue has 2 blocked actions", "GPU temperature exceeded threshold"],
           },
           action: {
+            title: "Optional action button",
             type: "object",
             description: "Optional action button attached to the notification",
             properties: {
               label: {
+                title: "Button label",
                 type: "string",
                 description: "Button label shown in the notification UI",
                 examples: ["Review approvals", "Open audit"],
               },
               tool: {
+                title: "Tool to invoke",
                 type: "string",
                 description: "MCP tool name to invoke when the button is clicked",
                 examples: ["sint__pending", "sint__approve"],
               },
               args: {
+                title: "Tool arguments",
                 description: "Arguments passed to the MCP tool when the action button is clicked",
               },
             },
@@ -165,6 +191,7 @@ export function getInterfaceToolDefinitions(): Array<{
         },
         required: ["message"],
         additionalProperties: false,
+        examples: [{ message: "Approval queue has blocked actions", action: { label: "Review approvals", tool: "sint__pending", args: {} } }],
       },
     },
     {

--- a/apps/sint-mcp/src/tools/sint-tools.ts
+++ b/apps/sint-mcp/src/tools/sint-tools.ts
@@ -42,22 +42,31 @@ export function getSintToolDefinitions(): Array<{
     {
       name: "sint__pending",
       description:
-        "List approval requests that are blocked waiting for review. Use this before calling sint__approve or sint__deny so you can inspect request IDs, affected resources, actions, and expiration times. Returns a JSON array of pending approval summaries.",
-      inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
+        "List approval requests that are blocked waiting for review. Use this before calling sint__approve or sint__deny so you can inspect request IDs, affected resources, actions, reasons, and expiration times. This tool does not mutate state and returns a JSON array of pending approval summaries.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        required: [],
+        additionalProperties: false,
+        examples: [{}],
+      },
     },
     {
       name: "sint__approve",
       description:
-        "Approve one pending escalated action after a human or operator review. Use this only with a requestId returned by sint__pending; approval releases the blocked action for execution. Returns a confirmation message, or an error if the request does not exist.",
+        "Approve one pending escalated action after human or operator review. Use this only with a requestId returned by sint__pending; approval releases the blocked action for execution and records the approver identity. Returns a confirmation message, or an error if the request does not exist.",
       inputSchema: {
         type: "object",
         properties: {
           requestId: {
+            title: "Approval request ID",
             type: "string",
             description: "Approval request ID returned by sint__pending",
+            minLength: 1,
             examples: ["apr_01hxyz..."],
           },
           by: {
+            title: "Approver",
             type: "string",
             description: "Human or operator identifier recorded as the approver; defaults to the current agent identity",
             examples: ["alice@example.com", "ops-console"],
@@ -65,26 +74,31 @@ export function getSintToolDefinitions(): Array<{
         },
         required: ["requestId"],
         additionalProperties: false,
+        examples: [{ requestId: "apr_01hxyz...", by: "ops-console" }],
       },
     },
     {
       name: "sint__deny",
       description:
-        "Reject one pending escalated action so it cannot proceed. Use this after review when the request is unsafe, out of policy, or no longer needed. Returns a confirmation message, or an error if the request ID is unknown.",
+        "Reject one pending escalated action so it cannot proceed. Use this after review when the request is unsafe, out of policy, or no longer needed; the denial reason is recorded in the audit trail. Returns a confirmation message, or an error if the request ID is unknown.",
       inputSchema: {
         type: "object",
         properties: {
           requestId: {
+            title: "Approval request ID",
             type: "string",
             description: "Approval request ID returned by sint__pending",
+            minLength: 1,
             examples: ["apr_01hxyz..."],
           },
           reason: {
+            title: "Denial reason",
             type: "string",
             description: "Human-readable reason recorded in the audit trail and returned to the caller",
             examples: ["Outside approved maintenance window"],
           },
           by: {
+            title: "Denying actor",
             type: "string",
             description: "Human or operator identifier recorded as the denying actor; defaults to the current agent identity",
             examples: ["alice@example.com", "ops-console"],
@@ -92,44 +106,53 @@ export function getSintToolDefinitions(): Array<{
         },
         required: ["requestId"],
         additionalProperties: false,
+        examples: [{ requestId: "apr_01hxyz...", reason: "Outside approved maintenance window", by: "alice@example.com" }],
       },
     },
     {
       name: "sint__audit",
       description:
-        "Read recent events from the SINT evidence ledger for debugging, compliance review, or operator context. Use this to inspect approvals, revocations, notifications, and other recorded actions without mutating state. Returns a JSON array of the most recent ledger events.",
+        "Read recent events from the SINT evidence ledger for debugging, compliance review, or operator context. Use this to inspect approvals, revocations, notifications, and other recorded actions without mutating state. Returns a JSON array of the newest ledger events, ordered from oldest to newest within the requested slice.",
       inputSchema: {
         type: "object",
         properties: {
           limit: {
+            title: "Event limit",
             type: "number",
             description: "Maximum number of newest ledger events to return; defaults to 20",
             minimum: 1,
+            default: 20,
             examples: [10, 50],
           },
         },
         required: [],
         additionalProperties: false,
+        examples: [{ limit: 10 }],
       },
     },
     {
       name: "sint__add_server",
       description:
-        "Register and connect a new downstream MCP server while SINT is running. Use this to aggregate a new stdio server into the proxy without restarting the process. Returns a confirmation message including the discovered tool count when the connection succeeds.",
+        "Register and connect a new downstream MCP server while SINT is running. Use this to aggregate a new stdio server into the proxy without restarting the process; on success the server is immediately available through the aggregated tool namespace. Returns a confirmation message including the discovered tool count, or an error message if connection fails.",
       inputSchema: {
         type: "object",
         properties: {
           name: {
+            title: "Server name",
             type: "string",
             description: "Unique short name used as the server prefix for aggregated tools",
+            minLength: 1,
             examples: ["filesystem", "github"],
           },
           command: {
+            title: "Startup command",
             type: "string",
             description: "Executable used to start the downstream stdio server",
+            minLength: 1,
             examples: ["npx", "node"],
           },
           args: {
+            title: "Command arguments",
             type: "array",
             items: { type: "string" },
             description: "Optional command arguments passed to the downstream server process",
@@ -138,72 +161,88 @@ export function getSintToolDefinitions(): Array<{
         },
         required: ["name", "command"],
         additionalProperties: false,
+        examples: [{ name: "filesystem", command: "npx", args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"] }],
       },
     },
     {
       name: "sint__remove_server",
       description:
-        "Disconnect and remove one downstream MCP server from the running proxy. Use this to disable an integration cleanly when it is unhealthy, no longer needed, or should stop exposing tools. Returns a confirmation message after removal.",
+        "Disconnect and remove one downstream MCP server from the running proxy. Use this to disable an integration cleanly when it is unhealthy, no longer needed, or should stop exposing tools; after removal its aggregated tools disappear from the namespace. Returns a confirmation message after removal, or an error if the server name is unknown.",
       inputSchema: {
         type: "object",
         properties: {
           name: {
+            title: "Server name",
             type: "string",
             description: "Server name as listed by sint__servers",
+            minLength: 1,
             examples: ["filesystem", "github"],
           },
         },
         required: ["name"],
         additionalProperties: false,
+        examples: [{ name: "filesystem" }],
       },
     },
     {
       name: "sint__issue_token",
       description:
-        "Issue a new attenuated capability token for another subject. Use this for controlled delegation or integration setup when a new actor needs scoped access to a resource and action set. Returns a JSON object with the new token ID, subject, resource, actions, and expiry.",
+        "Issue a new attenuated capability token for another subject. Use this for controlled delegation or integration setup when a new actor needs scoped access to a resource and action set; the new token is stored immediately and recorded in the ledger. Returns a JSON object with the new token ID, subject, resource, actions, and expiry.",
       inputSchema: {
         type: "object",
         properties: {
           subject: {
+            title: "Token subject",
             type: "string",
             description: "Public key or subject identifier that will own the new token",
+            minLength: 1,
             examples: ["ed25519:abc123...", "agent:planner-01"],
           },
           resource: {
+            title: "Resource pattern",
             type: "string",
             description: "Resource URI pattern the token may access",
+            minLength: 1,
             examples: ["mcp://filesystem/*", "mcp://github/repos/sint-ai/*"],
           },
           actions: {
+            title: "Allowed actions",
             type: "array",
             items: { type: "string" },
             description: "Allowed actions for the token on that resource",
+            minItems: 1,
             examples: [["call"], ["call", "exec.run"]],
           },
           expiresInHours: {
+            title: "Lifetime in hours",
             type: "number",
             description: "Token lifetime in hours; defaults to 24",
             minimum: 1,
+            default: 24,
             examples: [1, 24, 168],
           },
         },
         required: ["subject", "resource", "actions"],
         additionalProperties: false,
+        examples: [{ subject: "agent:planner-01", resource: "mcp://github/repos/sint-ai/sint-protocol/*", actions: ["call"], expiresInHours: 24 }],
       },
     },
     {
       name: "sint__revoke_token",
       description:
-        "Revoke an active capability token so it can no longer authorize actions. Use this when access should end immediately because of policy change, incident response, or delegation cleanup. Returns a confirmation message and records the revocation in the ledger.",
+        "Revoke an active capability token so it can no longer authorize actions. Use this when access should end immediately because of policy change, incident response, or delegation cleanup; the revocation is written to both the revocation store and the ledger. Returns a confirmation message.",
       inputSchema: {
         type: "object",
         properties: {
           tokenId: {
+            title: "Token ID",
             type: "string",
             description: "Token ID to revoke",
+            minLength: 1,
             examples: ["tok_01hxyz..."],
           },
           reason: {
+            title: "Revocation reason",
             type: "string",
             description: "Reason recorded in the revocation store and ledger",
             examples: ["Compromised credentials", "Delegation no longer needed"],
@@ -211,6 +250,7 @@ export function getSintToolDefinitions(): Array<{
         },
         required: ["tokenId"],
         additionalProperties: false,
+        examples: [{ tokenId: "tok_01hxyz...", reason: "Delegation no longer needed" }],
       },
     },
   ];

--- a/glama.json
+++ b/glama.json
@@ -37,11 +37,11 @@
     },
     {
       "name": "sint__pending",
-      "description": "List approval requests currently blocked for review. Use this before sint__approve or sint__deny; returns a JSON array of request IDs, resources, actions, reasons, and expiry times."
+      "description": "List approval requests currently blocked for review. Read-only. Use this before sint__approve or sint__deny; returns a JSON array of request IDs, resources, actions, reasons, and expiry times."
     },
     {
       "name": "sint__approve",
-      "description": "Approve one pending escalated action after review. Requires a requestId from sint__pending and returns confirmation or an error if the request is missing."
+      "description": "Approve one pending escalated action after review. Requires a requestId from sint__pending, records the approver identity, and returns confirmation or an error if the request is missing."
     },
     {
       "name": "sint__deny",
@@ -49,23 +49,23 @@
     },
     {
       "name": "sint__audit",
-      "description": "Read recent events from the SINT evidence ledger for debugging, compliance review, or operator context. Returns a JSON array of recent ledger events."
+      "description": "Read recent events from the SINT evidence ledger for debugging, compliance review, or operator context. Read-only. Returns a JSON array of recent ledger events."
     },
     {
       "name": "sint__add_server",
-      "description": "Register and connect a new downstream MCP server while SINT is running. Requires a unique server name and startup command, and returns the discovered tool count on success."
+      "description": "Register and connect a new downstream MCP server while SINT is running. Requires a unique server name and startup command, and returns the discovered tool count on success or an error if connection fails."
     },
     {
       "name": "sint__remove_server",
-      "description": "Disconnect and remove one downstream MCP server from the running proxy. Requires the server name as listed by sint__servers."
+      "description": "Disconnect and remove one downstream MCP server from the running proxy. Requires the server name as listed by sint__servers and returns confirmation or an error if the name is unknown."
     },
     {
       "name": "sint__issue_token",
-      "description": "Issue a new attenuated capability token for another subject. Requires subject, resource, and actions, and returns token metadata including tokenId and expiry."
+      "description": "Issue a new attenuated capability token for another subject. Requires subject, resource, and actions, stores the token immediately, and returns token metadata including tokenId and expiry."
     },
     {
       "name": "sint__revoke_token",
-      "description": "Revoke an active capability token so it can no longer authorize actions. Requires tokenId and records the reason in the audit trail."
+      "description": "Revoke an active capability token so it can no longer authorize actions. Requires tokenId, records the reason in the audit trail, and returns a confirmation message."
     },
     {
       "name": "sint__interface_status",
@@ -73,7 +73,7 @@
     },
     {
       "name": "sint__recall_memory",
-      "description": "Search the operator memory bank for relevant stored context. Requires a query string and returns matching memory entries as JSON."
+      "description": "Search the operator memory bank for relevant stored context. Read-only. Requires a query string and returns matching memory entries as JSON."
     },
     {
       "name": "sint__store_memory",
@@ -85,11 +85,11 @@
     },
     {
       "name": "sint__show_hud",
-      "description": "Show or refresh one HUD panel in the operator interface. Requires a target panel and optionally includes JSON data for that panel."
+      "description": "Show or refresh one HUD panel in the operator interface. Requires a target panel and optionally accepts JSON data for that panel. Returns a confirmation payload with the panel name and timestamp."
     },
     {
       "name": "sint__notify",
-      "description": "Send a proactive notification to the operator interface, optionally with one action button that invokes another MCP tool."
+      "description": "Send a proactive notification to the operator interface, optionally with one action button that invokes another MCP tool. Returns a confirmation payload with the notification timestamp."
     },
     {
       "name": "sint__interface_mode",
@@ -101,7 +101,7 @@
     },
     {
       "name": "sint__list_delegations",
-      "description": "List the active delegation tree rooted at the current token. Returns a JSON array of delegation nodes and scope relationships."
+      "description": "List the active delegation tree rooted at the current token. Read-only. Returns a JSON array of delegation nodes and scope relationships."
     },
     {
       "name": "sint__revoke_delegation_tree",


### PR DESCRIPTION
Targets the remaining lower-scoring SINT MCP tools with richer metadata for Glama inspection.

This pass adds:
- root-level schema examples for low-scoring tools
- titles, defaults, minLength, and minItems on important parameters
- clearer descriptions for side effects, return payloads, and read-only behavior
- matching wording updates in glama.json for the same tools