### PR TITLE
Add MCP behavior annotations for tool scoring

### DIFF
--- a/apps/sint-mcp/src/tools/delegation-tools.ts
+++ b/apps/sint-mcp/src/tools/delegation-tools.ts
@@ -29,6 +29,7 @@ export function getDelegationToolDefinitions(): Array<{
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
+  annotations?: Record<string, unknown>;
 }> {
   return [
     {
@@ -65,12 +66,14 @@ export function getDelegationToolDefinitions(): Array<{
         required: ["subagentId", "toolScope"],
         additionalProperties: false,
       },
+      annotations: { title: "Delegate To Agent", destructiveHint: false, idempotentHint: false, openWorldHint: false },
     },
     {
       name: "sint__list_delegations",
       description:
         "List the active delegation tree rooted at the current token. Use this to audit which sub-agents currently hold delegated access, how deep the tree is, and what scope has been passed down. This tool is read-only and returns a JSON array of delegation nodes.",
       inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false, examples: [{}] },
+      annotations: { title: "List Delegations", readOnlyHint: true, idempotentHint: true, openWorldHint: false },
     },
     {
       name: "sint__revoke_delegation_tree",
@@ -93,6 +96,7 @@ export function getDelegationToolDefinitions(): Array<{
         required: ["rootTokenId"],
         additionalProperties: false,
       },
+      annotations: { title: "Revoke Delegation Tree", destructiveHint: true, idempotentHint: false, openWorldHint: false },
     },
   ];
 }

--- a/apps/sint-mcp/src/tools/interface-tools.ts
+++ b/apps/sint-mcp/src/tools/interface-tools.ts
@@ -26,6 +26,7 @@ export function getInterfaceToolDefinitions(): Array<{
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
+  annotations?: Record<string, unknown>;
 }> {
   return [
     {
@@ -33,6 +34,7 @@ export function getInterfaceToolDefinitions(): Array<{
       description:
         "Inspect the current operator interface state before sending operator-facing updates. Use this to confirm the active mode, HUD panels, speaking/listening flags, and session context. Returns a JSON snapshot of the current interface state.",
       inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
+      annotations: { title: "Interface Status", readOnlyHint: true, idempotentHint: true, openWorldHint: false },
     },
     {
       name: "sint__recall_memory",
@@ -61,6 +63,7 @@ export function getInterfaceToolDefinitions(): Array<{
         additionalProperties: false,
         examples: [{ query: "incident 42", limit: 5 }],
       },
+      annotations: { title: "Recall Memory", readOnlyHint: true, idempotentHint: true, openWorldHint: false },
     },
     {
       name: "sint__speak",
@@ -88,6 +91,7 @@ export function getInterfaceToolDefinitions(): Array<{
         additionalProperties: false,
         examples: [{ text: "Approval needed for production deploy", priority: "urgent" }],
       },
+      annotations: { title: "Speak To Operator", destructiveHint: false, idempotentHint: false, openWorldHint: false },
     },
     {
       name: "sint__show_hud",
@@ -111,6 +115,7 @@ export function getInterfaceToolDefinitions(): Array<{
         additionalProperties: false,
         examples: [{ panel: "approvals" }, { panel: "context", data: { stage: "deploy", owner: "ops" } }],
       },
+      annotations: { title: "Show HUD Panel", destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
     {
       name: "sint__store_memory",
@@ -148,6 +153,7 @@ export function getInterfaceToolDefinitions(): Array<{
         additionalProperties: false,
         examples: [{ key: "incident-42/root-cause", value: { service: "gateway", summary: "Token scope mismatch" }, tags: ["incident", "prod"], persist: true }],
       },
+      annotations: { title: "Store Memory", destructiveHint: false, idempotentHint: false, openWorldHint: false },
     },
     {
       name: "sint__notify",
@@ -193,6 +199,7 @@ export function getInterfaceToolDefinitions(): Array<{
         additionalProperties: false,
         examples: [{ message: "Approval queue has blocked actions", action: { label: "Review approvals", tool: "sint__pending", args: {} } }],
       },
+      annotations: { title: "Send Notification", destructiveHint: false, idempotentHint: false, openWorldHint: false },
     },
     {
       name: "sint__interface_mode",
@@ -210,6 +217,7 @@ export function getInterfaceToolDefinitions(): Array<{
         required: ["mode"],
         additionalProperties: false,
       },
+      annotations: { title: "Change Interface Mode", destructiveHint: false, idempotentHint: true, openWorldHint: false },
     },
   ];
 }

--- a/apps/sint-mcp/src/tools/sint-tools.ts
+++ b/apps/sint-mcp/src/tools/sint-tools.ts
@@ -19,6 +19,7 @@ export function getSintToolDefinitions(): Array<{
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
+  annotations?: Record<string, unknown>;
 }> {
   return [
     {
@@ -26,18 +27,21 @@ export function getSintToolDefinitions(): Array<{
       description:
         "Inspect the current SINT runtime state before taking action. Use this to confirm the server is healthy, see how many downstream servers are connected, and check pending approvals. Returns a JSON status summary with server counts, aggregated tools, pending approvals, and ledger size.",
       inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
+      annotations: { title: "SINT Status", readOnlyHint: true, idempotentHint: true, openWorldHint: false },
     },
     {
       name: "sint__servers",
       description:
         "List all configured downstream MCP servers and their live connection state. Use this when you need to know which servers are connected, how many tools they expose, or whether an upstream integration is unavailable. Returns a JSON array of server health summaries.",
       inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
+      annotations: { title: "List Downstream Servers", readOnlyHint: true, idempotentHint: true, openWorldHint: false },
     },
     {
       name: "sint__whoami",
       description:
         "Show the active SINT identity for the current session. Use this before issuing tokens, approving requests, or debugging delegation so you can confirm the acting public key and token context. Returns a JSON object with the current public key, token ID, and role.",
       inputSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
+      annotations: { title: "Current Identity", readOnlyHint: true, idempotentHint: true, openWorldHint: false },
     },
     {
       name: "sint__pending",
@@ -50,6 +54,7 @@ export function getSintToolDefinitions(): Array<{
         additionalProperties: false,
         examples: [{}],
       },
+      annotations: { title: "List Pending Approvals", readOnlyHint: true, idempotentHint: true, openWorldHint: false },
     },
     {
       name: "sint__approve",
@@ -76,6 +81,7 @@ export function getSintToolDefinitions(): Array<{
         additionalProperties: false,
         examples: [{ requestId: "apr_01hxyz...", by: "ops-console" }],
       },
+      annotations: { title: "Approve Request", destructiveHint: false, idempotentHint: false, openWorldHint: false },
     },
     {
       name: "sint__deny",
@@ -108,6 +114,7 @@ export function getSintToolDefinitions(): Array<{
         additionalProperties: false,
         examples: [{ requestId: "apr_01hxyz...", reason: "Outside approved maintenance window", by: "alice@example.com" }],
       },
+      annotations: { title: "Deny Request", destructiveHint: true, idempotentHint: false, openWorldHint: false },
     },
     {
       name: "sint__audit",
@@ -129,6 +136,7 @@ export function getSintToolDefinitions(): Array<{
         additionalProperties: false,
         examples: [{ limit: 10 }],
       },
+      annotations: { title: "Read Audit Ledger", readOnlyHint: true, idempotentHint: true, openWorldHint: false },
     },
     {
       name: "sint__add_server",
@@ -163,6 +171,7 @@ export function getSintToolDefinitions(): Array<{
         additionalProperties: false,
         examples: [{ name: "filesystem", command: "npx", args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"] }],
       },
+      annotations: { title: "Add Downstream Server", destructiveHint: false, idempotentHint: false, openWorldHint: true },
     },
     {
       name: "sint__remove_server",
@@ -183,6 +192,7 @@ export function getSintToolDefinitions(): Array<{
         additionalProperties: false,
         examples: [{ name: "filesystem" }],
       },
+      annotations: { title: "Remove Downstream Server", destructiveHint: true, idempotentHint: false, openWorldHint: false },
     },
     {
       name: "sint__issue_token",
@@ -226,6 +236,7 @@ export function getSintToolDefinitions(): Array<{
         additionalProperties: false,
         examples: [{ subject: "agent:planner-01", resource: "mcp://github/repos/sint-ai/sint-protocol/*", actions: ["call"], expiresInHours: 24 }],
       },
+      annotations: { title: "Issue Capability Token", destructiveHint: false, idempotentHint: false, openWorldHint: false },
     },
     {
       name: "sint__revoke_token",
@@ -252,6 +263,7 @@ export function getSintToolDefinitions(): Array<{
         additionalProperties: false,
         examples: [{ tokenId: "tok_01hxyz...", reason: "Delegation no longer needed" }],
       },
+      annotations: { title: "Revoke Capability Token", destructiveHint: true, idempotentHint: false, openWorldHint: false },
     },
   ];
 }


### PR DESCRIPTION
Adds MCP-native behavior annotations to SINT MCP tool definitions, including readOnlyHint, destructiveHint, idempotentHint, and titles where appropriate.

This is aimed at Glama-style tool scoring clients that infer behavior and safety properties from standard MCP metadata.