### PR TITLE
[codex] Add SINT PDP interceptor scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ If you are an AI agent (Claude, GPT, Gemini, Cursor, etc.) working in this repo,
 | [`@sint/bridge-opcua`](packages/bridge-opcua) | OPC UA node/method mapping with safety-critical write/call promotion | 6 |
 | [`@sint/bridge-open-rmf`](packages/bridge-open-rmf) | Open-RMF fleet/facility mapping for warehouse dispatch workflows | 5 |
 | [`@sint/bridge-grpc`](packages/bridge-grpc) | gRPC service/method profile mapping with default tier assignment | 5 |
+| [`@sint/sint-pdp-interceptor`](packages/sint-pdp-interceptor) | Reference SEP-1763 PDP adapter for MCP interceptor hosts backed by `PolicyGateway.intercept()` | 5 |
 | [`@sint/bridge-economy`](packages/bridge-economy) | Economy bridge: balance, budget, trust, billing ports | 47 |
 | [`@sint/bridge-mavlink`](packages/bridge-mavlink) | MAVLink drone/UAV command bridge | 15 |
 | [`@sint/bridge-swarm`](packages/bridge-swarm) | Multi-robot swarm coordination bridge | 9 |

--- a/packages/sint-pdp-interceptor/README.md
+++ b/packages/sint-pdp-interceptor/README.md
@@ -1,0 +1,87 @@
+# `@pshkv/sint-pdp-interceptor`
+
+Reference SINT PDP adapter for SEP-1763 style MCP interceptor hosts.
+
+This package gives MCP hosts a thin `policy-pdp` interface on top of
+`PolicyGateway.intercept()`. The goal is to make SINT easy to plug into an
+interceptor framework without re-implementing SINT request construction.
+
+## What it does
+
+- adapts `caller_identity` into `SintRequest.agentId`
+- maps MCP call metadata into SINT `resource`, `action`, and `params`
+- forwards evaluation to `PolicyGateway.intercept()`
+- fails closed by default when the gateway is unavailable
+
+## Install
+
+```bash
+pnpm add @pshkv/sint-pdp-interceptor
+```
+
+## Usage
+
+```ts
+import { PolicyGateway } from "@pshkv/gate-policy-gateway";
+import { SINTPDPInterceptor } from "@pshkv/sint-pdp-interceptor";
+
+const gateway = new PolicyGateway({
+  resolveToken: async (tokenId) => tokenStore.get(tokenId),
+});
+
+const interceptor = new SINTPDPInterceptor({
+  gateway,
+  defaultTokenId: "0192f17e-7f7f-7000-8000-000000000001",
+});
+
+const result = await interceptor.evaluate({
+  caller_identity: "did:key:z6MkexampleAgent",
+  mcp_call: {
+    serverName: "filesystem",
+    toolName: "readFile",
+    params: { path: "/tmp/demo.txt" },
+  },
+});
+
+if (result.verdict === "allow") {
+  console.log("safe to proceed", result.decision);
+}
+```
+
+## Request shape
+
+`evaluate()` accepts a SEP-1763-style request envelope:
+
+```ts
+{
+  caller_identity: string,
+  mcp_call: {
+    serverName?: string,
+    toolName?: string,
+    method?: string,
+    resource?: string,
+    action?: string,
+    params?: Record<string, unknown>
+  },
+  context?: {
+    tokenId?: string,
+    physicalContext?: SintRequest["physicalContext"],
+    executionContext?: SintRequest["executionContext"],
+    recentActions?: readonly string[]
+  }
+}
+```
+
+If `resource` is not supplied, the adapter defaults to:
+
+```txt
+mcp://{serverName}/{toolName}
+```
+
+If `action` is not supplied, the adapter defaults to `call`.
+
+## Current milestone
+
+This scaffold focuses on the adapter package and the core request/decision flow.
+Bilateral receipts and the richer demo path are intentionally tracked as follow-on
+flagship issues so the first package stays simple and installable.

--- a/packages/sint-pdp-interceptor/__tests__/interceptor.test.ts
+++ b/packages/sint-pdp-interceptor/__tests__/interceptor.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import type { PolicyDecision, SintRequest } from "@pshkv/core";
+import { ApprovalTier, RiskTier } from "@pshkv/core";
+import { SINTPDPInterceptor } from "../src/interceptor.js";
+
+const timestamp = "2026-04-16T20:00:00.000Z";
+const requestId = "01963d6b-4100-7000-8000-000000000001";
+const tokenId = "01963d6b-4200-7000-8000-000000000001";
+
+function allowDecision(): PolicyDecision {
+  return {
+    requestId,
+    timestamp,
+    action: "allow",
+    assignedTier: ApprovalTier.T1_PREPARE,
+    assignedRisk: RiskTier.T1_WRITE_LOW,
+  };
+}
+
+describe("SINTPDPInterceptor", () => {
+  it("maps a SEP-1763 style request into a SINT gateway request", async () => {
+    let captured: SintRequest | undefined;
+
+    const interceptor = new SINTPDPInterceptor({
+      gateway: {
+        async intercept(request) {
+          captured = request;
+          return allowDecision();
+        },
+      },
+      defaultTokenId: tokenId,
+      now: () => timestamp,
+      createRequestId: () => requestId,
+    });
+
+    const result = await interceptor.evaluate({
+      caller_identity: "did:key:z6MkAgent",
+      mcp_call: {
+        serverName: "filesystem",
+        toolName: "readFile",
+        params: { path: "/tmp/demo.txt" },
+      },
+      context: {
+        recentActions: ["filesystem.listDirectory"],
+        physicalContext: { humanDetected: false },
+      },
+    });
+
+    expect(result.verdict).toBe("allow");
+    expect(result.tier).toBe(ApprovalTier.T1_PREPARE);
+    expect(captured).toEqual({
+      requestId,
+      timestamp,
+      agentId: "did:key:z6MkAgent",
+      tokenId,
+      resource: "mcp://filesystem/readFile",
+      action: "call",
+      params: { path: "/tmp/demo.txt" },
+      physicalContext: { humanDetected: false },
+      recentActions: ["filesystem.listDirectory"],
+      executionContext: undefined,
+    });
+  });
+
+  it("respects explicit resource, action, and context tokenId", async () => {
+    let captured: SintRequest | undefined;
+
+    const interceptor = new SINTPDPInterceptor({
+      gateway: {
+        async intercept(request) {
+          captured = request;
+          return allowDecision();
+        },
+      },
+      defaultTokenId: "01963d6b-4300-7000-8000-000000000001",
+      now: () => timestamp,
+      createRequestId: () => requestId,
+    });
+
+    await interceptor.evaluate({
+      caller_identity: "did:key:z6MkAgent",
+      mcp_call: {
+        resource: "ros2:///cmd_vel",
+        action: "publish",
+        params: { linear: { x: 0.2 } },
+      },
+      context: {
+        tokenId,
+        executionContext: {
+          bridgeId: "bridge-1",
+          bridgeProtocol: "mcp",
+        },
+      },
+    });
+
+    expect(captured?.tokenId).toBe(tokenId);
+    expect(captured?.resource).toBe("ros2:///cmd_vel");
+    expect(captured?.action).toBe("publish");
+    expect(captured?.executionContext).toEqual({
+      bridgeId: "bridge-1",
+      bridgeProtocol: "mcp",
+    });
+  });
+
+  it("fails closed when the gateway throws", async () => {
+    const interceptor = new SINTPDPInterceptor({
+      gateway: {
+        async intercept() {
+          throw new Error("network partition");
+        },
+      },
+      defaultTokenId: tokenId,
+      now: () => timestamp,
+      createRequestId: () => requestId,
+    });
+
+    const result = await interceptor.evaluate({
+      caller_identity: "did:key:z6MkAgent",
+      mcp_call: {
+        serverName: "filesystem",
+        toolName: "deleteFile",
+      },
+    });
+
+    expect(result.verdict).toBe("deny");
+    expect(result.decision.action).toBe("deny");
+    expect(result.decision.denial?.policyViolated).toBe("GATEWAY_UNAVAILABLE");
+  });
+
+  it("requires a token id from config or request context", async () => {
+    const interceptor = new SINTPDPInterceptor({
+      gateway: {
+        async intercept() {
+          return allowDecision();
+        },
+      },
+      now: () => timestamp,
+      createRequestId: () => requestId,
+    });
+
+    await expect(
+      interceptor.evaluate({
+        caller_identity: "did:key:z6MkAgent",
+        mcp_call: { serverName: "filesystem", toolName: "readFile" },
+      }),
+    ).rejects.toThrow(/tokenId/);
+  });
+});

--- a/packages/sint-pdp-interceptor/package.json
+++ b/packages/sint-pdp-interceptor/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@pshkv/sint-pdp-interceptor",
+  "version": "0.1.0",
+  "description": "SINT PDP interceptor adapter for MCP SEP-1763 style policy decision point integration",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc --build",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "test": "vitest run",
+    "test:watch": "vitest watch"
+  },
+  "dependencies": {
+    "@pshkv/core": "workspace:*",
+    "@pshkv/gate-capability-tokens": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sint-ai/sint-protocol",
+    "directory": "packages/sint-pdp-interceptor"
+  },
+  "homepage": "https://github.com/sint-ai/sint-protocol#readme",
+  "bugs": {
+    "url": "https://github.com/sint-ai/sint-protocol/issues"
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/sint-pdp-interceptor/src/index.ts
+++ b/packages/sint-pdp-interceptor/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @sint/sint-pdp-interceptor — reference PDP adapter for SEP-1763 style MCP interceptors.
+ *
+ * Presents a small `evaluate()` interface that maps MCP host requests into
+ * `PolicyGateway.intercept()` calls.
+ */
+
+export { SINTPDPInterceptor } from "./interceptor.js";
+export type {
+  PDPDecision,
+  PDPInterceptorCall,
+  PDPInterceptorContext,
+  PDPInterceptorRequest,
+  SINTGatewayLike,
+  SINTPDPInterceptorConfig,
+} from "./types.js";

--- a/packages/sint-pdp-interceptor/src/interceptor.ts
+++ b/packages/sint-pdp-interceptor/src/interceptor.ts
@@ -1,0 +1,127 @@
+import type { ISO8601, PolicyDecision, SintRequest, UUIDv7 } from "@pshkv/core";
+import { ApprovalTier, RiskTier } from "@pshkv/core";
+import { generateUUIDv7, nowISO8601 } from "@pshkv/gate-capability-tokens";
+import type {
+  PDPDecision,
+  PDPInterceptorCall,
+  PDPInterceptorRequest,
+  SINTPDPInterceptorConfig,
+} from "./types.js";
+
+function defaultResource(call: PDPInterceptorCall): string {
+  if (call.resource) return call.resource;
+  const serverName = call.serverName ?? "unknown";
+  const toolName = call.toolName ?? call.method ?? "unknown";
+  return `mcp://${serverName}/${toolName}`;
+}
+
+function defaultAction(call: PDPInterceptorCall): string {
+  if (call.action) return call.action;
+  return "call";
+}
+
+function denyFromError(
+  requestId: UUIDv7,
+  timestamp: ISO8601,
+  reason: string,
+): PDPDecision {
+  const decision: PolicyDecision = {
+    requestId,
+    timestamp,
+    action: "deny",
+    assignedTier: ApprovalTier.T3_COMMIT,
+    assignedRisk: RiskTier.T3_IRREVERSIBLE,
+    denial: {
+      reason,
+      policyViolated: "GATEWAY_UNAVAILABLE",
+      suggestedAlternative: "Retry once the SINT policy gateway is healthy.",
+    },
+  };
+
+  return {
+    verdict: "deny",
+    tier: decision.assignedTier,
+    reason,
+    decision,
+  };
+}
+
+function normalizeDecision(decision: PolicyDecision): PDPDecision {
+  const verdict =
+    decision.action === "deny"
+      ? "deny"
+      : decision.action === "escalate"
+        ? "escalate"
+        : "allow";
+
+  return {
+    verdict,
+    tier: decision.assignedTier,
+    reason: decision.denial?.reason ?? decision.escalation?.reason,
+    decision,
+  };
+}
+
+/**
+ * Thin adapter that presents a SEP-1763-style PDP interface on top of SINT's PolicyGateway.
+ */
+export class SINTPDPInterceptor {
+  readonly type = "policy-pdp" as const;
+
+  private readonly gateway: SINTPDPInterceptorConfig["gateway"];
+  private readonly defaultTokenId?: UUIDv7;
+  private readonly defaultAction: string;
+  private readonly failClosed: boolean;
+  private readonly now: () => ISO8601;
+  private readonly createRequestId: () => UUIDv7;
+  private readonly resolveResource: (call: PDPInterceptorCall) => string;
+  private readonly resolveAction: (call: PDPInterceptorCall) => string;
+
+  constructor(config: SINTPDPInterceptorConfig) {
+    this.gateway = config.gateway;
+    this.defaultTokenId = config.defaultTokenId;
+    this.defaultAction = config.defaultAction ?? "call";
+    this.failClosed = config.failClosed ?? true;
+    this.now = config.now ?? (() => nowISO8601() as ISO8601);
+    this.createRequestId = config.createRequestId ?? (() => generateUUIDv7() as UUIDv7);
+    this.resolveResource = config.resolveResource ?? defaultResource;
+    this.resolveAction = config.resolveAction ?? ((call) => call.action ?? this.defaultAction ?? defaultAction(call));
+  }
+
+  async evaluate(request: PDPInterceptorRequest): Promise<PDPDecision> {
+    const requestId = request.context?.requestId ?? this.createRequestId();
+    const timestamp = request.context?.timestamp ?? this.now();
+    const tokenId = request.context?.tokenId ?? this.defaultTokenId;
+
+    if (!tokenId) {
+      throw new Error(
+        "SINTPDPInterceptor requires a tokenId either in config.defaultTokenId or request.context.tokenId",
+      );
+    }
+
+    const sintRequest: SintRequest = {
+      requestId,
+      timestamp,
+      agentId: request.caller_identity,
+      tokenId,
+      resource: this.resolveResource(request.mcp_call),
+      action: this.resolveAction(request.mcp_call),
+      params: request.mcp_call.params ?? {},
+      physicalContext: request.context?.physicalContext,
+      recentActions: request.context?.recentActions,
+      executionContext: request.context?.executionContext,
+    };
+
+    try {
+      const decision = await this.gateway.intercept(sintRequest);
+      return normalizeDecision(decision);
+    } catch (error) {
+      if (!this.failClosed) throw error;
+      const reason =
+        error instanceof Error
+          ? `SINT gateway unavailable: ${error.message}`
+          : "SINT gateway unavailable";
+      return denyFromError(requestId, timestamp, reason);
+    }
+  }
+}

--- a/packages/sint-pdp-interceptor/src/types.ts
+++ b/packages/sint-pdp-interceptor/src/types.ts
@@ -1,0 +1,76 @@
+import type {
+  ApprovalTier,
+  ISO8601,
+  PolicyDecision,
+  SintExecutionContext,
+  SintRequest,
+  UUIDv7,
+} from "@pshkv/core";
+
+/**
+ * Minimal gateway contract used by the adapter.
+ * Keeps the package easy to test while remaining compatible with PolicyGateway.
+ */
+export interface SINTGatewayLike {
+  intercept(request: SintRequest): Promise<PolicyDecision>;
+}
+
+/**
+ * Tool or method call entering the PDP interceptor.
+ * The adapter accepts explicit resource/action values when the host already knows them,
+ * and falls back to an MCP-shaped server/tool naming scheme otherwise.
+ */
+export interface PDPInterceptorCall {
+  readonly serverName?: string;
+  readonly toolName?: string;
+  readonly method?: string;
+  readonly resource?: string;
+  readonly action?: string;
+  readonly params?: Record<string, unknown>;
+  readonly annotations?: Record<string, unknown>;
+  readonly metadata?: Record<string, unknown>;
+}
+
+/**
+ * Execution metadata carried by the host runtime alongside the MCP call.
+ */
+export interface PDPInterceptorContext {
+  readonly tokenId?: UUIDv7;
+  readonly requestId?: UUIDv7;
+  readonly timestamp?: ISO8601;
+  readonly physicalContext?: SintRequest["physicalContext"];
+  readonly executionContext?: SintExecutionContext;
+  readonly recentActions?: readonly string[];
+}
+
+/**
+ * SEP-1763-style request shape adapted into a SINT gateway call.
+ */
+export interface PDPInterceptorRequest {
+  readonly caller_identity: string;
+  readonly mcp_call: PDPInterceptorCall;
+  readonly context?: PDPInterceptorContext;
+}
+
+/**
+ * Normalized decision surface for MCP hosts.
+ * `verdict` collapses `transform` into `allow` so hosts can decide whether to proceed,
+ * while still preserving the raw SINT PolicyDecision for richer handling.
+ */
+export interface PDPDecision {
+  readonly verdict: "allow" | "deny" | "escalate";
+  readonly tier: ApprovalTier;
+  readonly reason?: string;
+  readonly decision: PolicyDecision;
+}
+
+export interface SINTPDPInterceptorConfig {
+  readonly gateway: SINTGatewayLike;
+  readonly defaultTokenId?: UUIDv7;
+  readonly defaultAction?: string;
+  readonly failClosed?: boolean;
+  readonly now?: () => ISO8601;
+  readonly createRequestId?: () => UUIDv7;
+  readonly resolveResource?: (call: PDPInterceptorCall) => string;
+  readonly resolveAction?: (call: PDPInterceptorCall) => string;
+}

--- a/packages/sint-pdp-interceptor/tsconfig.json
+++ b/packages/sint-pdp-interceptor/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
+  "references": [
+    { "path": "../core" },
+    { "path": "../capability-tokens" }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -850,6 +850,22 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@22.19.15)(jsdom@25.0.1)(tsx@4.21.0)
 
+  packages/sint-pdp-interceptor:
+    dependencies:
+      '@pshkv/core':
+        specifier: workspace:*
+        version: link:../core
+      '@pshkv/gate-capability-tokens':
+        specifier: workspace:*
+        version: link:../capability-tokens
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.15)(jsdom@25.0.1)(tsx@4.21.0)
+
   packages/token-registry:
     dependencies:
       '@pshkv/core':


### PR DESCRIPTION
Implements the first execution slice of #128 by shipping the package scaffold for #144.

What's included:
- new `@pshkv/sint-pdp-interceptor` workspace package
- SEP-1763 style `policy-pdp` adapter on top of `PolicyGateway.intercept()`
- fail-closed behavior when the gateway is unavailable
- focused tests for request mapping, override handling, and fail-closed denial
- README/package table visibility so the flagship package is discoverable

Validation:
- `pnpm --filter @pshkv/sint-pdp-interceptor build`
- `pnpm --filter @pshkv/sint-pdp-interceptor test`

Closes #144.