### PR TITLE
[codex] Canonicalize receipt and tool-definition hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,8 @@ Token fields:
 
 Every policy decision is recorded in a SHA-256 hash-chained append-only log. Chain integrity: `ℓ_k.previousHash = SHA256(canonical(ℓ_{k-1}))`. A gap or hash mismatch constitutes tamper evidence.
 
+For portable verification across bridges and external tooling, SINT now routes receipt and tool-definition signing through a shared deterministic canonical JSON serializer instead of relying on insertion-order-sensitive `JSON.stringify()` behavior.
+
 **Retention policy:**
 
 | Tier | Retention |

--- a/docs/specs/sint-protocol-v1.0.md
+++ b/docs/specs/sint-protocol-v1.0.md
@@ -363,7 +363,7 @@ SintRequest
 
 ### 7.2 Hash Chain Construction
 
-Events form a tamper-evident chain via SHA-256. The canonical form used for hashing:
+Events form a tamper-evident chain via SHA-256. The canonical form used for hashing must be deterministic across implementations: object keys are serialized in lexicographic order, arrays preserve order, and the same payload must yield the same byte sequence independent of insertion order. The canonical form used for hashing:
 
 ```json
 {

--- a/packages/bridge-mcp/__tests__/tool-registry.test.ts
+++ b/packages/bridge-mcp/__tests__/tool-registry.test.ts
@@ -82,6 +82,32 @@ describe("InMemoryToolRegistry", () => {
     expect(registry.detectDrift(def, signed)).toBe(false);
   });
 
+  it("produces the same definition hash regardless of inputSchema key insertion order", () => {
+    const left = makeDef({
+      inputSchema: {
+        type: "object",
+        properties: {
+          zeta: { type: "number" },
+          alpha: { type: "string" },
+        },
+      },
+    });
+    const right = makeDef({
+      inputSchema: {
+        properties: {
+          alpha: { type: "string" },
+          zeta: { type: "number" },
+        },
+        type: "object",
+      },
+    });
+
+    const leftSigned = registry.register(left, privateKey, publicKey);
+    const rightSigned = registry.register(right, privateKey, publicKey);
+
+    expect(leftSigned.definitionHash).toBe(rightSigned.definitionHash);
+  });
+
   it("get returns undefined for an unknown tool", () => {
     const result = registry.get("non-existent-server", "unknownTool");
     expect(result).toBeUndefined();

--- a/packages/bridge-mcp/src/tool-registry.ts
+++ b/packages/bridge-mcp/src/tool-registry.ts
@@ -9,6 +9,7 @@
  */
 
 import { hashSha256, sign, verify } from "@pshkv/gate-capability-tokens";
+import { canonicalJsonStringify } from "@pshkv/core";
 import type { MCPToolAnnotations } from "./types.js";
 
 /**
@@ -58,7 +59,7 @@ export interface ToolRegistry {
  * Compute the canonical JSON hash of a tool definition (sorted keys for determinism).
  */
 function canonicalHash(def: ToolDefinition): string {
-  const canonical = JSON.stringify({
+  const canonical = canonicalJsonStringify({
     serverId: def.serverId,
     toolName: def.toolName,
     description: def.description,

--- a/packages/core/__tests__/canonical-json.test.ts
+++ b/packages/core/__tests__/canonical-json.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { canonicalJsonStringify } from "../src/canonical-json.js";
+
+describe("canonicalJsonStringify", () => {
+  it("sorts object keys recursively", () => {
+    const value = {
+      z: 1,
+      a: {
+        d: true,
+        b: [3, { y: 2, x: 1 }],
+      },
+      m: "ok",
+    };
+
+    expect(canonicalJsonStringify(value)).toBe(
+      '{"a":{"b":[3,{"x":1,"y":2}],"d":true},"m":"ok","z":1}',
+    );
+  });
+
+  it("ignores undefined object values", () => {
+    expect(
+      canonicalJsonStringify({
+        b: 2,
+        a: undefined,
+      }),
+    ).toBe('{"b":2}');
+  });
+
+  it("rejects non-finite numbers", () => {
+    expect(() => canonicalJsonStringify({ bad: Number.NaN })).toThrow(/non-finite/);
+    expect(() => canonicalJsonStringify({ bad: Number.POSITIVE_INFINITY })).toThrow(/non-finite/);
+  });
+});

--- a/packages/core/src/canonical-json.ts
+++ b/packages/core/src/canonical-json.ts
@@ -1,0 +1,48 @@
+/**
+ * Canonical JSON serialization for SINT signing and hashing flows.
+ *
+ * This is intentionally strict:
+ * - object keys are serialized in lexicographic order
+ * - arrays preserve order
+ * - non-finite numbers are rejected
+ * - only JSON-compatible values are accepted
+ *
+ * The output is stable across insertion order and suitable for hashing/signing.
+ */
+
+function assertJsonCompatible(value: unknown): void {
+  if (value === undefined || typeof value === "function" || typeof value === "symbol") {
+    throw new TypeError("canonicalJsonStringify only accepts JSON-compatible values");
+  }
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    throw new TypeError("canonicalJsonStringify does not permit non-finite numbers");
+  }
+}
+
+function canonicalize(value: unknown): string {
+  assertJsonCompatible(value);
+
+  if (value === null || typeof value === "boolean" || typeof value === "number" || typeof value === "string") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalize(item)).join(",")}]`;
+  }
+
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, entryValue]) => entryValue !== undefined)
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
+
+    return `{${entries
+      .map(([key, entryValue]) => `${JSON.stringify(key)}:${canonicalize(entryValue)}`)
+      .join(",")}}`;
+  }
+
+  throw new TypeError("canonicalJsonStringify only accepts JSON-compatible values");
+}
+
+export function canonicalJsonStringify(value: unknown): string {
+  return canonicalize(value);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./types/index.js";
 export * from "./schemas/index.js";
 export * from "./constants/index.js";
+export { canonicalJsonStringify } from "./canonical-json.js";
 export {
   validateConstraintEnvelope,
   resolveEffectiveConstraints,

--- a/packages/evidence-ledger/__tests__/proof-receipt.test.ts
+++ b/packages/evidence-ledger/__tests__/proof-receipt.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { LedgerWriter } from "../src/writer.js";
 import { generateProofReceipt, verifyProofReceipt } from "../src/proof-receipt.js";
 import { generateKeypair, sign, verify } from "@pshkv/gate-capability-tokens";
+import { canonicalJsonStringify } from "@pshkv/core";
 
 describe("generateProofReceipt", () => {
   const authority = generateKeypair();
@@ -70,7 +71,7 @@ describe("generateProofReceipt", () => {
     );
 
     // Verify the signature over the receipt data
-    const receiptData = JSON.stringify({
+    const receiptData = canonicalJsonStringify({
       eventId: receipt.eventId,
       eventHash: receipt.eventHash,
       hashChain: receipt.hashChain,

--- a/packages/evidence-ledger/src/chain-of-custody.ts
+++ b/packages/evidence-ledger/src/chain-of-custody.ts
@@ -11,7 +11,7 @@
 
 import { sha256 } from "@noble/hashes/sha2";
 import { bytesToHex } from "@noble/hashes/utils";
-import type { SintLedgerEvent } from "@pshkv/core";
+import { canonicalJsonStringify, type SintLedgerEvent } from "@pshkv/core";
 
 export interface ChainOfCustodyProof {
   readonly eventId: string;
@@ -41,7 +41,7 @@ const GENESIS_HASH =
  * Must match the logic in writer.ts for consistency.
  */
 function recomputeHash(event: SintLedgerEvent): string {
-  const canonical = JSON.stringify({
+  const canonical = canonicalJsonStringify({
     eventId: event.eventId,
     sequenceNumber: event.sequenceNumber.toString(),
     timestamp: event.timestamp,

--- a/packages/evidence-ledger/src/csml.ts
+++ b/packages/evidence-ledger/src/csml.ts
@@ -18,7 +18,7 @@
  */
 
 import type { CsmlCoefficients, SintLedgerEvent } from "@pshkv/core";
-import { DEFAULT_CSML_COEFFICIENTS } from "@pshkv/core";
+import { DEFAULT_CSML_COEFFICIENTS, canonicalJsonStringify } from "@pshkv/core";
 
 /**
  * Decomposed CSML component values for transparency and debugging.
@@ -65,7 +65,7 @@ import { sha256 } from "@noble/hashes/sha2";
 import { bytesToHex } from "@noble/hashes/utils";
 
 function canonicalHash(event: SintLedgerEvent): string {
-  const canonical = JSON.stringify({
+  const canonical = canonicalJsonStringify({
     eventId: event.eventId,
     sequenceNumber: event.sequenceNumber.toString(),
     timestamp: event.timestamp,

--- a/packages/evidence-ledger/src/proof-receipt.ts
+++ b/packages/evidence-ledger/src/proof-receipt.ts
@@ -15,6 +15,7 @@ import type {
   SintLedgerEvent,
   SintProofReceipt,
 } from "@pshkv/core";
+import { canonicalJsonStringify } from "@pshkv/core";
 
 /**
  * Generate a Proof Receipt for a specific ledger event.
@@ -53,7 +54,7 @@ export function generateProofReceipt(
     .replace(/\.(\d{3})Z$/, ".$1000Z");
 
   // Create the receipt data to sign
-  const receiptData = JSON.stringify({
+  const receiptData = canonicalJsonStringify({
     eventId: targetEvent.eventId,
     eventHash: targetEvent.hash,
     hashChain,
@@ -96,7 +97,7 @@ export function verifyProofReceipt(
   if (lastHash !== receipt.eventHash) return false;
 
   // Verify the signature
-  const receiptData = JSON.stringify({
+  const receiptData = canonicalJsonStringify({
     eventId: receipt.eventId,
     eventHash: receipt.eventHash,
     hashChain: receipt.hashChain,

--- a/packages/evidence-ledger/src/writer.ts
+++ b/packages/evidence-ledger/src/writer.ts
@@ -22,7 +22,7 @@ import type {
   SintLedgerEvent,
   UUIDv7,
 } from "@pshkv/core";
-import { ok, err } from "@pshkv/core";
+import { ok, err, canonicalJsonStringify } from "@pshkv/core";
 import { randomBytes } from "node:crypto";
 
 /** Genesis hash — the hash chain starts here. */
@@ -34,7 +34,7 @@ const GENESIS_HASH: SHA256 =
  * Pure function — deterministic.
  */
 function computeEventHash(event: Omit<SintLedgerEvent, "hash">): SHA256 {
-  const canonical = JSON.stringify({
+  const canonical = canonicalJsonStringify({
     eventId: event.eventId,
     sequenceNumber: event.sequenceNumber.toString(),
     timestamp: event.timestamp,


### PR DESCRIPTION
Implements the next flagship execution slice for #128 by tackling #146.

What's included:
- shared `canonicalJsonStringify()` helper exported from `@pshkv/core`
- evidence-ledger receipt, chain-of-custody, writer, and CSML hashing paths switched off ad hoc `JSON.stringify()` ordering
- MCP tool-definition signing switched to the same canonical serialization path
- regression tests for canonical key ordering and stable tool-definition hashes

Validation:
- `pnpm --filter @pshkv/core test`
- `pnpm --filter @pshkv/core build`
- `pnpm --filter @pshkv/gate-evidence-ledger test`
- `pnpm --filter @pshkv/gate-evidence-ledger build`
- `pnpm --filter @pshkv/bridge-mcp test -- --run __tests__/tool-registry.test.ts __tests__/interceptor.test.ts __tests__/middleware.test.ts`
- `pnpm --filter @pshkv/bridge-mcp build`

Closes #146.