### PR TITLE
[codex] Add bilateral proof receipt model

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,8 @@ Every policy decision is recorded in a SHA-256 hash-chained append-only log. Cha
 
 For portable verification across bridges and external tooling, SINT now routes receipt and tool-definition signing through a shared deterministic canonical JSON serializer instead of relying on insertion-order-sensitive `JSON.stringify()` behavior.
 
+For strong-tier flows, SINT can emit a linked bilateral receipt pair: a gate receipt before execution is allowed to proceed and a completion receipt once execution settles. The pair shares a stable `actionRef` and `linkageHash` so auditors can verify both authorization and outcome as one governed action.
+
 **Retention policy:**
 
 | Tier | Retention |

--- a/docs/specs/sint-protocol-v1.0.md
+++ b/docs/specs/sint-protocol-v1.0.md
@@ -408,6 +408,12 @@ For T3 events and regulatory audit, a `SintProofReceipt` is generated:
 | `signerPublicKey` | Ed25519PublicKey | Signing authority's public key. |
 | `teeAttestation` | object? | Optional TEE attestation for regulatory-grade proof (Intel SGX, ARM TrustZone, AMD SEV). Required for T2/T3 events in certified deployments. |
 
+For strong-tier execution paths, deployments MAY emit a linked bilateral receipt pair instead of treating proof generation as a single terminal artifact:
+
+- **Gate receipt**: attests that the governing decision was recorded before execution was permitted to proceed.
+- **Completion receipt**: attests that the eventual execution outcome (`completed`, `failed`, or `rolledback`) was recorded.
+- Both receipts share a stable `actionRef` and deterministic `linkageHash`, and each names the counterpart event ID.
+
 ---
 
 ## 8. Bridge Adapter Contract

--- a/packages/core/src/types/evidence.ts
+++ b/packages/core/src/types/evidence.ts
@@ -203,6 +203,31 @@ export interface SintProofReceipt {
 }
 
 /**
+ * Stage-specific receipt used for strong-tier flows that need both a gate receipt
+ * before execution and a completion receipt after execution settles.
+ */
+export interface SintBilateralProofReceipt extends SintProofReceipt {
+  /** Stable cross-system correlation identifier for the governed action. */
+  readonly actionRef: string;
+  /** Whether this receipt captures the authorization gate or the execution result. */
+  readonly stage: "gate" | "completion";
+  /** The paired event on the other side of the gate/completion lifecycle. */
+  readonly counterpartEventId: UUIDv7;
+  /** Shared deterministic linkage hash tying the pair together. */
+  readonly linkageHash: SHA256;
+  /** Stage-specific outcome associated with the receipt. */
+  readonly outcome: "allow" | "deny" | "escalate" | "completed" | "failed" | "rolledback";
+}
+
+/**
+ * Linked receipt pair for strong-tier execution governance.
+ */
+export interface SintBilateralProofReceiptPair {
+  readonly gate: SintBilateralProofReceipt;
+  readonly completion: SintBilateralProofReceipt;
+}
+
+/**
  * Formal DFA states for the SINT request lifecycle.
  *
  * Models physical consequence severity of every request through a deterministic

--- a/packages/evidence-ledger/README.md
+++ b/packages/evidence-ledger/README.md
@@ -39,6 +39,7 @@ console.log(integrity.valid); // true — no entries tampered
 - **Tamper detection** — broken chain = evidence of modification
 - **SIEM export** — syslog, JSON-Lines, CEF output formats
 - **NIST chain-of-custody** — proof receipts for compliance
+- **Bilateral receipts for strong-tier flows** — linked gate/completion receipts with shared `actionRef` and `linkageHash`
 - **Semantic query API** — filter by session, action, time range, tier
 - **Pluggable storage** — in-memory, PostgreSQL, or custom adapters
 

--- a/packages/evidence-ledger/__tests__/bilateral-proof-receipt.test.ts
+++ b/packages/evidence-ledger/__tests__/bilateral-proof-receipt.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { generateKeypair, sign, verify } from "@pshkv/gate-capability-tokens";
+import { LedgerWriter } from "../src/writer.js";
+import {
+  computeReceiptLinkageHash,
+  generateBilateralProofReceiptPair,
+  verifyBilateralReceiptPair,
+} from "../src/proof-receipt.js";
+
+describe("bilateral proof receipts", () => {
+  const authority = generateKeypair();
+
+  it("generates linked gate and completion receipts with a shared linkage hash", () => {
+    const writer = new LedgerWriter();
+    const agentId = "a".repeat(64);
+
+    const gateEvent = writer.append({
+      eventType: "policy.evaluated",
+      agentId,
+      payload: { action: "allow", tier: "T3_commit" },
+    });
+    const completionEvent = writer.append({
+      eventType: "action.completed",
+      agentId,
+      payload: { result: "ok" },
+    });
+
+    const pair = generateBilateralProofReceiptPair({
+      actionRef: "01963d6b-5000-7000-8000-000000000001",
+      gateEvent,
+      gateChainEvents: [gateEvent],
+      completionEvent,
+      completionChainEvents: writer.getAll(),
+      signerPublicKey: authority.publicKey,
+      signFn: (data) => sign(authority.privateKey, data),
+    });
+
+    expect(pair.gate.stage).toBe("gate");
+    expect(pair.completion.stage).toBe("completion");
+    expect(pair.gate.actionRef).toBe(pair.completion.actionRef);
+    expect(pair.gate.linkageHash).toBe(pair.completion.linkageHash);
+    expect(pair.gate.counterpartEventId).toBe(completionEvent.eventId);
+    expect(pair.completion.counterpartEventId).toBe(gateEvent.eventId);
+  });
+
+  it("verifies a valid bilateral receipt pair", () => {
+    const writer = new LedgerWriter();
+    const agentId = "b".repeat(64);
+
+    const gateEvent = writer.append({
+      eventType: "policy.evaluated",
+      agentId,
+      payload: { action: "allow" },
+    });
+    const completionEvent = writer.append({
+      eventType: "action.failed",
+      agentId,
+      payload: { reason: "device timeout" },
+    });
+
+    const pair = generateBilateralProofReceiptPair({
+      actionRef: "01963d6b-5000-7000-8000-000000000002",
+      gateEvent,
+      gateChainEvents: [gateEvent],
+      completionEvent,
+      completionChainEvents: writer.getAll(),
+      completionOutcome: "failed",
+      signerPublicKey: authority.publicKey,
+      signFn: (data) => sign(authority.privateKey, data),
+    });
+
+    expect(
+      verifyBilateralReceiptPair(pair, (pubKey, signature, data) =>
+        verify(pubKey, signature, data),
+      ),
+    ).toBe(true);
+  });
+
+  it("fails verification when the pair linkage is tampered", () => {
+    const writer = new LedgerWriter();
+    const agentId = "c".repeat(64);
+
+    const gateEvent = writer.append({
+      eventType: "policy.evaluated",
+      agentId,
+      payload: { action: "escalate" },
+    });
+    const completionEvent = writer.append({
+      eventType: "action.rolledback",
+      agentId,
+      payload: { reason: "operator abort" },
+    });
+
+    const pair = generateBilateralProofReceiptPair({
+      actionRef: "01963d6b-5000-7000-8000-000000000003",
+      gateEvent,
+      gateChainEvents: [gateEvent],
+      gateOutcome: "escalate",
+      completionEvent,
+      completionChainEvents: writer.getAll(),
+      completionOutcome: "rolledback",
+      signerPublicKey: authority.publicKey,
+      signFn: (data) => sign(authority.privateKey, data),
+    });
+
+    const tampered = {
+      gate: pair.gate,
+      completion: {
+        ...pair.completion,
+        linkageHash: computeReceiptLinkageHash(
+          pair.completion.actionRef,
+          pair.completion.eventId,
+          pair.gate.eventId,
+        ),
+      },
+    };
+
+    expect(
+      verifyBilateralReceiptPair(tampered, (pubKey, signature, data) =>
+        verify(pubKey, signature, data),
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/evidence-ledger/src/index.ts
+++ b/packages/evidence-ledger/src/index.ts
@@ -1,6 +1,13 @@
 export { LedgerWriter } from "./writer.js";
 export { queryLedger, replayEvents } from "./reader.js";
-export { generateProofReceipt, verifyProofReceipt } from "./proof-receipt.js";
+export {
+  computeReceiptLinkageHash,
+  generateProofReceipt,
+  generateBilateralProofReceiptPair,
+  verifyProofReceipt,
+  verifyBilateralProofReceipt,
+  verifyBilateralReceiptPair,
+} from "./proof-receipt.js";
 export { computeCsml, computeCsmlPerModel } from "./csml.js";
 export type { CsmlComponents, CsmlResult } from "./csml.js";
 export {

--- a/packages/evidence-ledger/src/proof-receipt.ts
+++ b/packages/evidence-ledger/src/proof-receipt.ts
@@ -12,10 +12,15 @@
 import type {
   Ed25519PublicKey,
   SHA256,
+  SintBilateralProofReceipt,
+  SintBilateralProofReceiptPair,
   SintLedgerEvent,
   SintProofReceipt,
+  UUIDv7,
 } from "@pshkv/core";
 import { canonicalJsonStringify } from "@pshkv/core";
+import { sha256 } from "@noble/hashes/sha2";
+import { bytesToHex } from "@noble/hashes/utils";
 
 /**
  * Generate a Proof Receipt for a specific ledger event.
@@ -109,4 +114,153 @@ export function verifyProofReceipt(
     receipt.signature,
     receiptData,
   );
+}
+
+function inferCompletionOutcome(
+  event: SintLedgerEvent,
+): SintBilateralProofReceipt["outcome"] {
+  switch (event.eventType) {
+    case "action.completed":
+      return "completed";
+    case "action.failed":
+      return "failed";
+    case "action.rolledback":
+      return "rolledback";
+    default:
+      return "completed";
+  }
+}
+
+export function computeReceiptLinkageHash(
+  actionRef: string,
+  gateEventId: UUIDv7,
+  completionEventId: UUIDv7,
+): SHA256 {
+  const canonical = canonicalJsonStringify({
+    actionRef,
+    gateEventId,
+    completionEventId,
+  });
+  return bytesToHex(sha256(new TextEncoder().encode(canonical)));
+}
+
+function signBilateralReceipt(
+  receipt: Omit<SintBilateralProofReceipt, "signature">,
+  signFn: (data: string) => string,
+): SintBilateralProofReceipt {
+  const receiptData = canonicalJsonStringify(receipt);
+  return {
+    ...receipt,
+    signature: signFn(receiptData),
+  };
+}
+
+export function generateBilateralProofReceiptPair(params: {
+  readonly actionRef: string;
+  readonly gateEvent: SintLedgerEvent;
+  readonly gateChainEvents: readonly SintLedgerEvent[];
+  readonly gateOutcome?: Extract<SintBilateralProofReceipt["outcome"], "allow" | "deny" | "escalate">;
+  readonly completionEvent: SintLedgerEvent;
+  readonly completionChainEvents: readonly SintLedgerEvent[];
+  readonly completionOutcome?: Extract<SintBilateralProofReceipt["outcome"], "completed" | "failed" | "rolledback">;
+  readonly signerPublicKey: Ed25519PublicKey;
+  readonly signFn: (data: string) => string;
+}): SintBilateralProofReceiptPair {
+  const gateBase = generateProofReceipt(
+    params.gateEvent,
+    params.gateChainEvents,
+    params.signerPublicKey,
+    params.signFn,
+  );
+  const completionBase = generateProofReceipt(
+    params.completionEvent,
+    params.completionChainEvents,
+    params.signerPublicKey,
+    params.signFn,
+  );
+  const { signature: _gateSignature, ...gateUnsignedBase } = gateBase;
+  const { signature: _completionSignature, ...completionUnsignedBase } = completionBase;
+
+  const linkageHash = computeReceiptLinkageHash(
+    params.actionRef,
+    params.gateEvent.eventId,
+    params.completionEvent.eventId,
+  );
+
+  const gate = signBilateralReceipt(
+    {
+      ...gateUnsignedBase,
+      actionRef: params.actionRef,
+      stage: "gate",
+      counterpartEventId: params.completionEvent.eventId,
+      linkageHash,
+      outcome: params.gateOutcome ?? "allow",
+    },
+    params.signFn,
+  );
+
+  const completion = signBilateralReceipt(
+    {
+      ...completionUnsignedBase,
+      actionRef: params.actionRef,
+      stage: "completion",
+      counterpartEventId: params.gateEvent.eventId,
+      linkageHash,
+      outcome: params.completionOutcome ?? inferCompletionOutcome(params.completionEvent),
+    },
+    params.signFn,
+  );
+
+  return { gate, completion };
+}
+
+export function verifyBilateralProofReceipt(
+  receipt: SintBilateralProofReceipt,
+  verifySignatureFn: (publicKey: string, signature: string, data: string) => boolean,
+): boolean {
+  if (receipt.hashChain.length === 0) return false;
+  const lastHash = receipt.hashChain[receipt.hashChain.length - 1];
+  if (lastHash !== receipt.eventHash) return false;
+
+  const receiptData = canonicalJsonStringify({
+    eventId: receipt.eventId,
+    eventHash: receipt.eventHash,
+    hashChain: receipt.hashChain,
+    generatedAt: receipt.generatedAt,
+    signerPublicKey: receipt.signerPublicKey,
+    teeAttestation: receipt.teeAttestation,
+    actionRef: receipt.actionRef,
+    stage: receipt.stage,
+    counterpartEventId: receipt.counterpartEventId,
+    linkageHash: receipt.linkageHash,
+    outcome: receipt.outcome,
+  });
+
+  return verifySignatureFn(
+    receipt.signerPublicKey,
+    receipt.signature,
+    receiptData,
+  );
+}
+
+export function verifyBilateralReceiptPair(
+  pair: SintBilateralProofReceiptPair,
+  verifySignatureFn: (publicKey: string, signature: string, data: string) => boolean,
+): boolean {
+  if (!verifyBilateralProofReceipt(pair.gate, verifySignatureFn)) return false;
+  if (!verifyBilateralProofReceipt(pair.completion, verifySignatureFn)) return false;
+
+  if (pair.gate.stage !== "gate" || pair.completion.stage !== "completion") return false;
+  if (pair.gate.actionRef !== pair.completion.actionRef) return false;
+  if (pair.gate.linkageHash !== pair.completion.linkageHash) return false;
+  if (pair.gate.counterpartEventId !== pair.completion.eventId) return false;
+  if (pair.completion.counterpartEventId !== pair.gate.eventId) return false;
+
+  const recomputedLinkageHash = computeReceiptLinkageHash(
+    pair.gate.actionRef,
+    pair.gate.eventId,
+    pair.completion.eventId,
+  );
+
+  return pair.gate.linkageHash === recomputedLinkageHash;
 }


### PR DESCRIPTION
Implements the next flagship execution slice for #128 by tackling #147.

What's included:
- new `SintBilateralProofReceipt` and `SintBilateralProofReceiptPair` types in core
- linked gate/completion receipt generation in evidence-ledger
- shared `actionRef`, `counterpartEventId`, and deterministic `linkageHash` across the pair
- pair verification helpers plus regression tests for valid and tampered linkage
- docs/spec updates describing bilateral receipts for strong-tier flows

Validation:
- `pnpm --filter @pshkv/core build`
- `pnpm --filter @pshkv/gate-evidence-ledger test`
- `pnpm --filter @pshkv/gate-evidence-ledger build`

Closes #147.