### PR TITLE
[codex] Add fail-closed guarded execution helper

### DIFF
--- a/packages/sint-pdp-interceptor/README.md
+++ b/packages/sint-pdp-interceptor/README.md
@@ -85,3 +85,26 @@ If `action` is not supplied, the adapter defaults to `call`.
 This scaffold focuses on the adapter package and the core request/decision flow.
 Bilateral receipts and the richer demo path are intentionally tracked as follow-on
 flagship issues so the first package stays simple and installable.
+
+## Fail-closed guarded execution
+
+Hosts that want a stronger safety story can use `runGuarded()` instead of calling
+`evaluate()` directly. This helper:
+
+- stops immediately on `deny`
+- never runs downstream execution on `escalate`
+- can require a verified gate prerequisite before execution proceeds
+- returns `failed` rather than silently succeeding when downstream execution throws
+
+```ts
+const outcome = await interceptor.runGuarded(request, {
+  verifyGatePrerequisite: async () => ({
+    ok: true,
+    evidenceRef: "sint://ledger/gate-001",
+  }),
+  execute: async () => runRealToolCall(),
+});
+```
+
+If `verifyGatePrerequisite()` returns `{ ok: false }`, the helper fail-closes and
+returns a deny decision with `policyViolated = "GATE_PREREQUISITE_MISSING"`.

--- a/packages/sint-pdp-interceptor/__tests__/interceptor.test.ts
+++ b/packages/sint-pdp-interceptor/__tests__/interceptor.test.ts
@@ -145,4 +145,123 @@ describe("SINTPDPInterceptor", () => {
       }),
     ).rejects.toThrow(/tokenId/);
   });
+
+  it("does not execute downstream work when the decision escalates", async () => {
+    let executed = false;
+
+    const interceptor = new SINTPDPInterceptor({
+      gateway: {
+        async intercept() {
+          return {
+            requestId,
+            timestamp,
+            action: "escalate",
+            assignedTier: ApprovalTier.T3_COMMIT,
+            assignedRisk: RiskTier.T3_IRREVERSIBLE,
+            escalation: {
+              requiredTier: ApprovalTier.T3_COMMIT,
+              reason: "Human approval required",
+              timeoutMs: 120000,
+              fallbackAction: "deny",
+            },
+          };
+        },
+      },
+      defaultTokenId: tokenId,
+      now: () => timestamp,
+      createRequestId: () => requestId,
+    });
+
+    const result = await interceptor.runGuarded(
+      {
+        caller_identity: "did:key:z6MkAgent",
+        mcp_call: { serverName: "filesystem", toolName: "deleteFile" },
+      },
+      {
+        execute: async () => {
+          executed = true;
+          return "ok";
+        },
+      },
+    );
+
+    expect(result.stage).toBe("escalated");
+    expect(executed).toBe(false);
+  });
+
+  it("blocks execution when the gate prerequisite is missing", async () => {
+    let executed = false;
+
+    const interceptor = new SINTPDPInterceptor({
+      gateway: {
+        async intercept() {
+          return allowDecision();
+        },
+      },
+      defaultTokenId: tokenId,
+      now: () => timestamp,
+      createRequestId: () => requestId,
+    });
+
+    const result = await interceptor.runGuarded(
+      {
+        caller_identity: "did:key:z6MkAgent",
+        mcp_call: { serverName: "filesystem", toolName: "writeFile" },
+      },
+      {
+        verifyGatePrerequisite: async () => ({
+          ok: false,
+          reason: "Missing verified gate receipt",
+        }),
+        execute: async () => {
+          executed = true;
+          return "ok";
+        },
+      },
+    );
+
+    expect(result.stage).toBe("blocked");
+    expect(result.decision.verdict).toBe("deny");
+    expect(result.decision.decision.denial?.policyViolated).toBe("GATE_PREREQUISITE_MISSING");
+    expect(executed).toBe(false);
+  });
+
+  it("returns failed when downstream execution throws", async () => {
+    const seenErrors: unknown[] = [];
+
+    const interceptor = new SINTPDPInterceptor({
+      gateway: {
+        async intercept() {
+          return allowDecision();
+        },
+      },
+      defaultTokenId: tokenId,
+      now: () => timestamp,
+      createRequestId: () => requestId,
+    });
+
+    const result = await interceptor.runGuarded(
+      {
+        caller_identity: "did:key:z6MkAgent",
+        mcp_call: { serverName: "filesystem", toolName: "writeFile" },
+      },
+      {
+        verifyGatePrerequisite: async () => ({
+          ok: true,
+          evidenceRef: "sint://ledger/gate-001",
+        }),
+        execute: async () => {
+          throw new Error("downstream actuator timeout");
+        },
+        onExecutionError: async (error) => {
+          seenErrors.push(error);
+        },
+      },
+    );
+
+    expect(result.stage).toBe("failed");
+    expect(result.decision.verdict).toBe("allow");
+    expect((result.error as Error).message).toContain("downstream actuator timeout");
+    expect(seenErrors).toHaveLength(1);
+  });
 });

--- a/packages/sint-pdp-interceptor/src/index.ts
+++ b/packages/sint-pdp-interceptor/src/index.ts
@@ -7,6 +7,9 @@
 
 export { SINTPDPInterceptor } from "./interceptor.js";
 export type {
+  GatePrerequisiteResult,
+  GuardedExecutionOptions,
+  GuardedExecutionResult,
   PDPDecision,
   PDPInterceptorCall,
   PDPInterceptorContext,

--- a/packages/sint-pdp-interceptor/src/interceptor.ts
+++ b/packages/sint-pdp-interceptor/src/interceptor.ts
@@ -2,6 +2,9 @@ import type { ISO8601, PolicyDecision, SintRequest, UUIDv7 } from "@pshkv/core";
 import { ApprovalTier, RiskTier } from "@pshkv/core";
 import { generateUUIDv7, nowISO8601 } from "@pshkv/gate-capability-tokens";
 import type {
+  GatePrerequisiteResult,
+  GuardedExecutionOptions,
+  GuardedExecutionResult,
   PDPDecision,
   PDPInterceptorCall,
   PDPInterceptorRequest,
@@ -58,6 +61,32 @@ function normalizeDecision(decision: PolicyDecision): PDPDecision {
     verdict,
     tier: decision.assignedTier,
     reason: decision.denial?.reason ?? decision.escalation?.reason,
+    decision,
+  };
+}
+
+function denyFromGateFailure(
+  requestId: UUIDv7,
+  timestamp: ISO8601,
+  reason: string,
+): PDPDecision {
+  const decision: PolicyDecision = {
+    requestId,
+    timestamp,
+    action: "deny",
+    assignedTier: ApprovalTier.T3_COMMIT,
+    assignedRisk: RiskTier.T3_IRREVERSIBLE,
+    denial: {
+      reason,
+      policyViolated: "GATE_PREREQUISITE_MISSING",
+      suggestedAlternative: "Do not execute until a valid gate receipt or prerequisite is present.",
+    },
+  };
+
+  return {
+    verdict: "deny",
+    tier: decision.assignedTier,
+    reason,
     decision,
   };
 }
@@ -122,6 +151,51 @@ export class SINTPDPInterceptor {
           ? `SINT gateway unavailable: ${error.message}`
           : "SINT gateway unavailable";
       return denyFromError(requestId, timestamp, reason);
+    }
+  }
+
+  async runGuarded<Result = unknown>(
+    request: PDPInterceptorRequest,
+    options: GuardedExecutionOptions<Result> = {},
+  ): Promise<GuardedExecutionResult<Result>> {
+    const decision = await this.evaluate(request);
+
+    if (decision.verdict === "deny") {
+      return { stage: "denied", decision };
+    }
+
+    if (decision.verdict === "escalate") {
+      return { stage: "escalated", decision };
+    }
+
+    let gate: GatePrerequisiteResult | undefined;
+    if (options.verifyGatePrerequisite) {
+      gate = await options.verifyGatePrerequisite(decision, request);
+      if (!gate.ok) {
+        const requestId = request.context?.requestId ?? decision.decision.requestId;
+        const timestamp = request.context?.timestamp ?? decision.decision.timestamp;
+        return {
+          stage: "blocked",
+          decision: denyFromGateFailure(
+            requestId,
+            timestamp,
+            gate.reason ?? "Gate prerequisite verification failed",
+          ),
+          gate,
+        };
+      }
+    }
+
+    if (!options.execute) {
+      return { stage: "executed", decision, gate };
+    }
+
+    try {
+      const result = await options.execute();
+      return { stage: "executed", decision, gate, result };
+    } catch (error) {
+      await options.onExecutionError?.(error);
+      return { stage: "failed", decision, gate, error };
     }
   }
 }

--- a/packages/sint-pdp-interceptor/src/types.ts
+++ b/packages/sint-pdp-interceptor/src/types.ts
@@ -64,6 +64,39 @@ export interface PDPDecision {
   readonly decision: PolicyDecision;
 }
 
+export interface GatePrerequisiteResult {
+  readonly ok: boolean;
+  readonly reason?: string;
+  readonly evidenceRef?: string;
+}
+
+export interface GuardedExecutionOptions<Result = unknown> {
+  /**
+   * Verifies the gate prerequisite before downstream execution proceeds.
+   * Typical use: confirm a gate receipt exists and is valid.
+   */
+  readonly verifyGatePrerequisite?: (
+    decision: PDPDecision,
+    request: PDPInterceptorRequest,
+  ) => Promise<GatePrerequisiteResult>;
+  /**
+   * Executes the downstream operation once the SINT decision and gate prerequisite allow it.
+   */
+  readonly execute?: () => Promise<Result>;
+  /**
+   * Optional best-effort hook for recording downstream execution faults.
+   */
+  readonly onExecutionError?: (error: unknown) => Promise<void> | void;
+}
+
+export interface GuardedExecutionResult<Result = unknown> {
+  readonly stage: "denied" | "escalated" | "blocked" | "executed" | "failed";
+  readonly decision: PDPDecision;
+  readonly gate?: GatePrerequisiteResult;
+  readonly result?: Result;
+  readonly error?: unknown;
+}
+
 export interface SINTPDPInterceptorConfig {
   readonly gateway: SINTGatewayLike;
   readonly defaultTokenId?: UUIDv7;


### PR DESCRIPTION
## Summary
- add a guarded execution helper on top of the PDP interceptor evaluation flow
- fail closed when a required gate prerequisite is missing or when downstream execution errors
- document and test the stronger safety story for execution-time enforcement

## Testing
- pnpm --filter @pshkv/sint-pdp-interceptor test
- pnpm --filter @pshkv/sint-pdp-interceptor build

Closes #148