### PR TITLE
[codex] Add 5-minute interceptor quickstart demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,26 @@ docker build -t sint-mcp .
 docker run --rm -i sint-mcp
 ```
 
+## Try the interceptor flagship in 5 minutes
+
+If you want the fastest builder-facing path into the SEP-1763 interceptor work:
+
+```bash
+pnpm install
+pnpm run build
+pnpm run demo:interceptor-quickstart
+```
+
+That walkthrough shows the full flagship loop in one terminal transcript:
+- MCP-style request enters the interceptor
+- SINT returns `allow` or `escalate`
+- an audit receipt is generated for the allowed path
+- execution fail-closes when a gate prerequisite is missing
+
+Start here:
+- [`docs/guides/sint-pdp-interceptor-quickstart.md`](docs/guides/sint-pdp-interceptor-quickstart.md)
+- [`packages/sint-pdp-interceptor`](packages/sint-pdp-interceptor)
+
 ## Why SINT?
 
 AI agents can now control robots, execute code, move money, and operate machinery. But there's no standard security layer between "the LLM decided to do X" and "X happened in the physical world."

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -36,6 +36,7 @@ export default defineConfig({
       {
         text: "Guides",
         items: [
+          { text: "SINT PDP Interceptor Quickstart", link: "/guides/sint-pdp-interceptor-quickstart" },
           { text: "Docker Deployment", link: "/guides/docker-deployment" },
           { text: "Persistence Baseline", link: "/guides/persistence-baseline" },
           { text: "WebSocket Approvals", link: "/guides/websocket-approvals" },

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,6 +2,8 @@
 
 This guide gets you from clone to a complete `token -> intercept -> approval -> ledger` flow in about 10 minutes.
 
+If you want the fastest builder-facing walkthrough for the new interceptor flagship instead of the full local stack, start with [SINT PDP Interceptor Quickstart](./guides/sint-pdp-interceptor-quickstart.md). It shows `request -> decision -> receipt` plus the fail-closed path in one terminal run.
+
 ## Prerequisites
 
 - Node.js 22+

--- a/docs/guides/sint-pdp-interceptor-quickstart.md
+++ b/docs/guides/sint-pdp-interceptor-quickstart.md
@@ -1,0 +1,78 @@
+# SINT PDP Interceptor Quickstart
+
+This is the fastest way to understand the flagship interceptor work from issue #128 without digging through packages or tests.
+
+In one terminal run, you will see:
+
+- an MCP-style request enter `@pshkv/sint-pdp-interceptor`
+- a SINT gateway decision for an allowed operation
+- a proof receipt generated for the audited decision path
+- an escalated operation that does not execute downstream work
+- a fail-closed denial when a gate prerequisite is missing
+
+## Run it
+
+```bash
+pnpm install
+pnpm run build
+pnpm run demo:interceptor-quickstart
+```
+
+The demo entrypoint lives in the repo at [`examples/sint-pdp-interceptor-quickstart.mjs`](https://github.com/sint-ai/sint-protocol/blob/main/examples/sint-pdp-interceptor-quickstart.mjs).
+
+## What the demo covers
+
+### 1. Allow path with receipt
+
+The demo sends a `filesystem.writeFile` style request through the interceptor, gets an `allow` decision, and then generates a proof receipt for the resulting `policy.evaluated` ledger event.
+
+That gives one compact flow:
+
+`request -> decision -> receipt`
+
+### 2. Escalation path
+
+The demo then sends a destructive `filesystem.deleteFile` style request. The gateway responds with `escalate`, and the guarded helper does not run downstream execution.
+
+This is the important behavior for launch messaging: the interceptor does not just classify risk, it blocks irreversible work until an approval path exists.
+
+### 3. Fail-closed path
+
+Finally, the demo shows an actuator-style command with a missing verified gate prerequisite. `runGuarded()` converts that into a deny decision with `policyViolated = "GATE_PREREQUISITE_MISSING"` before any side effect occurs.
+
+## Example transcript
+
+The exact hashes and signatures will vary, but the structure should look like this:
+
+```text
+SINT PDP Interceptor — 5 minute quickstart
+Command: pnpm run build && pnpm run demo:interceptor-quickstart
+
+=== 1. Allow path with receipt ===
+Request
+{ ...filesystem write request... }
+
+Decision
+{ "action": "allow", "assignedTier": "T1_prepare", ... }
+
+Receipt
+{ "eventId": "...", "eventHash": "...", "hashChainLength": 2, "verified": true }
+
+=== 2. Escalation path ===
+Escalation decision
+{ "action": "escalate", "assignedTier": "T3_commit", ... }
+Executed downstream work: no
+
+=== 3. Fail-closed missing prerequisite ===
+Blocked decision
+{ "action": "deny", "denial": { "policyViolated": "GATE_PREREQUISITE_MISSING", ... } }
+Final stage: blocked
+Outcome: the interceptor denied execution before any downstream side effect.
+```
+
+## Where to look next
+
+- Package README: [`packages/sint-pdp-interceptor/README.md`](https://github.com/sint-ai/sint-protocol/blob/main/packages/sint-pdp-interceptor/README.md)
+- Source: [`packages/sint-pdp-interceptor/src/interceptor.ts`](https://github.com/sint-ai/sint-protocol/blob/main/packages/sint-pdp-interceptor/src/interceptor.ts)
+- Tests: [`packages/sint-pdp-interceptor/__tests__/interceptor.test.ts`](https://github.com/sint-ai/sint-protocol/blob/main/packages/sint-pdp-interceptor/__tests__/interceptor.test.ts)
+- Bilateral receipts: [`packages/evidence-ledger/src/proof-receipt.ts`](https://github.com/sint-ai/sint-protocol/blob/main/packages/evidence-ledger/src/proof-receipt.ts)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,11 +13,11 @@ hero:
       text: Quick Start
       link: /getting-started
     - theme: alt
+      text: Interceptor Demo
+      link: /guides/sint-pdp-interceptor-quickstart
+    - theme: alt
       text: Protocol Spec v0.2
       link: /SINT_v0.2_SPEC
-    - theme: alt
-      text: Roadmap
-      link: /roadmap
 
 features:
   - title: Runtime Safety Enforcement
@@ -34,6 +34,7 @@ features:
 - Local docs dev server: `pnpm run docs:dev`
 - Build static docs site: `pnpm run docs:build`
 - Core onboarding: [Getting Started](./getting-started.md)
+- Flagship interceptor demo: [SINT PDP Interceptor Quickstart](./guides/sint-pdp-interceptor-quickstart.md)
 - Integration examples: [Tutorials](./tutorials/hello-world-agent.md)
 - Standalone certification tool: [Guide](./guides/standalone-certification-tool.md)
 - NIST submission playbook: [Guide](./guides/nist-submission-playbook.md)

--- a/examples/sint-pdp-interceptor-quickstart.mjs
+++ b/examples/sint-pdp-interceptor-quickstart.mjs
@@ -1,0 +1,228 @@
+import { canonicalJsonStringify, ApprovalTier, RiskTier } from "../packages/core/dist/index.js";
+import {
+  generateProofReceipt,
+  verifyProofReceipt,
+} from "../packages/evidence-ledger/dist/index.js";
+import {
+  generateKeypair,
+  hashSha256,
+  sign,
+  verify,
+} from "../packages/capability-tokens/dist/index.js";
+import { SINTPDPInterceptor } from "../packages/sint-pdp-interceptor/dist/index.js";
+
+const timestamp = "2026-04-17T07:45:00.000Z";
+const tokenId = "01964000-4200-7000-8000-000000000001";
+const requestId = "01964000-4100-7000-8000-000000000001";
+const agentId = "did:key:z6Mkr7fExampleSINTAgent";
+
+const authority = generateKeypair();
+
+function createLedgerEvent({
+  sequenceNumber,
+  eventId,
+  eventType,
+  payload,
+  previousHash,
+}) {
+  const body = {
+    eventId,
+    sequenceNumber: sequenceNumber.toString(),
+    timestamp,
+    eventType,
+    agentId: authority.publicKey,
+    tokenId,
+    payload,
+    previousHash,
+  };
+
+  return {
+    ...body,
+    sequenceNumber,
+    hash: hashSha256(canonicalJsonStringify(body)),
+  };
+}
+
+function demoGatewayDecision(request) {
+  const toolName = request.params?.toolName;
+
+  if (toolName === "deleteFile") {
+    return {
+      requestId: request.requestId,
+      timestamp,
+      action: "escalate",
+      assignedTier: ApprovalTier.T3_COMMIT,
+      assignedRisk: RiskTier.T3_IRREVERSIBLE,
+      escalation: {
+        requiredTier: ApprovalTier.T3_COMMIT,
+        reason: "Irreversible deletion requires human approval",
+        timeoutMs: 120000,
+        fallbackAction: "deny",
+      },
+    };
+  }
+
+  return {
+    requestId: request.requestId,
+    timestamp,
+    action: "allow",
+    assignedTier: ApprovalTier.T1_PREPARE,
+    assignedRisk: RiskTier.T1_WRITE_LOW,
+    transformations: {
+      additionalAuditFields: {
+        demoFlow: true,
+        receiptMode: "proof-receipt",
+      },
+    },
+  };
+}
+
+function printSection(title) {
+  console.log(`\n=== ${title} ===`);
+}
+
+function printJson(label, value) {
+  console.log(`\n${label}`);
+  console.log(JSON.stringify(value, null, 2));
+}
+
+async function main() {
+  const interceptor = new SINTPDPInterceptor({
+    gateway: {
+      async intercept(request) {
+        return demoGatewayDecision({
+          ...request,
+          params: {
+            ...request.params,
+            toolName:
+              typeof request.resource === "string"
+                ? request.resource.split("/").pop()
+                : undefined,
+          },
+        });
+      },
+    },
+    defaultTokenId: tokenId,
+    now: () => timestamp,
+    createRequestId: () => requestId,
+  });
+
+  console.log("SINT PDP Interceptor — 5 minute quickstart");
+  console.log("Command: pnpm run build && pnpm run demo:interceptor-quickstart");
+
+  printSection("1. Allow path with receipt");
+
+  const allowRequest = {
+    caller_identity: agentId,
+    mcp_call: {
+      serverName: "filesystem",
+      toolName: "writeFile",
+      params: {
+        path: "/workspace/demo.txt",
+        content: "hello from SINT",
+      },
+    },
+  };
+
+  const allowResult = await interceptor.runGuarded(allowRequest, {
+    verifyGatePrerequisite: async () => ({
+      ok: true,
+      evidenceRef: "sint://ledger/gate-allow-001",
+    }),
+    execute: async () => ({
+      status: "ok",
+      bytesWritten: 15,
+    }),
+  });
+
+  printJson("Request", allowRequest);
+  printJson("Decision", allowResult.decision.decision);
+
+  const event1 = createLedgerEvent({
+    sequenceNumber: 1n,
+    eventId: "01964000-5000-7000-8000-000000000001",
+    eventType: "request.received",
+    payload: {
+      requestId,
+      resource: "mcp://filesystem/writeFile",
+    },
+    previousHash: "0".repeat(64),
+  });
+
+  const event2 = createLedgerEvent({
+    sequenceNumber: 2n,
+    eventId: "01964000-5000-7000-8000-000000000002",
+    eventType: "policy.evaluated",
+    payload: {
+      requestId,
+      action: allowResult.decision.decision.action,
+      tier: allowResult.decision.tier,
+    },
+    previousHash: event1.hash,
+  });
+
+  const receipt = generateProofReceipt(
+    event2,
+    [event1, event2],
+    authority.publicKey,
+    (data) => sign(authority.privateKey, data),
+  );
+
+  printJson("Receipt", {
+    eventId: receipt.eventId,
+    eventHash: receipt.eventHash,
+    generatedAt: receipt.generatedAt,
+    hashChainLength: receipt.hashChain.length,
+    signaturePrefix: `${receipt.signature.slice(0, 16)}...`,
+    verified: verifyProofReceipt(receipt, verify),
+  });
+
+  printSection("2. Escalation path");
+
+  const escalateRequest = {
+    caller_identity: agentId,
+    mcp_call: {
+      serverName: "filesystem",
+      toolName: "deleteFile",
+      params: {
+        path: "/workspace/production.db",
+      },
+    },
+  };
+
+  const escalateResult = await interceptor.runGuarded(escalateRequest, {
+    execute: async () => ({ status: "should-not-run" }),
+  });
+
+  printJson("Escalation decision", escalateResult.decision.decision);
+  console.log(`Executed downstream work: ${escalateResult.stage === "executed" ? "yes" : "no"}`);
+
+  printSection("3. Fail-closed missing prerequisite");
+
+  const blockedResult = await interceptor.runGuarded(
+    {
+      caller_identity: agentId,
+      mcp_call: {
+        serverName: "robot-arm",
+        toolName: "moveJoint",
+        params: {
+          joint: "elbow",
+          degrees: 15,
+        },
+      },
+    },
+    {
+      verifyGatePrerequisite: async () => ({
+        ok: false,
+        reason: "No verified gate receipt attached to actuator command",
+      }),
+      execute: async () => ({ status: "should-not-run" }),
+    },
+  );
+
+  printJson("Blocked decision", blockedResult.decision.decision);
+  console.log(`Final stage: ${blockedResult.stage}`);
+  console.log("\nOutcome: the interceptor denied execution before any downstream side effect.");
+}
+
+await main();

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "typecheck": "turbo run typecheck",
     "clean": "turbo run clean",
     "demo": "pnpm --filter @sint/conformance-tests exec vitest run src/e2e-demo.test.ts --reporter=verbose",
+    "demo:interceptor-quickstart": "node ./examples/sint-pdp-interceptor-quickstart.mjs",
     "cert:fixtures": "pnpm --filter ./packages/policy-gateway build && pnpm --filter ./packages/conformance-tests run test:fixtures && pnpm --filter ./packages/bridge-iot run test:fixtures && pnpm --filter ./sdks/typescript run test:contracts && pnpm --filter ./packages/persistence-postgres run test:fixtures",
     "cert:bundle": "node ./scripts/generate-certification-bundle.mjs",
     "nist:bundle": "node ./scripts/generate-nist-submission-bundle.mjs",

--- a/packages/sint-pdp-interceptor/README.md
+++ b/packages/sint-pdp-interceptor/README.md
@@ -6,6 +6,16 @@ This package gives MCP hosts a thin `policy-pdp` interface on top of
 `PolicyGateway.intercept()`. The goal is to make SINT easy to plug into an
 interceptor framework without re-implementing SINT request construction.
 
+For the fastest repo-level walkthrough, run the 5-minute quickstart:
+
+```bash
+pnpm install
+pnpm run build
+pnpm run demo:interceptor-quickstart
+```
+
+Guide: [`docs/guides/sint-pdp-interceptor-quickstart.md`](../../docs/guides/sint-pdp-interceptor-quickstart.md)
+
 ## What it does
 
 - adapts `caller_identity` into `SintRequest.agentId`
@@ -82,9 +92,13 @@ If `action` is not supplied, the adapter defaults to `call`.
 
 ## Current milestone
 
-This scaffold focuses on the adapter package and the core request/decision flow.
-Bilateral receipts and the richer demo path are intentionally tracked as follow-on
-flagship issues so the first package stays simple and installable.
+This package now covers the core flagship path:
+
+- adapter request mapping
+- deterministic decision evaluation
+- bilateral receipt support in the ledger layer
+- fail-closed guarded execution for downstream calls
+- a repo-level 5-minute quickstart and transcript demo
 
 ## Fail-closed guarded execution
 


### PR DESCRIPTION
## Summary
- add a runnable quickstart demo that shows request -> decision -> receipt in one terminal transcript
- link the interceptor demo from the repo README, docs home, getting-started, and package README
- add a dedicated guide for the fail-closed and escalation paths so launch work can point to one builder-facing artifact

## Testing
- pnpm run demo:interceptor-quickstart
- pnpm run docs:build
- git diff --check

Closes #145