### PR TITLE
[codex] Refocus launch assets around interceptor demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,26 @@ docker build -t sint-mcp .
 docker run --rm -i sint-mcp
 ```
 
+## Try the interceptor flagship in 5 minutes
+
+If you want the fastest builder-facing path into the SEP-1763 interceptor work:
+
+```bash
+pnpm install
+pnpm run build
+pnpm run demo:interceptor-quickstart
+```
+
+That walkthrough shows the full flagship loop in one terminal transcript:
+- MCP-style request enters the interceptor
+- SINT returns `allow` or `escalate`
+- an audit receipt is generated for the allowed path
+- execution fail-closes when a gate prerequisite is missing
+
+Start here:
+- [`docs/guides/sint-pdp-interceptor-quickstart.md`](docs/guides/sint-pdp-interceptor-quickstart.md)
+- [`packages/sint-pdp-interceptor`](packages/sint-pdp-interceptor)
+
 ## Why SINT?
 
 AI agents can now control robots, execute code, move money, and operate machinery. But there's no standard security layer between "the LLM decided to do X" and "X happened in the physical world."

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -36,6 +36,7 @@ export default defineConfig({
       {
         text: "Guides",
         items: [
+          { text: "SINT PDP Interceptor Quickstart", link: "/guides/sint-pdp-interceptor-quickstart" },
           { text: "Docker Deployment", link: "/guides/docker-deployment" },
           { text: "Persistence Baseline", link: "/guides/persistence-baseline" },
           { text: "WebSocket Approvals", link: "/guides/websocket-approvals" },

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,6 +2,8 @@
 
 This guide gets you from clone to a complete `token -> intercept -> approval -> ledger` flow in about 10 minutes.
 
+If you want the fastest builder-facing walkthrough for the new interceptor flagship instead of the full local stack, start with [SINT PDP Interceptor Quickstart](./guides/sint-pdp-interceptor-quickstart.md). It shows `request -> decision -> receipt` plus the fail-closed path in one terminal run.
+
 ## Prerequisites
 
 - Node.js 22+

--- a/docs/guides/sint-pdp-interceptor-quickstart.md
+++ b/docs/guides/sint-pdp-interceptor-quickstart.md
@@ -1,0 +1,78 @@
+# SINT PDP Interceptor Quickstart
+
+This is the fastest way to understand the flagship interceptor work from issue #128 without digging through packages or tests.
+
+In one terminal run, you will see:
+
+- an MCP-style request enter `@pshkv/sint-pdp-interceptor`
+- a SINT gateway decision for an allowed operation
+- a proof receipt generated for the audited decision path
+- an escalated operation that does not execute downstream work
+- a fail-closed denial when a gate prerequisite is missing
+
+## Run it
+
+```bash
+pnpm install
+pnpm run build
+pnpm run demo:interceptor-quickstart
+```
+
+The demo entrypoint lives in the repo at [`examples/sint-pdp-interceptor-quickstart.mjs`](https://github.com/sint-ai/sint-protocol/blob/main/examples/sint-pdp-interceptor-quickstart.mjs).
+
+## What the demo covers
+
+### 1. Allow path with receipt
+
+The demo sends a `filesystem.writeFile` style request through the interceptor, gets an `allow` decision, and then generates a proof receipt for the resulting `policy.evaluated` ledger event.
+
+That gives one compact flow:
+
+`request -> decision -> receipt`
+
+### 2. Escalation path
+
+The demo then sends a destructive `filesystem.deleteFile` style request. The gateway responds with `escalate`, and the guarded helper does not run downstream execution.
+
+This is the important behavior for launch messaging: the interceptor does not just classify risk, it blocks irreversible work until an approval path exists.
+
+### 3. Fail-closed path
+
+Finally, the demo shows an actuator-style command with a missing verified gate prerequisite. `runGuarded()` converts that into a deny decision with `policyViolated = "GATE_PREREQUISITE_MISSING"` before any side effect occurs.
+
+## Example transcript
+
+The exact hashes and signatures will vary, but the structure should look like this:
+
+```text
+SINT PDP Interceptor — 5 minute quickstart
+Command: pnpm run build && pnpm run demo:interceptor-quickstart
+
+=== 1. Allow path with receipt ===
+Request
+{ ...filesystem write request... }
+
+Decision
+{ "action": "allow", "assignedTier": "T1_prepare", ... }
+
+Receipt
+{ "eventId": "...", "eventHash": "...", "hashChainLength": 2, "verified": true }
+
+=== 2. Escalation path ===
+Escalation decision
+{ "action": "escalate", "assignedTier": "T3_commit", ... }
+Executed downstream work: no
+
+=== 3. Fail-closed missing prerequisite ===
+Blocked decision
+{ "action": "deny", "denial": { "policyViolated": "GATE_PREREQUISITE_MISSING", ... } }
+Final stage: blocked
+Outcome: the interceptor denied execution before any downstream side effect.
+```
+
+## Where to look next
+
+- Package README: [`packages/sint-pdp-interceptor/README.md`](https://github.com/sint-ai/sint-protocol/blob/main/packages/sint-pdp-interceptor/README.md)
+- Source: [`packages/sint-pdp-interceptor/src/interceptor.ts`](https://github.com/sint-ai/sint-protocol/blob/main/packages/sint-pdp-interceptor/src/interceptor.ts)
+- Tests: [`packages/sint-pdp-interceptor/__tests__/interceptor.test.ts`](https://github.com/sint-ai/sint-protocol/blob/main/packages/sint-pdp-interceptor/__tests__/interceptor.test.ts)
+- Bilateral receipts: [`packages/evidence-ledger/src/proof-receipt.ts`](https://github.com/sint-ai/sint-protocol/blob/main/packages/evidence-ledger/src/proof-receipt.ts)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,11 +13,11 @@ hero:
       text: Quick Start
       link: /getting-started
     - theme: alt
+      text: Interceptor Demo
+      link: /guides/sint-pdp-interceptor-quickstart
+    - theme: alt
       text: Protocol Spec v0.2
       link: /SINT_v0.2_SPEC
-    - theme: alt
-      text: Roadmap
-      link: /roadmap
 
 features:
   - title: Runtime Safety Enforcement
@@ -34,6 +34,7 @@ features:
 - Local docs dev server: `pnpm run docs:dev`
 - Build static docs site: `pnpm run docs:build`
 - Core onboarding: [Getting Started](./getting-started.md)
+- Flagship interceptor demo: [SINT PDP Interceptor Quickstart](./guides/sint-pdp-interceptor-quickstart.md)
 - Integration examples: [Tutorials](./tutorials/hello-world-agent.md)
 - Standalone certification tool: [Guide](./guides/standalone-certification-tool.md)
 - NIST submission playbook: [Guide](./guides/nist-submission-playbook.md)

--- a/docs/social/launch-checklist.md
+++ b/docs/social/launch-checklist.md
@@ -8,57 +8,26 @@ Day-of sequence. Work top to bottom — each step depends on the previous.
 
 - [ ] `git pull --rebase` — confirm on latest master
 - [ ] `pnpm run build && pnpm run test` — all 1,105 tests pass
-- [ ] `node apps/sint-mcp-scanner/dist/cli.js --help` — CLI smoke test
+- [ ] `pnpm run demo:interceptor-quickstart` — demo transcript prints allow, escalate, and fail-closed paths
+- [ ] `pnpm run docs:build` — quickstart guide resolves cleanly in docs site
 
 ---
 
-## Step 1 — Publish @pshkv/mcp-scanner to npm
-
-```bash
-npm login  # log in as sint-ai org or personal account with @sint scope access
-bash scripts/publish-scanner.sh --dry-run  # preview what will be published
-bash scripts/publish-scanner.sh            # publish
-```
-
-Verify:
-```bash
-npx @pshkv/mcp-scanner --server test --tools '[{"name":"bash","description":"runs shell"}]'
-npx sint-scan --help
-```
-
-- [ ] `npx sint-scan` works from a fresh directory (no local install)
-- [ ] npm page at npmjs.com/package/@pshkv/mcp-scanner shows correct README and version
-
----
-
-## Step 2 — Update README Badge
-
-After npm publish, update the npm badge in README.md to the real registry link:
-
-```
-![npm](https://img.shields.io/npm/v/@pshkv/mcp-scanner?label=npm%3A%40sint%2Fmcp-scanner)
-```
-
-Commit: `docs(readme): add live npm badge for @pshkv/mcp-scanner`
-
----
-
-## Step 3 — Post X Thread
+## Step 1 — Post X Thread
 
 Copy from `docs/social/twitter-launch-thread.md`. Post as a thread (7 tweets, each is one block).
 
-- [ ] Attach [VIDEO] to Tweet 1 — 30s demo: dashboard + ROS2 robot arm denial
-- [ ] Attach [SCREENSHOT] to Tweet 4 — terminal showing `npx sint-scan` CRITICAL output
-- [ ] Tag all accounts in Tweet 7: @jspahrsummers @doppenhe @Aurimas_Gr @M_haggis @SlowMist_Team
+- [ ] Attach [VIDEO] to Tweet 1 — 30s terminal demo: allow, escalate, fail-closed
+- [ ] Attach [SCREENSHOT] to Tweet 4 — terminal showing `pnpm run demo:interceptor-quickstart`
 - [ ] Post thread
 
 ---
 
-## Step 4 — Post Show HN
+## Step 2 — Post Show HN
 
 Copy from `docs/social/show-hn-draft.md`.
 
-- Title: `Show HN: SINT Protocol – MCP security layer with capability tokens, T0–T3 tiers, and tamper-evident audit log`
+- Title: `Show HN: A fail-closed policy interceptor for MCP-style agent tool calls`
 - URL: `https://github.com/sint-ai/sint-protocol`
 - Post the comment text as the first comment immediately after submission
 
@@ -67,49 +36,42 @@ Copy from `docs/social/show-hn-draft.md`.
 
 ---
 
-## Step 5 — Post LinkedIn
+## Step 3 — Post LinkedIn
 
 Copy from `docs/social/linkedin-launch-post.md`.
 
 - [ ] Post published
-- [ ] Tagged: Anthropic, Open Robotics, NIST
 
 ---
 
-## Step 6 — Community Distribution
+## Step 4 — Community Distribution
 
 From `COMMUNITY-TARGETS.md`:
 
 - [ ] MCP Discord — #show-and-tell or #security channel
-- [ ] LangChain Discord — #announcements or #tools
-- [ ] Hugging Face Discord — #agents
-- [ ] Reply to @doppenhe MCP security posts
-- [ ] Reply to @Aurimas_Gr robotics security posts
-- [ ] Reply to @M_haggis physical AI posts
-- [ ] DM @SlowMist_Team for security research collaboration
+- [ ] awesome-mcp-servers or equivalent listing with the quickstart guide
+- [ ] One standards-adjacent channel only after launch thread is live
 
 ---
 
-## Step 7 — Outreach Emails
+## Step 5 — Outreach Emails
 
-- [ ] ros-security@openrobotics.org — attach WHITEPAPER.md summary, link to GitHub
-- [ ] ai-inquiries@nist.gov — NIST AI RMF alignment section from WHITEPAPER.md (Section 8.1)
+- [ ] Only send if there is inbound interest or a concrete submission reason
+- [ ] Lead with the runnable demo and exact technical scope, not broad pitch language
 
 ---
 
-## Step 8 — Monitor and Respond
+## Step 6 — Monitor and Respond
 
 - [ ] Set up GitHub notification for new issues/stars
 - [ ] Respond to HN comments within 2 hours of submission
 - [ ] Respond to X replies within 2 hours of posting
-- [ ] Track star count: target 50 stars day 1, 200 by end of week
+- [ ] Track clickthrough to the quickstart guide and demo path, not just stars
 
 ---
 
 ## Human-Only Actions (Cannot Be Automated)
 
-- Recording the 30-second demo video (dashboard + ROS2 denial)
-- `npm login` authentication
+- Recording the 30-second terminal demo
 - Actually posting to X, HN, LinkedIn
-- Sending emails to ros-security@ and ai-inquiries@
 - Responding to community replies

--- a/docs/social/linkedin-launch-post.md
+++ b/docs/social/linkedin-launch-post.md
@@ -1,41 +1,34 @@
-# LinkedIn Launch Post — SINT Protocol
+# LinkedIn Launch Post — Interceptor Demo
 
-> **Instructions:** Post from personal or company account. Tone: professional, outcome-focused. Tag company pages where possible.
+> **Instructions:** Post from personal or company account. Tone: professional, technical, and concrete.
 
 ---
 
 ## Post Text
 
-AI agents are moving into production — controlling robots, executing code, managing infrastructure. But most deployments have a dangerous gap: **there's no authorization layer between the model's decision and the physical action.**
+AI agents are moving into production, but there is still a missing layer between “the model chose a tool” and “the side effect happened.”
 
-Today we're open-sourcing **SINT Protocol** — the security enforcement layer for production AI agents.
+We just shipped a concrete piece of that gap: a fail-closed reference interceptor for MCP-style tool calls in **SINT Protocol**.
 
-SINT sits between your AI agents and every tool they can call. Every action is authorized by a signed capability token, classified into an approval tier (auto-approve → human sign-off), and recorded in a tamper-evident audit log. Shell execution and irreversible operations require explicit human approval. Physics constraints — velocity, force, geofence — are enforced at the protocol level, not in application code.
+The builder-facing path is intentionally simple:
+- a request enters the interceptor
+- SINT returns `allow`, `escalate`, or `deny`
+- the allowed path gets a proof receipt
+- missing prerequisites fail closed before downstream execution runs
 
-**Why it matters for enterprises:**
-- **EU AI Act compliance** — Article 14(4)(e) human oversight requirement is built-in via the CircuitBreaker stop mechanism
-- **NIST AI RMF alignment** — GOVERN-1.1 (human oversight), MANAGE-4.2 (incident response), MEASURE-2.6 (monitoring) are directly addressed
-- **Audit-ready** — SHA-256 hash-chained evidence ledger with SIEM export. Every agent decision is cryptographically recorded
-- **MCP + ROS2 + IoT ready** — bridge adapters for Model Context Protocol, ROS 2, MAVLink, MQTT, OPC-UA out of the box
+We also turned it into a 5-minute quickstart so people can see the whole `request -> decision -> receipt` loop in one terminal run instead of reading around the repo.
 
-1,105 tests. 31 packages. Apache-2.0. Production-ready Docker Compose deployment.
+What I find most interesting is not just the allow/deny logic, but the explicit fail-closed behavior when the system lacks the prerequisite evidence to continue safely.
 
-Scan your MCP server's tools right now: `npx sint-scan`
+If you build agent tooling, infra, or security controls, I’d genuinely love feedback on whether this is the right shape for a reference interceptor.
 
 GitHub: https://github.com/sint-ai/sint-protocol
-Whitepaper: https://github.com/sint-ai/sint-protocol/blob/master/WHITEPAPER.md
+Quickstart guide: https://github.com/sint-ai/sint-protocol/blob/main/docs/guides/sint-pdp-interceptor-quickstart.md
 
-What gap in AI agent security keeps you up at night? Happy to discuss in the comments.
+What would you want to see before trusting a policy interceptor in front of real tools?
 
 ---
 
 ## Hashtags
 
-#AIAgents #AIGovernance #MCP #PhysicalAI #CyberSecurity #Robotics #EUAIAct #NIST #OpenSource #AgentSecurity
-
-## Tags to include (company pages)
-
-- Anthropic
-- Open Robotics
-- NIST
-
+#AIAgents #MCP #AgentSecurity #CyberSecurity #OpenSource #DeveloperTools

--- a/docs/social/show-hn-draft.md
+++ b/docs/social/show-hn-draft.md
@@ -1,6 +1,6 @@
-# Show HN Draft — SINT Protocol
+# Show HN Draft — Interceptor Demo
 
-> **Title:** Show HN: SINT Protocol – Runtime authorization for physical AI agents (robots, drones, actuators)
+> **Title:** Show HN: A fail-closed policy interceptor for MCP-style agent tool calls
 
 > **URL:** https://github.com/sint-ai/sint-protocol
 
@@ -10,68 +10,52 @@
 
 Hi HN,
 
-Try this first — it'll make the rest concrete:
+The fastest way to see what this does is:
 
 ```bash
-npx sint-scan --server myserver --tools '[
-  {"name":"bash","description":"runs shell commands"},
-  {"name":"readFile","description":"reads files"},
-  {"name":"deleteFile","description":"deletes files"}
-]'
+pnpm install
+pnpm run build
+pnpm run demo:interceptor-quickstart
 ```
 
-It maps your MCP server's tools to SINT approval tiers and flags anything that needs human sign-off before an agent can call it. Exit code 2 on CRITICAL — drop it in CI.
+That prints one full terminal transcript:
+- an MCP-style request enters the interceptor
+- SINT returns `allow` or `escalate`
+- the allowed path gets an audit receipt
+- execution fail-closes when a verified prerequisite is missing
 
 ---
 
-**Why we built this:**
+**Why we built it:**
 
-MCP gives AI agents powerful tools. But there's no authorization layer between "the LLM decided to call bash()" and "bash() ran." No token required. No audit trail. No rate limit. No human-in-the-loop. If the agent is compromised, you find out when the damage is done.
+MCP gives agents useful tools, but there is still a missing layer between “the model chose a tool” and “the real side effect happened.”
 
-We built SINT Protocol because we needed a principled answer to: *what should actually happen between an agent's decision and a physical action?*
-
----
-
-**What SINT does:**
-
-Every agent action (tool call, robot command, code execution) passes through a single Policy Gateway that enforces:
-
-1. **Capability tokens** — Ed25519-signed, attenuating credentials scoped to specific resources and actions. Delegation can only reduce permissions, never escalate.
-
-2. **Tiered approval (T0–T3)** — authorization requirements matched to physical consequence severity:
-   - T0 OBSERVE: `readFile`, `listDir` → auto-approved, logged
-   - T1 PREPARE: `writeFile`, `saveConfig` → auto-approved, audited
-   - T2 ACT: `deleteFile`, `moveRobot` → escalation required
-   - T3 COMMIT: `bash`, `exec`, `eval` → human sign-off required
-
-3. **Physics constraints** — hard velocity/force/geofence limits enforced at the protocol level, not in application code that can be bypassed.
-
-4. **Tamper-evident ledger** — SHA-256 hash-chained, append-only audit log. Every decision is recorded and cryptographically detectable if tampered with.
+This project is a reference answer to a narrow question: what should sit in that gap when the operation is destructive, irreversible, or missing the evidence required to continue safely?
 
 ---
 
-**How it differs from Microsoft Agent Governance Toolkit:**
-Microsoft AGT (released April 2, 2026) targets digital/software agents — LangChain, CrewAI, etc. SINT targets physical AI — robots, drones, factory actuators — where actions are irreversible and have real-world consequences. Different problem, different enforcement model.
+**What the demo shows:**
 
-**Technical details:**
-- TypeScript monorepo, 42 packages, 1,973 tests
-- Bridge adapters for MCP, ROS 2, MAVLink, MQTT, OPC-UA, gRPC, A2A, Open-RMF, Sparkplug B (12 bridges)
-- Works as a proxy between any AI agent and any tool server
-- All 10 OWASP Agentic AI Top-10 categories regression-tested (29 fixture pairs)
-- ROS2 control-loop latency: p99 < 5ms steady-state
-- Constraint Language CL-1.0: portable machine-readable safety envelopes across all bridges
-- Public capability token registry (`@sint/token-registry`) for agent discovery
-- Result<T, E> pattern throughout — no exceptions for control flow
-- Apache 2.0 licensed
+1. **Tiered decisions** — lower-risk operations can proceed; higher-risk ones escalate before execution.
+2. **Fail-closed behavior** — if a required prerequisite is missing, the helper denies the action before downstream work runs.
+3. **Tamper-evident receipts** — the allowed path gets a proof receipt tied to the ledger chain so the audit story is explicit.
+
+The full repo is broader than the demo, but the demo is the most concrete path into the interception model.
 
 ---
 
-**What we're looking for:** Feedback on the security model, the tier classification system, and the capability token design. We're especially interested in hearing from people building with MCP servers, physical robots, or agentic pipelines where an agent going wrong would have real consequences.
+**Implementation shape:**
+- TypeScript monorepo
+- reference `sint-pdp-interceptor` package
+- deterministic canonical hashing for signed decision and receipt paths
+- bilateral proof receipts in the ledger layer
+- fail-closed guarded execution helper for downstream calls
 
-Want to know if your MCP server has unsafe tools? Run:
+---
 
-```bash
-npx sint-scan --server myserver --tools '[{"name":"bash","description":"runs shell"}]'
-```
+**What I’d love feedback on:** whether this is the right shape for a reference interceptor:
+- is `allow / escalate / deny` the right decision surface?
+- is “fail closed on missing prerequisite” the right default?
+- what would you want added before using this pattern in front of real tools?
 
-Happy to answer questions about the architecture or design decisions.
+Happy to answer questions about the design tradeoffs.

--- a/docs/social/twitter-launch-thread.md
+++ b/docs/social/twitter-launch-thread.md
@@ -1,87 +1,87 @@
-# X/Twitter Launch Thread — SINT Protocol
+# X/Twitter Launch Thread — Interceptor Demo
 
-> **Instructions:** Post as a thread. Each numbered section = one tweet. Add [VIDEO] asset to Tweet 1 (30s demo: dashboard + ROS2 robot denial). Screenshot of `npx sint-scan` output goes in Tweet 4.
+> **Instructions:** Post as a thread. Each numbered section = one tweet. Add [VIDEO] asset to Tweet 1 showing the interceptor quickstart transcript or terminal flow.
 
 ---
 
 **1/**
-We built the Policy Gateway MCP has been begging for.
+We built a fail-closed policy interceptor for MCP-style tool calls.
 
-Capability tokens. T0–T3 approval tiers. Physics constraints. Tamper-evident ledger.
+It gives one concrete path:
+request -> decision -> receipt
 
-Every agent action — tool calls, robot commands, code execution — flows through a single choke point before it touches the real world.
+And when a prerequisite is missing, downstream execution does not run.
 
-[VIDEO: 30s demo — dashboard + ROS2 robot denial]
+[VIDEO: quick terminal demo — allow, escalate, fail-closed]
 
 github.com/sint-ai/sint-protocol
 
 ---
 
 **2/**
-Here's the gap nobody talks about:
+The gap it tries to close:
 
-MCP gives AI agents powerful tools. But there's zero authorization between "the LLM decided to call bash()" and "bash() ran."
+an agent decides to call a tool, and the real side effect happens immediately.
 
-No token required. No audit trail. No rate limit. No human-in-the-loop.
-
-If the agent is compromised, you find out when the damage is done.
+That’s fine for some workloads, but not for destructive or irreversible ones.
 
 ---
 
 **3/**
-SINT maps authorization to physical consequence:
+The demo shows three outcomes:
 
-🟢 T0 OBSERVE — readFile, listDir → auto-allowed, logged
-🟡 T1 PREPARE — writeFile, saveConfig → auto-allowed, audited
-🟠 T2 ACT — deleteFile, moveRobot → requires escalation
-🔴 T3 COMMIT — bash, exec, eval → requires human sign-off
+1. `allow`
+2. `escalate`
+3. `deny` before execution when a required prerequisite is missing
 
-A robot arm moving at 3 m/s needs different governance than a read query. SINT encodes that difference.
+That last one was the behavior we cared about most.
 
 ---
 
 **4/**
-`npx sint-scan` — audit any MCP server for risks in 10 seconds:
+Fastest way to try it:
 
-[SCREENSHOT: terminal showing CRITICAL bash + HIGH deleteFile + recommendations]
+[SCREENSHOT: terminal showing quickstart transcript]
 
+```bash
+pnpm install
+pnpm run build
+pnpm run demo:interceptor-quickstart
 ```
-npx sint-scan --server myserver \
-  --tools '[{"name":"bash","description":"runs shell"}]'
-```
 
-Exit code 2 on CRITICAL. Drop it in your CI pipeline.
+The quickstart guide is in the repo and walks through the exact flow.
 
 ---
 
 **5/**
-Two features nobody else has:
+Two implementation details that mattered:
 
-**Physics constraints** — velocity caps, force limits, geofence polygons enforced at the protocol level. Not in application code that can be bypassed.
+Deterministic canonical hashing for signed decision and receipt paths.
 
-**Tamper-evident ledger** — SHA-256 hash-chained, append-only. Every decision recorded. Any tampering is cryptographically detectable.
-
-Your compliance team will thank you.
+Proof receipts so the allowed path has explicit audit evidence rather than “trust us, it was logged.”
 
 ---
 
 **6/**
-Full OWASP Agentic AI Top-10 coverage. All 10 ASI categories regression-tested:
+The broader repo goes further than the demo:
 
-ASI01 goal hijacking → GoalHijackPlugin (5-layer heuristics)
-ASI05 shell via tool calls → T3 classifier
-ASI06 memory poisoning → MemoryIntegrityChecker
-ASI10 rogue agent → CircuitBreakerPlugin (EU AI Act Art. 14(4)(e) stop button)
+- interceptor package
+- ledger layer
+- capability tokens
+- MCP / ROS2 / MAVLink / industrial bridges
 
-1,105 tests. 31 packages. Apache-2.0.
+But the quickstart is the shortest path to understanding the core model.
 
 ---
 
 **7/**
-If you're building with MCP, thinking about physical AI, or care about what happens when agents go wrong — this is for you.
+If you’re building agent tooling and care about what should happen between “tool selected” and “side effect happened,” I’d love feedback.
 
-Star, share, break it: github.com/sint-ai/sint-protocol
+Especially on:
+- fail-closed defaults
+- escalation ergonomics
+- what a reference interceptor should expose
 
-cc @jspahrsummers @doppenhe @Aurimas_Gr @M_haggis @SlowMist_Team
+github.com/sint-ai/sint-protocol
 
-#MCP #AgentSecurity #PhysicalAI #AIGovernance #OWASP
+#MCP #AgentSecurity #AIAgents #OpenSource

--- a/examples/sint-pdp-interceptor-quickstart.mjs
+++ b/examples/sint-pdp-interceptor-quickstart.mjs
@@ -1,0 +1,228 @@
+import { canonicalJsonStringify, ApprovalTier, RiskTier } from "../packages/core/dist/index.js";
+import {
+  generateProofReceipt,
+  verifyProofReceipt,
+} from "../packages/evidence-ledger/dist/index.js";
+import {
+  generateKeypair,
+  hashSha256,
+  sign,
+  verify,
+} from "../packages/capability-tokens/dist/index.js";
+import { SINTPDPInterceptor } from "../packages/sint-pdp-interceptor/dist/index.js";
+
+const timestamp = "2026-04-17T07:45:00.000Z";
+const tokenId = "01964000-4200-7000-8000-000000000001";
+const requestId = "01964000-4100-7000-8000-000000000001";
+const agentId = "did:key:z6Mkr7fExampleSINTAgent";
+
+const authority = generateKeypair();
+
+function createLedgerEvent({
+  sequenceNumber,
+  eventId,
+  eventType,
+  payload,
+  previousHash,
+}) {
+  const body = {
+    eventId,
+    sequenceNumber: sequenceNumber.toString(),
+    timestamp,
+    eventType,
+    agentId: authority.publicKey,
+    tokenId,
+    payload,
+    previousHash,
+  };
+
+  return {
+    ...body,
+    sequenceNumber,
+    hash: hashSha256(canonicalJsonStringify(body)),
+  };
+}
+
+function demoGatewayDecision(request) {
+  const toolName = request.params?.toolName;
+
+  if (toolName === "deleteFile") {
+    return {
+      requestId: request.requestId,
+      timestamp,
+      action: "escalate",
+      assignedTier: ApprovalTier.T3_COMMIT,
+      assignedRisk: RiskTier.T3_IRREVERSIBLE,
+      escalation: {
+        requiredTier: ApprovalTier.T3_COMMIT,
+        reason: "Irreversible deletion requires human approval",
+        timeoutMs: 120000,
+        fallbackAction: "deny",
+      },
+    };
+  }
+
+  return {
+    requestId: request.requestId,
+    timestamp,
+    action: "allow",
+    assignedTier: ApprovalTier.T1_PREPARE,
+    assignedRisk: RiskTier.T1_WRITE_LOW,
+    transformations: {
+      additionalAuditFields: {
+        demoFlow: true,
+        receiptMode: "proof-receipt",
+      },
+    },
+  };
+}
+
+function printSection(title) {
+  console.log(`\n=== ${title} ===`);
+}
+
+function printJson(label, value) {
+  console.log(`\n${label}`);
+  console.log(JSON.stringify(value, null, 2));
+}
+
+async function main() {
+  const interceptor = new SINTPDPInterceptor({
+    gateway: {
+      async intercept(request) {
+        return demoGatewayDecision({
+          ...request,
+          params: {
+            ...request.params,
+            toolName:
+              typeof request.resource === "string"
+                ? request.resource.split("/").pop()
+                : undefined,
+          },
+        });
+      },
+    },
+    defaultTokenId: tokenId,
+    now: () => timestamp,
+    createRequestId: () => requestId,
+  });
+
+  console.log("SINT PDP Interceptor — 5 minute quickstart");
+  console.log("Command: pnpm run build && pnpm run demo:interceptor-quickstart");
+
+  printSection("1. Allow path with receipt");
+
+  const allowRequest = {
+    caller_identity: agentId,
+    mcp_call: {
+      serverName: "filesystem",
+      toolName: "writeFile",
+      params: {
+        path: "/workspace/demo.txt",
+        content: "hello from SINT",
+      },
+    },
+  };
+
+  const allowResult = await interceptor.runGuarded(allowRequest, {
+    verifyGatePrerequisite: async () => ({
+      ok: true,
+      evidenceRef: "sint://ledger/gate-allow-001",
+    }),
+    execute: async () => ({
+      status: "ok",
+      bytesWritten: 15,
+    }),
+  });
+
+  printJson("Request", allowRequest);
+  printJson("Decision", allowResult.decision.decision);
+
+  const event1 = createLedgerEvent({
+    sequenceNumber: 1n,
+    eventId: "01964000-5000-7000-8000-000000000001",
+    eventType: "request.received",
+    payload: {
+      requestId,
+      resource: "mcp://filesystem/writeFile",
+    },
+    previousHash: "0".repeat(64),
+  });
+
+  const event2 = createLedgerEvent({
+    sequenceNumber: 2n,
+    eventId: "01964000-5000-7000-8000-000000000002",
+    eventType: "policy.evaluated",
+    payload: {
+      requestId,
+      action: allowResult.decision.decision.action,
+      tier: allowResult.decision.tier,
+    },
+    previousHash: event1.hash,
+  });
+
+  const receipt = generateProofReceipt(
+    event2,
+    [event1, event2],
+    authority.publicKey,
+    (data) => sign(authority.privateKey, data),
+  );
+
+  printJson("Receipt", {
+    eventId: receipt.eventId,
+    eventHash: receipt.eventHash,
+    generatedAt: receipt.generatedAt,
+    hashChainLength: receipt.hashChain.length,
+    signaturePrefix: `${receipt.signature.slice(0, 16)}...`,
+    verified: verifyProofReceipt(receipt, verify),
+  });
+
+  printSection("2. Escalation path");
+
+  const escalateRequest = {
+    caller_identity: agentId,
+    mcp_call: {
+      serverName: "filesystem",
+      toolName: "deleteFile",
+      params: {
+        path: "/workspace/production.db",
+      },
+    },
+  };
+
+  const escalateResult = await interceptor.runGuarded(escalateRequest, {
+    execute: async () => ({ status: "should-not-run" }),
+  });
+
+  printJson("Escalation decision", escalateResult.decision.decision);
+  console.log(`Executed downstream work: ${escalateResult.stage === "executed" ? "yes" : "no"}`);
+
+  printSection("3. Fail-closed missing prerequisite");
+
+  const blockedResult = await interceptor.runGuarded(
+    {
+      caller_identity: agentId,
+      mcp_call: {
+        serverName: "robot-arm",
+        toolName: "moveJoint",
+        params: {
+          joint: "elbow",
+          degrees: 15,
+        },
+      },
+    },
+    {
+      verifyGatePrerequisite: async () => ({
+        ok: false,
+        reason: "No verified gate receipt attached to actuator command",
+      }),
+      execute: async () => ({ status: "should-not-run" }),
+    },
+  );
+
+  printJson("Blocked decision", blockedResult.decision.decision);
+  console.log(`Final stage: ${blockedResult.stage}`);
+  console.log("\nOutcome: the interceptor denied execution before any downstream side effect.");
+}
+
+await main();

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "typecheck": "turbo run typecheck",
     "clean": "turbo run clean",
     "demo": "pnpm --filter @sint/conformance-tests exec vitest run src/e2e-demo.test.ts --reporter=verbose",
+    "demo:interceptor-quickstart": "node ./examples/sint-pdp-interceptor-quickstart.mjs",
     "cert:fixtures": "pnpm --filter ./packages/policy-gateway build && pnpm --filter ./packages/conformance-tests run test:fixtures && pnpm --filter ./packages/bridge-iot run test:fixtures && pnpm --filter ./sdks/typescript run test:contracts && pnpm --filter ./packages/persistence-postgres run test:fixtures",
     "cert:bundle": "node ./scripts/generate-certification-bundle.mjs",
     "nist:bundle": "node ./scripts/generate-nist-submission-bundle.mjs",

--- a/packages/sint-pdp-interceptor/README.md
+++ b/packages/sint-pdp-interceptor/README.md
@@ -6,6 +6,16 @@ This package gives MCP hosts a thin `policy-pdp` interface on top of
 `PolicyGateway.intercept()`. The goal is to make SINT easy to plug into an
 interceptor framework without re-implementing SINT request construction.
 
+For the fastest repo-level walkthrough, run the 5-minute quickstart:
+
+```bash
+pnpm install
+pnpm run build
+pnpm run demo:interceptor-quickstart
+```
+
+Guide: [`docs/guides/sint-pdp-interceptor-quickstart.md`](../../docs/guides/sint-pdp-interceptor-quickstart.md)
+
 ## What it does
 
 - adapts `caller_identity` into `SintRequest.agentId`
@@ -82,9 +92,13 @@ If `action` is not supplied, the adapter defaults to `call`.
 
 ## Current milestone
 
-This scaffold focuses on the adapter package and the core request/decision flow.
-Bilateral receipts and the richer demo path are intentionally tracked as follow-on
-flagship issues so the first package stays simple and installable.
+This package now covers the core flagship path:
+
+- adapter request mapping
+- deterministic decision evaluation
+- bilateral receipt support in the ledger layer
+- fail-closed guarded execution for downstream calls
+- a repo-level 5-minute quickstart and transcript demo
 
 ## Fail-closed guarded execution
 


### PR DESCRIPTION
## Summary
- rewrite the launch assets so they point to the interceptor quickstart as the primary builder CTA
- update Show HN, X/Twitter, and LinkedIn drafts to center the fail-closed demo path
- simplify the launch checklist so it unlocks cleanly after the quickstart PR lands

## Testing
- pnpm run docs:build
- git diff --check

Depends on #153 for the quickstart guide and demo entrypoint.