### PR TITLE
Add Official MCP Registry manifest (.mcp/server.json)

### DIFF
--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "name": "io.github.pshkv/sint-mcp",
+  "version": "0.1.0",
+  "title": "SINT MCP",
+  "description": "Security-first MCP proxy with policy enforcement, approvals, and audit receipts.",
+  "websiteUrl": "https://github.com/sint-ai/sint-protocol/tree/main/apps/sint-mcp",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "sint-mcp",
+      "version": "0.1.0",
+      "transport": { "type": "stdio" },
+      "packageArguments": [],
+      "environmentVariables": [
+        { "name": "SINT_MCP_CONFIG", "required": false, "description": "Path to a sint-mcp JSON config file." },
+        { "name": "SINT_MCP_POLICY", "required": false, "description": "Default enforcement posture (permissive|cautious|strict)." },
+        { "name": "SINT_MCP_TRANSPORT", "required": false, "description": "Transport mode (stdio|sse). Defaults to stdio." },
+        { "name": "SINT_MCP_PORT", "required": false, "description": "Port used only when transport is sse." },
+        { "name": "SINT_MCP_APPROVAL_TIMEOUT", "required": false, "description": "Approval timeout in ms (default 120000)." },
+        { "name": "SINT_AGENT_PRIVATE_KEY", "required": false, "description": "Ed25519 private key hex (optional; omit to auto-generate)." }
+      ]
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/sint-ai/sint-protocol",
+    "source": "github"
+  }
+}
+

--- a/apps/sint-mcp/README.md
+++ b/apps/sint-mcp/README.md
@@ -1,5 +1,7 @@
 # sint-mcp
 
+<!-- mcp-name: io.github.pshkv/sint-mcp -->
+
 **Security-first MCP proxy server.** Connects to any number of downstream MCP servers and enforces SINT capability-token policy on every tool call before it reaches the real tool. Provides human-in-the-loop approval for high-consequence actions, a hash-chained audit ledger, and operator interface controls — all through the MCP protocol.
 
 ## How it works

--- a/docs/guides/mcp-registry-publish.md
+++ b/docs/guides/mcp-registry-publish.md
@@ -1,0 +1,33 @@
+# Publish `sint-mcp` To The Official MCP Registry
+
+This repo ships an official MCP Registry manifest at `.mcp/server.json`.
+
+## What Gets Published
+
+- Registry listing name: `io.github.pshkv/sint-mcp`
+- npm package: `sint-mcp`
+- Transport: `stdio`
+
+The `apps/sint-mcp/README.md` includes the required marker:
+
+```text
+<!-- mcp-name: io.github.pshkv/sint-mcp -->
+```
+
+## Publish Steps
+
+1. Download the `mcp-publisher` binary for your OS/arch from the latest release of `modelcontextprotocol/registry`.
+2. Authenticate (GitHub-based namespace):
+
+```bash
+./mcp-publisher login github
+```
+
+3. Publish the manifest:
+
+```bash
+./mcp-publisher publish .mcp/server.json
+```
+
+4. Verify in the registry UI by searching for `sint-mcp`.
+


### PR DESCRIPTION
Adds an official MCP Registry manifest for `sint-mcp` at `.mcp/server.json` and documents the publish flow.

Also includes the required README marker:
- `apps/sint-mcp/README.md`: `<!-- mcp-name: io.github.pshkv/sint-mcp -->`