### PR TITLE
Tighten Show HN draft around the 5-minute demo

### DIFF
--- a/docs/social/show-hn-draft.md
+++ b/docs/social/show-hn-draft.md
@@ -1,6 +1,6 @@
 # Show HN Draft — Interceptor Demo
 
-> **Title:** Show HN: A fail-closed policy interceptor for MCP-style agent tool calls
+> **Title:** Show HN: A fail-closed policy interceptor for MCP agent tool calls (with receipts)
 
 > **URL:** https://github.com/sint-ai/sint-protocol
 
@@ -10,35 +10,34 @@
 
 Hi HN,
 
-The fastest way to see what this does is:
+If you only try one thing, run the **5-minute interceptor demo** (Node 22 + pnpm):
 
 ```bash
-pnpm install
+pnpm install --frozen-lockfile
 pnpm run build
 pnpm run demo:interceptor-quickstart
 ```
 
-That prints one full terminal transcript:
-- an MCP-style request enters the interceptor
-- SINT returns `allow` or `escalate`
-- the allowed path gets an audit receipt
-- execution fail-closes when a verified prerequisite is missing
+It prints one terminal transcript with three paths:
+1. **Allow**: tool call proceeds and produces a tamper-evident proof receipt.
+2. **Escalate**: irreversible tool call is blocked pending approval (and does not execute).
+3. **Fail-closed**: a physical/actuator-like call is denied when a required prerequisite is missing (no “best effort” fallback).
 
 ---
 
 **Why we built it:**
 
-MCP gives agents useful tools, but there is still a missing layer between “the model chose a tool” and “the real side effect happened.”
+MCP gives agents useful tools, but there’s still a missing layer between “the model chose a tool” and “the real side effect happened.”
 
-This project is a reference answer to a narrow question: what should sit in that gap when the operation is destructive, irreversible, or missing the evidence required to continue safely?
+This is a reference answer to a narrow question: what should sit in that gap when the operation is destructive/irreversible, or missing evidence required to continue safely?
 
 ---
 
 **What the demo shows:**
 
 1. **Tiered decisions** — lower-risk operations can proceed; higher-risk ones escalate before execution.
-2. **Fail-closed behavior** — if a required prerequisite is missing, the helper denies the action before downstream work runs.
-3. **Tamper-evident receipts** — the allowed path gets a proof receipt tied to the ledger chain so the audit story is explicit.
+2. **Fail-closed behavior** — if a required prerequisite is missing, execution is denied before any downstream work runs.
+3. **Tamper-evident receipts** — allowed paths get a signed receipt tied to a hash chain (portable verification via canonical JSON).
 
 The full repo is broader than the demo, but the demo is the most concrete path into the interception model.
 
@@ -47,9 +46,9 @@ The full repo is broader than the demo, but the demo is the most concrete path i
 **Implementation shape:**
 - TypeScript monorepo
 - reference `sint-pdp-interceptor` package
-- deterministic canonical hashing for signed decision and receipt paths
-- bilateral proof receipts in the ledger layer
-- fail-closed guarded execution helper for downstream calls
+- deterministic canonical hashing for signed decision + receipt paths
+- proof receipts in the ledger layer (and room for bilateral receipts)
+- guarded execution helper for downstream calls
 
 ---
 
@@ -58,4 +57,4 @@ The full repo is broader than the demo, but the demo is the most concrete path i
 - is “fail closed on missing prerequisite” the right default?
 - what would you want added before using this pattern in front of real tools?
 
-Happy to answer questions about the design tradeoffs.
+Happy to answer questions about the tradeoffs, or to share a minimal “wrap an existing MCP server” example if that’s more interesting than the toy demo.


### PR DESCRIPTION
Refocuses the Show HN draft to lead with the single 5-minute interceptor demo, and makes the fail-closed + receipt story obvious in the first paragraph.