### PR TITLE
Make docker compose stack runnable out of the box

### DIFF
--- a/apps/gateway-server/package.json
+++ b/apps/gateway-server/package.json
@@ -36,13 +36,13 @@
     "@pshkv/interface-bridge": "workspace:*",
     "@pshkv/persistence": "workspace:*",
     "hono": "^4.7.0",
+    "ioredis": "^5.4.0",
     "ws": "^8.18.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {
     "@types/node": "^22.13.0",
     "@types/ws": "^8.18.1",
-    "ioredis": "^5.4.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"

--- a/apps/gateway-server/src/redis-factory.ts
+++ b/apps/gateway-server/src/redis-factory.ts
@@ -7,15 +7,16 @@
  * @module @sint/gateway-server/redis-factory
  */
 
+import { createRequire } from "node:module";
 import type { Redis } from "ioredis";
+
+const require = createRequire(import.meta.url);
 
 /**
  * Create a new Redis connection.
- * Uses dynamic require to handle ioredis' CJS export pattern.
+ * Uses createRequire(import.meta.url) to pull ioredis' CJS export from an ESM module.
  */
 export function createRedisClient(url: string): Redis {
-  // ioredis uses `export = Redis` (CJS) — must use require for Node16 moduleResolution
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const RedisConstructor = require("ioredis") as new (url: string) => Redis;
   return new RedisConstructor(url);
 }

--- a/apps/sint-interface/Dockerfile
+++ b/apps/sint-interface/Dockerfile
@@ -25,7 +25,7 @@ COPY packages/bridge-economy/package.json     packages/bridge-economy/
 COPY apps/gateway-server/package.json         apps/gateway-server/
 
 # Install only dependencies needed for the interface
-RUN pnpm install --frozen-lockfile --filter @sint/interface...
+RUN pnpm install --frozen-lockfile --filter @pshkv/interface...
 
 # Copy interface source
 COPY apps/sint-interface/ apps/sint-interface/

--- a/docs/profiles/sros2-sint.docker-compose.yml
+++ b/docs/profiles/sros2-sint.docker-compose.yml
@@ -19,7 +19,7 @@ services:
     command: >
       sh -c "npm install -g pnpm &&
              pnpm install --frozen-lockfile &&
-             pnpm --filter @sint/gateway-server build &&
+             pnpm --filter @pshkv/gateway-server build &&
              node apps/gateway-server/dist/index.js"
     environment:
       - SINT_STORE=memory

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       hono:
         specifier: ^4.7.0
         version: 4.12.8
+      ioredis:
+        specifier: ^5.4.0
+        version: 5.10.0
       ws:
         specifier: ^8.18.0
         version: 8.19.0
@@ -141,9 +144,6 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
-      ioredis:
-        specifier: ^5.4.0
-        version: 5.10.0
       tsx:
         specifier: ^4.19.0
         version: 4.21.0


### PR DESCRIPTION
## Summary

`pnpm stack:interface` fails cleanly out of the box with four distinct root causes. Fixing all four lets `docker compose up gateway sint-interface postgres redis` come up healthy.

## Reproduced failures (in order hit)

1. **`apps/sint-interface/Dockerfile:28`** — `pnpm install --frozen-lockfile --filter @sint/interface...` returns `No projects matched the filters in "/app"`. The package is `@pshkv/interface` after the recent scope rename, so node_modules never gets installed and the next `pnpm build` step fails with `sh: tsc: not found`.

2. **`docs/profiles/sros2-sint.docker-compose.yml:22`** — same `@sint/gateway-server` → `@pshkv/gateway-server` leftover. Not exercised by the main stack, but blocks the SROS2 profile for anyone who finds it.

3. **`apps/gateway-server/package.json`** — `ioredis` was in `devDependencies`, but `redis-factory.ts` needs it at runtime whenever `SINT_CACHE=redis`. Production pnpm installs prune devDeps, so the container crashes with `Cannot find module 'ioredis'`.

4. **`apps/gateway-server/src/redis-factory.ts:19`** — the file is loaded as ESM (`file:///…/redis-factory.js`) but calls bare `require()`, which is undefined under pure ESM. The source comment already flagged this as a CJS/ESM interop concern. Fix: `createRequire(import.meta.url)` — matches the author's stated intent, zero behavior change on happy path.

## Verification

```
$ pnpm stack:interface
…
gateway-1         | [SINT] PostgreSQL schema verified
gateway-1         | [SINT] gateway listening on :3100

$ docker compose ps
NAME                             STATUS
sint-protocol-gateway-1          Up (healthy)
sint-protocol-postgres-1         Up (healthy)
sint-protocol-redis-1            Up (healthy)
sint-protocol-sint-interface-1   Up (healthy)

$ curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3202/
200
```

## Test plan

- [ ] `pnpm stack:interface` comes up healthy with all four services
- [ ] `http://localhost:3202/` returns 200 (SPA loads)
- [ ] `SINT_CACHE=redis` path in gateway init no longer crashes on startup
- [ ] `docs/profiles/sros2-sint.docker-compose.yml` profile builds (not verified in this PR, grep-only fix)