### PR TITLE
scanner: add on-chain and pentest domain-verb patterns

### DIFF
--- a/apps/sint-mcp-scanner-standalone/scanner.js
+++ b/apps/sint-mcp-scanner-standalone/scanner.js
@@ -21,6 +21,19 @@ const SHELL_EXEC_PATTERNS = [
   /\bsystem\s*call/i, /\bsubprocess/i, /\bspawn\b/i,
 ];
 
+const ONCHAIN_T3_PATTERNS = [
+  /\b(mint|burn|seize|freeze|unfreeze|force[_\s-]?burn|force[_\s-]?transfer)\b/i,
+  /\b(swap|stake|unstake|claim|withdraw|deposit|bridge|airdrop)\b/i,
+  /\b(on[-\s]?chain|smart\s+contract|signer|private\s+key|keypair)\b/i,
+];
+
+const PENTEST_T3_PATTERNS = [
+  /\b(exploit|payload|brute[-\s]?force|credential\s+stuff|password\s+crack)\b/i,
+  /\b(metasploit|msfconsole|meterpreter|reverse\s+shell|web\s+shell)\b/i,
+  /\b(privilege\s+escal|lateral\s+movement|persistence|rootkit|backdoor)\b/i,
+  /\b(sql\s+injection|xss|rce|csrf)\b/i,
+];
+
 const T3_PATTERNS = [
   /\b(delete|drop|destroy|remove|purge|wipe|truncate|format)\b/i,
   /\b(deploy|release|publish|push\s+to\s+prod)/i,
@@ -33,8 +46,9 @@ const T3_PATTERNS = [
 
 const T2_PATTERNS = [
   /\b(write|create|update|modify|edit|append|overwrite)\b/i,
+  /\b(adjust|toggle|tune|override|allowlist|blocklist|denylist|whitelist|blacklist)\b/i,
   /\b(move|rename|copy|upload)\b/i,
-  /\b(set|configure|install|enable|disable)\b/i,
+  /\b(set|configure|install|enable|disable|pause|unpause|activate|deactivate)\b/i,
   /\b(database|db|sql|postgres|mysql|mongo)\b/i,
   /\b(api\s+call|http\s+(post|put|patch|delete))\b/i,
   /\b(robot|actuator|servo|motor|gripper|arm)\b/i,
@@ -71,8 +85,15 @@ function classifyTool(tool) {
     if (pattern) owasp.push({ code, desc: check.desc });
   }
 
-  // Shell exec → always T3
-  if (SHELL_EXEC_PATTERNS.some(p => p.test(text))) {
+  // On-chain / financial operations → T3 (catch before generic shell-exec match
+  // so `sdp_execute_swap` is classified as on-chain, not shell exec)
+  if (ONCHAIN_T3_PATTERNS.some(p => p.test(text))) {
+    tier = 'T3';
+    reasons.push('On-chain / financial operation detected — irreversible value transfer');
+  } else if (PENTEST_T3_PATTERNS.some(p => p.test(text))) {
+    tier = 'T3';
+    reasons.push('Offensive security / exploitation capability detected');
+  } else if (SHELL_EXEC_PATTERNS.some(p => p.test(text))) {
     tier = 'T3';
     reasons.push('Shell/command execution detected — OWASP ASI05');
   } else if (T3_PATTERNS.some(p => p.test(text))) {


### PR DESCRIPTION
## Summary

The keyword classifier in `apps/sint-mcp-scanner-standalone/scanner.js` misses several high-severity tool categories because their verbs aren't in the existing T2/T3 pattern lists. Reproduced on three real MCP servers.

## Before / After

| Tool | Before | After |
|---|---|---|
| `sdp_mint_tokens` *(mints stablecoin)* | **T0 LOW** ❌ | T3 CRITICAL ✅ |
| `sdp_issuance_burn_tokens` *(destroys supply)* | **T0 LOW** ❌ | T3 CRITICAL ✅ |
| `sdp_issuance_force_burn` *(seizes without consent)* | **T0 LOW** ❌ | T3 CRITICAL ✅ |
| `kali_msf` *(Metasploit exploitation)* | **T0 LOW** ❌ | T3 CRITICAL ✅ |
| `kali_hydra` *(brute-force cracking)* | **T0 LOW** ❌ | T3 CRITICAL ✅ |
| `adjust_inventory` *(mutates quantity)* | **T0 LOW** ❌ | T2 HIGH ✅ |
| `sdp_execute_swap` | T3 via shell-exec ASI05 ⚠️ | T3 via on-chain reason ✅ |

The `sdp_execute_swap` change is reason-only — same tier, correct category. Before the fix it was flagged as shell exec because of the word "execute"; now it classifies as an on-chain financial operation.

## What changed

Two new domain-specific pattern groups evaluated *before* the generic shell-exec check, so on-chain and pentest tools classify with the correct reason code:

- **`ONCHAIN_T3_PATTERNS`** — `mint|burn|seize|freeze|unfreeze|force_burn|force_transfer|swap|stake|unstake|claim|withdraw|deposit|bridge|airdrop|on-chain|smart contract|signer|private key|keypair`
- **`PENTEST_T3_PATTERNS`** — `exploit|payload|brute-force|credential stuff|password crack|metasploit|msfconsole|meterpreter|reverse shell|web shell|privilege escal|lateral movement|persistence|rootkit|backdoor|sql injection|xss|rce|csrf`
- **`T2_PATTERNS` extended** — `adjust|toggle|tune|override|allowlist|blocklist|denylist|whitelist|blacklist|pause|unpause|activate|deactivate`

## Motivation

The scanner is pitched as a governance tool for MCP servers, and stablecoin / pentesting / e-commerce are three of the most common MCP use cases where false negatives have real blast radius — a T0 classification on `force_burn` tells operators "no approval needed" for an action that seizes tokens from any account without consent.

Regex-only is not enough for semantic classification long-term (richer fixes: LLM-assisted scoring, tool-annotation hints per MCP behavior spec, operator-provided overrides). This PR is the cheapest next step — extend the keyword list to cover domains where the scanner is already being pointed.

## Verification

Regression check passed: existing T0/T1/T2/T3 cases classify the same after the patch.

```
=== READ-ONLY (expect T0/T1) ===
  [T0] get_order
  [T1] list_products
  [T1] search_customers
  [T1] check_inventory

=== LEGACY T3 (expect T3) ===
  [T3] deleteFile
  [T3] process_payment

=== LEGACY T2 (expect T2) ===
  [T2] writeFile
  [T2] update_record
  [T2] upload_file
```

## Test plan

- [ ] Snapshot `scanner.js` false-negative cases above as fixtures + add a vitest run (happy to follow up in a second PR)
- [ ] Review pattern list for overreach — open to trimming terms that might fire on benign descriptions

## Not in this PR

A separate pre-existing miss I noticed while testing: `send_email` with description *"Send an email to a user"* → T0, because the T3 pattern is `/\bsend\s+email\b/` and "send an email" has the intervening `an`. Happy to file a separate issue for relaxing that one.