### PR TITLE
docs/schemas: JSON Schema for heartbeat, approval, delegation, task report (closes #17)

### DIFF
--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -1,0 +1,51 @@
+# SINT Message Schemas
+
+JSON Schema (draft 2020-12) definitions for message types that cross process or transport boundaries in the SINT stack. These are intended for validation at client integration points and for SDK generation.
+
+## Index
+
+| File | Emitted on | Defines |
+|---|---|---|
+| [`heartbeat.schema.json`](./heartbeat.schema.json) | Approvals WebSocket (`/v1/approvals/ws`) | Server-originated 30-second keepalive. |
+| [`approval-request.schema.json`](./approval-request.schema.json) | Approvals WebSocket, approvals SSE | `APPROVAL_REQUIRED` event when a T2/T3 request is escalated for human review. |
+| [`delegation-request.schema.json`](./delegation-request.schema.json) | `POST /v1/tokens/delegate` | Body for delegating a capability token with strictly narrower authority. |
+| [`task-report.schema.json`](./task-report.schema.json) | Evidence Ledger (`GET /v1/ledger`) | Ledger event reporting the outcome of an agent action (`action.started` / `action.completed` / `action.failed` / `action.rolledback`). |
+
+## Using the schemas
+
+### Validate a message programmatically (Node, via ajv)
+
+```ts
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import heartbeatSchema from "./heartbeat.schema.json" assert { type: "json" };
+
+const ajv = new Ajv({ strict: false });
+addFormats(ajv);
+const validate = ajv.compile(heartbeatSchema);
+
+const message = { type: "heartbeat", ts: new Date().toISOString() };
+if (!validate(message)) {
+  console.error(validate.errors);
+}
+```
+
+### Generate client types
+
+```bash
+# TypeScript types
+npx json-schema-to-typescript docs/schemas/approval-request.schema.json
+
+# Python types (datamodel-code-generator)
+datamodel-codegen --input docs/schemas/delegation-request.schema.json --output delegation.py
+```
+
+## Source of truth
+
+These schemas are derived from (and should stay in sync with):
+
+- `packages/core/src/types/evidence.ts` — `SintLedgerEvent`, `SintEventType`
+- `packages/core/src/schemas/capability-token.schema.ts` — `capabilityTokenRequestSchema`, `delegationChainSchema`
+- `apps/gateway-server/src/ws/ws-approval-stream.ts` — `ApprovalRequiredEvent`, `DecisionEvent`
+
+When the Zod schemas or TypeScript interfaces change, these JSON Schemas need a corresponding update. A future CI step could diff-check them automatically.

--- a/docs/schemas/approval-request.schema.json
+++ b/docs/schemas/approval-request.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sint.gg/schemas/approval-request.schema.json",
+  "title": "SINT Approval Request Message",
+  "description": "Emitted on the approvals WebSocket / SSE stream when a T2_ACT or T3_COMMIT request has been escalated and awaits human review. Corresponds to the APPROVAL_REQUIRED event in apps/gateway-server/src/ws/ws-approval-stream.ts.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["type", "requestId", "agentId", "resource", "action", "tier", "timestamp"],
+  "properties": {
+    "type": {
+      "const": "APPROVAL_REQUIRED",
+      "description": "Message type discriminator."
+    },
+    "requestId": {
+      "type": "string",
+      "format": "uuid",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+      "description": "UUID v7 identifier of the intercepted SINT request."
+    },
+    "agentId": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "Ed25519 public key of the agent (hex-encoded, 64 chars)."
+    },
+    "resource": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "description": "Resource the agent is attempting to act on (e.g. ros2:///cmd_vel, mcp://filesystem/writeFile)."
+    },
+    "action": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "description": "Action requested against the resource (e.g. publish, write, delete)."
+    },
+    "tier": {
+      "type": "string",
+      "enum": ["T2_act", "T3_commit"],
+      "description": "Approval tier that triggered escalation. Only T2+ tiers generate APPROVAL_REQUIRED events."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when the escalation decision was made."
+    },
+    "replay": {
+      "type": "boolean",
+      "description": "True if this event was replayed to a newly-connected subscriber (via ?cursor= or ?since= query params). Absent/false for live events."
+    }
+  },
+  "examples": [
+    {
+      "type": "APPROVAL_REQUIRED",
+      "requestId": "019d9f21-0c09-7bcb-8309-6296a4eb4a50",
+      "agentId": "e894f1b6e542c20cbe2afa7dfc5bf11dada1329927fc1a0ee303d1d4e3691a34",
+      "resource": "mcp://filesystem/deleteFile",
+      "action": "delete",
+      "tier": "T3_commit",
+      "timestamp": "2026-04-17T12:00:00.000Z"
+    }
+  ]
+}

--- a/docs/schemas/delegation-request.schema.json
+++ b/docs/schemas/delegation-request.schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sint.gg/schemas/delegation-request.schema.json",
+  "title": "SINT Delegation Request",
+  "description": "Body for POST /v1/tokens/delegate. Delegates a parent capability token to a new subject with attenuated (strictly narrower) authority. Depth is bounded at 10; attenuation is enforced by delegateCapabilityToken in @pshkv/gate-capability-tokens.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["parentTokenId", "request", "privateKey"],
+  "properties": {
+    "parentTokenId": {
+      "type": "string",
+      "format": "uuid",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+      "description": "UUID v7 of the parent token being delegated from. Must already exist in the token store."
+    },
+    "request": {
+      "$ref": "#/$defs/delegationRequest",
+      "description": "The new token request derived from the parent. Authority fields (resource, actions, constraints, expiresAt) must be strictly narrower than the parent's."
+    },
+    "privateKey": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "Ed25519 private key (hex-encoded, 64 chars) of the parent token's subject. Used to sign the delegated token."
+    }
+  },
+  "$defs": {
+    "delegationRequest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["issuer", "subject", "resource", "actions", "constraints", "delegationChain", "expiresAt", "revocable"],
+      "properties": {
+        "issuer": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "Ed25519 public key of the delegating party (must equal parent.subject)."
+        },
+        "subject": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "Ed25519 public key of the new token holder."
+        },
+        "resource": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512,
+          "description": "Resource URI. Must equal or be a sub-path of parent.resource."
+        },
+        "actions": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 16,
+          "items": { "type": "string", "minLength": 1, "maxLength": 64 },
+          "description": "Actions granted. Must be a subset of parent.actions."
+        },
+        "constraints": {
+          "type": "object",
+          "description": "Physical constraints. Each field must be tighter than or equal to parent.constraints (monotonic narrowing).",
+          "properties": {
+            "maxVelocityMps": { "type": "number", "exclusiveMinimum": 0 },
+            "maxForceNewtons": { "type": "number", "exclusiveMinimum": 0 },
+            "requiresHumanPresence": { "type": "boolean" }
+          }
+        },
+        "delegationChain": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["parentTokenId", "depth", "attenuated"],
+          "properties": {
+            "parentTokenId": {
+              "type": ["string", "null"],
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+              "description": "Parent token UUID v7. Must equal top-level parentTokenId."
+            },
+            "depth": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 10,
+              "description": "Delegation depth. Root tokens have depth 0; each delegation increments by 1. Max 10."
+            },
+            "attenuated": {
+              "type": "boolean",
+              "description": "Must be true for any non-root delegated token."
+            }
+          }
+        },
+        "expiresAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 expiry. Must be <= parent.expiresAt."
+        },
+        "revocable": {
+          "type": "boolean",
+          "description": "Whether the token can be revoked via POST /v1/tokens/revoke."
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "parentTokenId": "019d9f21-0c10-718c-b804-66f2ac19582b",
+      "request": {
+        "issuer": "e894f1b6e542c20cbe2afa7dfc5bf11dada1329927fc1a0ee303d1d4e3691a34",
+        "subject": "b12abc345de67f8901234567890abcdef1234567890abcdef1234567890abcd",
+        "resource": "ros2:///cmd_vel",
+        "actions": ["publish"],
+        "constraints": { "maxVelocityMps": 0.5 },
+        "delegationChain": {
+          "parentTokenId": "019d9f21-0c10-718c-b804-66f2ac19582b",
+          "depth": 1,
+          "attenuated": true
+        },
+        "expiresAt": "2026-04-18T00:00:00.000Z",
+        "revocable": true
+      },
+      "privateKey": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2a3b4c5d6a7b8c9d0e1f2"
+    }
+  ]
+}

--- a/docs/schemas/heartbeat.schema.json
+++ b/docs/schemas/heartbeat.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sint.gg/schemas/heartbeat.schema.json",
+  "title": "SINT Heartbeat Message",
+  "description": "Server-originated keepalive emitted on the approvals WebSocket every 30 seconds. Used by clients to detect connection liveness. Also emitted as a bare SSE comment line (': heartbeat') on approval and risk-score SSE streams.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["type", "ts"],
+  "properties": {
+    "type": {
+      "const": "heartbeat",
+      "description": "Message type discriminator."
+    },
+    "ts": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when the heartbeat was emitted by the gateway."
+    }
+  },
+  "examples": [
+    {
+      "type": "heartbeat",
+      "ts": "2026-04-17T12:00:00.000Z"
+    }
+  ]
+}

--- a/docs/schemas/task-report.schema.json
+++ b/docs/schemas/task-report.schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sint.gg/schemas/task-report.schema.json",
+  "title": "SINT Task Report (Action Ledger Event)",
+  "description": "Ledger event reporting the outcome of an agent action. Written to the Evidence Ledger after action.started, action.completed, action.failed, or action.rolledback. This is the SINT equivalent of a 'task report' — an immutable, hash-chained record of what the agent did and how it ended. Derived from SintLedgerEvent in packages/core/src/types/evidence.ts.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["eventId", "sequenceNumber", "timestamp", "eventType", "agentId", "payload", "previousHash", "hash"],
+  "properties": {
+    "eventId": {
+      "type": "string",
+      "format": "uuid",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+      "description": "UUID v7 unique identifier for this event."
+    },
+    "sequenceNumber": {
+      "type": ["string", "integer"],
+      "description": "Monotonic sequence number. Serialized as string when it exceeds JS Number.MAX_SAFE_INTEGER (BigInt transport)."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp with microsecond precision in UTC (e.g. 2026-04-17T07:45:00.000000Z)."
+    },
+    "eventType": {
+      "type": "string",
+      "enum": [
+        "action.started",
+        "action.completed",
+        "action.failed",
+        "action.rolledback"
+      ],
+      "description": "Which phase of the action lifecycle this report records. Only the action.* family is considered a task report; other ledger event types (policy.evaluated, risk.score.computed, etc.) have their own semantics."
+    },
+    "agentId": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "Ed25519 public key of the agent that executed the action (hex-encoded, 64 chars)."
+    },
+    "tokenId": {
+      "type": "string",
+      "format": "uuid",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+      "description": "Capability token used to authorize the action. Optional for reports not tied to a specific token (e.g. an agent-level report)."
+    },
+    "payload": {
+      "type": "object",
+      "description": "Event-specific payload. Shape varies by eventType but commonly includes requestId, resource, action, outcome fields (bytesWritten, error message, rollback reason).",
+      "properties": {
+        "requestId": {
+          "type": "string",
+          "format": "uuid",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+          "description": "Correlates the report back to a SINT request that was previously intercepted."
+        },
+        "resource": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512,
+          "description": "The resource the action was taken on (e.g. ros2:///cmd_vel)."
+        },
+        "action": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "description": "The action performed (e.g. publish, write, delete)."
+        },
+        "outcome": {
+          "type": "string",
+          "enum": ["success", "failure", "rolledback"],
+          "description": "High-level outcome flag. Full detail in type-specific fields."
+        },
+        "error": {
+          "type": "string",
+          "description": "Error message when eventType is action.failed."
+        },
+        "rollbackReason": {
+          "type": "string",
+          "description": "Reason for rollback when eventType is action.rolledback (e.g. 'estop.triggered', 'constraint.violated')."
+        }
+      }
+    },
+    "previousHash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "SHA-256 hash of the previous event in the chain (hex-encoded). The genesis event uses 64 zeros."
+    },
+    "hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "SHA-256 hash of this event, computed over the canonical JSON of all fields except hash itself. Provides tamper-evidence."
+    },
+    "rosclaw_audit_ref": {
+      "type": "string",
+      "description": "Cross-reference to a ROSClaw audit log entry for cross-system CSML computation (arXiv:2603.26997)."
+    },
+    "rosclaw_failure_mode": {
+      "type": "string",
+      "enum": ["malformed_params", "wrong_action_type", "replan_loop"],
+      "description": "ROSClaw-classified failure mode when eventType is action.failed."
+    },
+    "foundation_model_id": {
+      "type": "string",
+      "description": "Foundation model backend identifier, used for per-model CSML behavioral tracking."
+    }
+  },
+  "examples": [
+    {
+      "eventId": "01964000-5000-7000-8000-000000000003",
+      "sequenceNumber": "7",
+      "timestamp": "2026-04-17T07:45:01.000000Z",
+      "eventType": "action.completed",
+      "agentId": "e894f1b6e542c20cbe2afa7dfc5bf11dada1329927fc1a0ee303d1d4e3691a34",
+      "tokenId": "019d9f21-0c10-718c-b804-66f2ac19582b",
+      "payload": {
+        "requestId": "019d9f21-0c09-7bcb-8309-6296a4eb4a50",
+        "resource": "mcp://filesystem/writeFile",
+        "action": "write",
+        "outcome": "success"
+      },
+      "previousHash": "236078de48cbdef25de171e409598f042d0559bcf4109b15f9b7a9c0bfa8d0cb",
+      "hash": "f5242fae02af9b7c8e1d6a4b3c2d1e0f9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #17.

## Summary

Adds four JSON Schema (draft 2020-12) files under \`docs/schemas/\` for message types that cross process or transport boundaries in the SINT stack, plus a README indexing them and showing how to use them.

## Files

| File | Shape | Derived from |
|---|---|---|
| \`heartbeat.schema.json\` | WS/SSE 30s keepalive | \`apps/gateway-server/src/ws/approvals-websocket.ts:121\` |
| \`approval-request.schema.json\` | \`APPROVAL_REQUIRED\` event on approvals stream | \`apps/gateway-server/src/ws/ws-approval-stream.ts\` (\`ApprovalRequiredEvent\`) |
| \`delegation-request.schema.json\` | Body for \`POST /v1/tokens/delegate\` | \`capabilityTokenRequestSchema\` + \`delegationChainSchema\` in \`packages/core/src/schemas/capability-token.schema.ts\` |
| \`task-report.schema.json\` | \`action.*\` family ledger events | \`SintLedgerEvent\` + \`SintEventType\` in \`packages/core/src/types/evidence.ts\` |

Each schema ships one example that exercises the shape. Patterns enforce:

- UUID v7 timestamp/random layout (\`[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\`)
- 64-hex-char Ed25519 public keys
- 64-hex-char SHA-256 hashes
- ISO 8601 \`date-time\` fields (spec-defined \`.000000Z\` microsecond precision preserved in docstring)

## On \"task report\"

The protocol has no standalone message named \"task report\" — the closest semantic match is the \`action.*\` family of \`SintLedgerEvent\`:
\`action.started\` / \`action.completed\` / \`action.failed\` / \`action.rolledback\`.

That's what an agent emits to the Evidence Ledger after executing a gated action, so the schema restricts \`eventType\` to that family. Other ledger event types (\`policy.evaluated\`, \`risk.score.computed\`, \`agent.capability.granted\`, etc.) have different semantics and are out of scope for this file. Happy to split into one schema per event type if that fits the roadmap better.

## Validation

JSON validity of all four files confirmed with \`jq\`. Schemas were checked by hand against:
- The Zod schemas they mirror (\`.strict()\` usage, \`optional()\` fields)
- The actual runtime shapes observed against a running stack (PR #162)

Happy to add a small CI step that validates \`examples\` against the schema using \`ajv\` — left out of this PR to keep it doc-only.

## Test plan

- [ ] Files parse as JSON (verified)
- [ ] \`examples\` in each file validate against its own schema (suggest adding ajv-based CI)
- [ ] Fields match current Zod schemas / TS types in \`packages/core\` and \`gateway-server\`