### PR TITLE
fix(capability-tokens): canonical signing payload survives JSONB round-trip

### DIFF
--- a/docs/specs/sint-protocol-v1.0.md
+++ b/docs/specs/sint-protocol-v1.0.md
@@ -137,7 +137,19 @@ A `SintCapabilityToken` is the atomic unit of permission in SINT. All fields are
 | `tokenId` | UUIDv7 | Unique token identifier. Sortable by issuance time. |
 | `issuer` | Ed25519PublicKey (hex) | Public key of the issuing authority. The root key is a hardware-protected operator keypair. |
 | `subject` | Ed25519PublicKey (hex) | Public key of the receiving agent. Corresponds to the agent's `did:key` identity. |
-| `signature` | Ed25519Signature (hex) | Ed25519 signature over the canonical token payload, excluding the `signature` field itself. |
+| `signature` | Ed25519Signature (hex) | Ed25519 signature over the canonical token payload, excluding the `signature` field itself. See Section 4.1.1. |
+
+#### 4.1.1 Canonical Signing Payload
+
+The signing payload is a deterministic serialization of all token fields except `signature`. The canonical form must be identical across implementations and must survive round-trips through storage backends that do not preserve object key order (e.g. Postgres `JSONB`):
+
+- Object keys are serialized in lexicographic (Unicode code-point) order at every depth.
+- Array element order is preserved.
+- `undefined` properties are omitted (matching `JSON.stringify` semantics).
+- No whitespace between tokens.
+- Numbers, strings, booleans, and `null` are serialized per RFC 8259.
+
+This is the same rule applied to Evidence Ledger event hashing (Section 5). A verifier that fails to recurse into nested objects (e.g. `constraints`, `delegationChain`) will produce non-deterministic payloads and reject valid signatures.
 
 ### 4.2 Scope Fields
 

--- a/packages/capability-tokens/__tests__/canonical-json.test.ts
+++ b/packages/capability-tokens/__tests__/canonical-json.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { canonicalJSONStringify } from "../src/utils.js";
+
+describe("canonicalJSONStringify", () => {
+  it("produces the same output regardless of object key insertion order", () => {
+    const a = { b: 1, a: 2, c: 3 };
+    const b = { a: 2, b: 1, c: 3 };
+    const c = { c: 3, a: 2, b: 1 };
+    expect(canonicalJSONStringify(a)).toBe(canonicalJSONStringify(b));
+    expect(canonicalJSONStringify(b)).toBe(canonicalJSONStringify(c));
+    expect(canonicalJSONStringify(a)).toBe('{"a":2,"b":1,"c":3}');
+  });
+
+  it("sorts keys recursively at every depth", () => {
+    const input = {
+      z: { b: 1, a: 2 },
+      a: { d: 4, c: 3 },
+    };
+    expect(canonicalJSONStringify(input)).toBe(
+      '{"a":{"c":3,"d":4},"z":{"a":2,"b":1}}',
+    );
+  });
+
+  it("preserves array element order", () => {
+    expect(canonicalJSONStringify([3, 1, 2])).toBe("[3,1,2]");
+    expect(canonicalJSONStringify({ xs: [{ b: 1, a: 2 }, { a: 1, b: 2 }] })).toBe(
+      '{"xs":[{"a":2,"b":1},{"a":1,"b":2}]}',
+    );
+  });
+
+  it("omits undefined values (matches JSON.stringify semantics for objects)", () => {
+    const input = { a: 1, b: undefined, c: 2 };
+    expect(canonicalJSONStringify(input)).toBe('{"a":1,"c":2}');
+  });
+
+  it("handles primitives and null", () => {
+    expect(canonicalJSONStringify(null)).toBe("null");
+    expect(canonicalJSONStringify(42)).toBe("42");
+    expect(canonicalJSONStringify(true)).toBe("true");
+    expect(canonicalJSONStringify("hi")).toBe('"hi"');
+  });
+
+  it("handles empty objects and arrays", () => {
+    expect(canonicalJSONStringify({})).toBe("{}");
+    expect(canonicalJSONStringify([])).toBe("[]");
+  });
+
+  it("is deterministic for a capability-token-like structure with nested constraints", () => {
+    const tokenA = {
+      tokenId: "01905f7c-4e8a-7b3d-9a1e-f2c3d4e5f6a7",
+      issuer: "abc",
+      subject: "def",
+      constraints: { maxVelocityMps: 0.5, maxForceNewtons: 50 },
+      delegationChain: { parentTokenId: null, depth: 0, attenuated: false },
+      actions: ["publish"],
+    };
+    // Same semantic content, different property insertion order at every level.
+    const tokenB = {
+      actions: ["publish"],
+      delegationChain: { attenuated: false, depth: 0, parentTokenId: null },
+      constraints: { maxForceNewtons: 50, maxVelocityMps: 0.5 },
+      subject: "def",
+      issuer: "abc",
+      tokenId: "01905f7c-4e8a-7b3d-9a1e-f2c3d4e5f6a7",
+    };
+    expect(canonicalJSONStringify(tokenA)).toBe(canonicalJSONStringify(tokenB));
+  });
+});

--- a/packages/capability-tokens/__tests__/validator.test.ts
+++ b/packages/capability-tokens/__tests__/validator.test.ts
@@ -68,6 +68,50 @@ describe("Capability Token Validator", () => {
     expect(result.error).toBe("INVALID_SIGNATURE");
   });
 
+  // Regression test for sint-ai/sint-protocol#166.
+  // Signing payload must be canonical at every depth so that nested objects
+  // survive round-trips through storage that doesn't preserve key order
+  // (Postgres JSONB, MessagePack without canonicalization, etc).
+  it("should validate a token whose nested constraint keys were reordered after issuance", () => {
+    const token = createValidToken({
+      constraints: {
+        maxVelocityMps: 0.5,
+        maxForceNewtons: 50,
+        requiresHumanPresence: true,
+      },
+    });
+    const reordered: SintCapabilityToken = {
+      ...token,
+      constraints: {
+        requiresHumanPresence: token.constraints.requiresHumanPresence!,
+        maxForceNewtons: token.constraints.maxForceNewtons!,
+        maxVelocityMps: token.constraints.maxVelocityMps!,
+      },
+    };
+    const result = validateCapabilityToken(reordered, {
+      resource: "ros2:///cmd_vel",
+      action: "publish",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("should validate a token whose delegationChain keys were reordered after issuance", () => {
+    const token = createValidToken();
+    const reordered: SintCapabilityToken = {
+      ...token,
+      delegationChain: {
+        attenuated: token.delegationChain.attenuated,
+        depth: token.delegationChain.depth,
+        parentTokenId: token.delegationChain.parentTokenId,
+      },
+    };
+    const result = validateCapabilityToken(reordered, {
+      resource: "ros2:///cmd_vel",
+      action: "publish",
+    });
+    expect(result.ok).toBe(true);
+  });
+
   it("should reject a token with tampered resource", () => {
     const token = createValidToken();
     const tampered = { ...token, resource: "ros2:///evil_topic" };

--- a/packages/capability-tokens/src/issuer.ts
+++ b/packages/capability-tokens/src/issuer.ts
@@ -23,7 +23,7 @@ import {
   ok,
 } from "@pshkv/core";
 import { sign } from "./crypto.js";
-import { generateUUIDv7, nowISO8601 } from "./utils.js";
+import { canonicalJSONStringify, generateUUIDv7, nowISO8601 } from "./utils.js";
 
 /**
  * Compute the canonical signing payload for a capability token.
@@ -38,26 +38,15 @@ import { generateUUIDv7, nowISO8601 } from "./utils.js";
  * ```
  */
 export function computeSigningPayload(
-  token: Omit<SintCapabilityToken, "signature">,
+  token: Omit<SintCapabilityToken, "signature"> | SintCapabilityToken,
 ): string {
-  // Canonical JSON: sorted keys, no whitespace, deterministic
-  return JSON.stringify({
-    actions: token.actions,
-    attestationRequirements: token.attestationRequirements,
-    constraints: token.constraints,
-    delegationChain: token.delegationChain,
-    expiresAt: token.expiresAt,
-    executionEnvelope: token.executionEnvelope,
-    issuedAt: token.issuedAt,
-    issuer: token.issuer,
-    modelConstraints: token.modelConstraints,
-    resource: token.resource,
-    revocable: token.revocable,
-    revocationEndpoint: token.revocationEndpoint,
-    subject: token.subject,
-    tokenId: token.tokenId,
-    verifiableComputeRequirements: token.verifiableComputeRequirements,
-  });
+  // Canonical JSON with recursive key sort so nested objects survive
+  // round-trips through storage that does not preserve key order
+  // (e.g. Postgres JSONB). Signature is always excluded so callers may
+  // pass either the unsigned or signed token interchangeably.
+  const { signature: _ignored, ...rest } =
+    token as SintCapabilityToken & { signature?: string };
+  return canonicalJSONStringify(rest);
 }
 
 /**

--- a/packages/capability-tokens/src/utils.ts
+++ b/packages/capability-tokens/src/utils.ts
@@ -68,3 +68,32 @@ export function nowISO8601(): ISO8601 {
   // Replace ".000Z" with ".000000Z" for microsecond format
   return ms.replace(/\.(\d{3})Z$/, ".$1000Z");
 }
+
+/**
+ * Serialize a value to canonical JSON per RFC 8785 (JCS), subset:
+ * object keys sorted alphabetically at every depth, arrays preserve order,
+ * `undefined` properties omitted.
+ *
+ * Deterministic output across identical inputs regardless of key insertion
+ * order. Required for signing payloads that round-trip through storage
+ * backends (e.g. Postgres JSONB) that do not preserve object key order.
+ */
+export function canonicalJSONStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return "[" + value.map((v) => canonicalJSONStringify(v)).join(",") + "]";
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj)
+    .filter((k) => obj[k] !== undefined)
+    .sort();
+  return (
+    "{" +
+    keys
+      .map((k) => JSON.stringify(k) + ":" + canonicalJSONStringify(obj[k]))
+      .join(",") +
+    "}"
+  );
+}


### PR DESCRIPTION
Closes #166.

## The bug

`computeSigningPayload` canonicalizes **only the top-level keys** and relies on JavaScript property iteration order for anything nested. After a token is stored in Postgres `JSONB` and retrieved, nested key order is not preserved, so re-computing the payload at verify time produces a different string than what was signed — validation fails with `INVALID_SIGNATURE`.

### Reproducer

```js
// Fresh token validates fine.
const token = issueCapabilityToken(req, issuerPriv).value;
validateCapabilityToken(token, { resource, action });
// → ok

// Simulate JSONB round-trip: reconstruct `constraints` with different key order.
const roundTripped = {
  ...token,
  constraints: {
    requiresHumanPresence: token.constraints.requiresHumanPresence,
    maxForceNewtons: token.constraints.maxForceNewtons,
    maxVelocityMps: token.constraints.maxVelocityMps,
  },
};
validateCapabilityToken(roundTripped, { resource, action });
// → INVALID_SIGNATURE
```

This hit me against a running `sint-gateway-server` pointed at Postgres: `POST /v1/tokens` returns 201, the token is persisted and cached, but `POST /v1/intercept` then denies every request because the retrieved token fails signature verification.

## The fix

- Added `canonicalJSONStringify` in `utils.ts`: recursive key sort (RFC 8785 JCS-style), omits `undefined`, preserves array element order.
- `computeSigningPayload` now uses it and explicitly strips the `signature` field, so callers may pass either the unsigned or signed token interchangeably (the APS cross-verify test does the latter).

## Tests

- 7 unit tests for `canonicalJSONStringify` (`__tests__/canonical-json.test.ts`).
- 2 regression tests in `validator.test.ts` covering reordered `constraints` and reordered `delegationChain`.
- Full workspace test suite runs clean — 76 tests in `@pshkv/gate-capability-tokens`, 257 in `@pshkv/gate-policy-gateway`, no regressions across the 20+ other packages.

## Compatibility

⚠️ **Breaking for any token signed under the old algorithm.** In practice no such tokens are durable — any persisted token already failed validation after the first JSONB round-trip — so this is net positive.

## Follow-ups (separate issues, not blocking this PR)

- `packages/persistence/src/pg-token-store.ts` `rowToToken` drops five optional token fields (`modelConstraints`, `attestationRequirements`, `verifiableComputeRequirements`, `executionEnvelope`, `revocationEndpoint`) and three newer ones (`behavioralConstraints`, `passportId`, `delegationDepth`). If any are set at issue time, round-trip still breaks the signature even after this fix. Needs a schema migration.