### PR TITLE
docs(core): JSDoc on exported types and fields

### DIFF
--- a/packages/core/src/constants/geofence-templates.ts
+++ b/packages/core/src/constants/geofence-templates.ts
@@ -24,6 +24,24 @@ function circlePolygon(
   return coords;
 }
 
+/**
+ * Library of reusable geofence polygons for common physical-AI deployments.
+ * Each entry is a `{ coordinates }` shape that can be dropped straight into
+ * a `SintPhysicalConstraints.geofence` field.
+ *
+ * Coordinates are `[x, y]` pairs in metres relative to the local frame origin.
+ * For GPS-based deployments, supply your own GeoJSON-convention polygon instead.
+ *
+ * @example
+ * ```ts
+ * import { GEOFENCE_TEMPLATES } from "@pshkv/core";
+ *
+ * const token = await issueCapabilityToken({
+ *   // ...
+ *   constraints: { geofence: GEOFENCE_TEMPLATES.WAREHOUSE_BAY_10M },
+ * }, issuerKey);
+ * ```
+ */
 export const GEOFENCE_TEMPLATES = {
   /**
    * Standard warehouse bay: 10 m × 10 m square.
@@ -76,4 +94,9 @@ export const GEOFENCE_TEMPLATES = {
   },
 } as const;
 
+/**
+ * Union of the keys in `GEOFENCE_TEMPLATES`. Useful for configuration
+ * surfaces where an operator picks a named template rather than supplying
+ * raw coordinates.
+ */
 export type GeofenceTemplateName = keyof typeof GEOFENCE_TEMPLATES;

--- a/packages/core/src/constants/schema-catalog.ts
+++ b/packages/core/src/constants/schema-catalog.ts
@@ -6,6 +6,12 @@
  * @module @sint/core/constants/schema-catalog
  */
 
+/**
+ * Shape of a JSON Schema document carried by `SINT_SCHEMA_CATALOG`.
+ * A plain string-keyed record is used rather than a strict JSON Schema
+ * type so that draft-2020-12 features (such as `$dynamicRef`) remain
+ * representable as the spec evolves.
+ */
 export type JsonSchemaDoc = Record<string, unknown>;
 
 const CAPABILITY_TOKEN_SCHEMA: JsonSchemaDoc = {
@@ -461,6 +467,25 @@ const TIER_COMPLIANCE_CROSSWALK_SCHEMA: JsonSchemaDoc = {
   additionalProperties: false,
 };
 
+/**
+ * Registry of public JSON Schema documents for every SINT wire type.
+ *
+ * Keyed by short slug (e.g. `"capability-token"`, `"policy-decision"`).
+ * Consumers use this catalog to (a) publish the canonical machine-readable
+ * schema set for the protocol, (b) validate wire messages at boundaries
+ * where strict typing is unavailable, and (c) generate SDKs in non-TS
+ * languages.
+ *
+ * @example
+ * ```ts
+ * import Ajv from "ajv";
+ * import { SINT_SCHEMA_CATALOG } from "@pshkv/core";
+ *
+ * const ajv = new Ajv({ strict: false });
+ * const validateToken = ajv.compile(SINT_SCHEMA_CATALOG["capability-token"]);
+ * if (!validateToken(incoming)) throw new Error("invalid token");
+ * ```
+ */
 export const SINT_SCHEMA_CATALOG: Readonly<Record<string, JsonSchemaDoc>> = {
   "capability-token": CAPABILITY_TOKEN_SCHEMA,
   request: REQUEST_SCHEMA,

--- a/packages/core/src/types/capability-token.ts
+++ b/packages/core/src/types/capability-token.ts
@@ -269,8 +269,11 @@ export interface SintDelegationChain {
  */
 export interface SintCapabilityToken {
   // --- Identity ---
+  /** Unique, time-ordered token identifier. Sortable by issuance time. */
   readonly tokenId: UUIDv7;
+  /** Ed25519 public key of the issuing authority. Used to verify `signature`. */
   readonly issuer: Ed25519PublicKey;
+  /** Ed25519 public key of the receiving agent. A request's `agentId` must match this for the token to apply. */
   readonly subject: Ed25519PublicKey;
 
   // --- Scope ---
@@ -311,28 +314,51 @@ export interface SintCapabilityToken {
   readonly delegationDepth?: number;
 
   // --- Delegation ---
+  /** Verifiable lineage of this token from its root issuer. */
   readonly delegationChain: SintDelegationChain;
 
   // --- Lifecycle ---
+  /** When the token was issued (ISO 8601 with microsecond precision). */
   readonly issuedAt: ISO8601;
+  /** When the token stops being valid. No grace period — `now >= expiresAt` fails validation. */
   readonly expiresAt: ISO8601;
+  /** Whether the issuer (or its delegate) may revoke this token before expiry. */
   readonly revocable: boolean;
+  /** Optional URL the gateway can call to propagate revocations (CRL/OCSP-style). */
   readonly revocationEndpoint?: string;
 
   // --- Cryptographic binding ---
+  /**
+   * Ed25519 signature over the canonical signing payload (every field above
+   * except `signature` itself, serialized via RFC-8785-style recursive key sort).
+   * See `computeSigningPayload` in `@pshkv/gate-capability-tokens`.
+   */
   readonly signature: Ed25519Signature;
 }
 
-/** Fields required to issue a new capability token (before signing). */
+/**
+ * Fields required to issue a new capability token. `tokenId`, `issuedAt`,
+ * and `signature` are filled in by the issuer; every other field mirrors
+ * `SintCapabilityToken`. Pass this shape to `issueCapabilityToken()`.
+ */
 export interface SintCapabilityTokenRequest {
+  /** Ed25519 public key of the issuing authority. */
   readonly issuer: Ed25519PublicKey;
+  /** Ed25519 public key of the receiving agent. */
   readonly subject: Ed25519PublicKey;
+  /** Resource URI this token grants access to. */
   readonly resource: string;
+  /** Permitted actions on the resource. */
   readonly actions: readonly string[];
+  /** Physical safety constraints enforced at runtime. */
   readonly constraints: SintPhysicalConstraints;
+  /** Optional model identity restrictions. */
   readonly modelConstraints?: SintModelConstraints;
+  /** Optional TEE attestation requirements. */
   readonly attestationRequirements?: SintAttestationRequirements;
+  /** Optional ZK/TEE verifiable-compute proof requirements. */
   readonly verifiableComputeRequirements?: SintVerifiableComputeRequirements;
+  /** Optional pre-approved trajectory envelope for low-latency control. */
   readonly executionEnvelope?: SintExecutionEnvelope;
   /** Optional runtime behavioral constraints for this token. */
   readonly behavioralConstraints?: SintBehavioralConstraints;
@@ -340,9 +366,13 @@ export interface SintCapabilityTokenRequest {
   readonly passportId?: string;
   /** Delegation depth in the APS chain (0 = root). */
   readonly delegationDepth?: number;
+  /** Delegation lineage; supply `{ parentTokenId: null, depth: 0, attenuated: false }` for a root issuance. */
   readonly delegationChain: SintDelegationChain;
+  /** Absolute expiry timestamp (ISO 8601, microsecond precision). */
   readonly expiresAt: ISO8601;
+  /** Whether the issuer retains revocation authority. */
   readonly revocable: boolean;
+  /** Optional revocation propagation endpoint. */
   readonly revocationEndpoint?: string;
 }
 

--- a/packages/core/src/types/evidence.ts
+++ b/packages/core/src/types/evidence.ts
@@ -223,7 +223,9 @@ export interface SintBilateralProofReceipt extends SintProofReceipt {
  * Linked receipt pair for strong-tier execution governance.
  */
 export interface SintBilateralProofReceiptPair {
+  /** Receipt emitted at the authorization gate (before execution). */
   readonly gate: SintBilateralProofReceipt;
+  /** Receipt emitted at action completion (success, failure, or rollback). */
   readonly completion: SintBilateralProofReceipt;
 }
 
@@ -298,13 +300,21 @@ export const DEFAULT_CSML_COEFFICIENTS: CsmlCoefficients = {
  * Query parameters for reading from the Evidence Ledger.
  */
 export interface LedgerQuery {
+  /** Restrict results to events emitted for this agent. */
   readonly agentId?: Ed25519PublicKey;
+  /** Restrict results to a specific event type. */
   readonly eventType?: SintEventType;
+  /** Inclusive lower bound on `sequenceNumber`. */
   readonly fromSequence?: bigint;
+  /** Inclusive upper bound on `sequenceNumber`. */
   readonly toSequence?: bigint;
+  /** Inclusive lower bound on `timestamp` (ISO 8601). */
   readonly fromTimestamp?: ISO8601;
+  /** Inclusive upper bound on `timestamp` (ISO 8601). */
   readonly toTimestamp?: ISO8601;
+  /** Maximum number of events to return. */
   readonly limit?: number;
+  /** Number of matching events to skip (paging). */
   readonly offset?: number;
 }
 

--- a/packages/core/src/types/policy.ts
+++ b/packages/core/src/types/policy.ts
@@ -51,7 +51,9 @@ export enum RiskTier {
 
 /** K-of-N approval quorum attached to escalated requests. */
 export interface SintApprovalQuorum {
+  /** Number of distinct approvals required before the request can proceed. */
   readonly required: number;
+  /** Approver identifiers (e.g. DIDs or public keys) permitted to sign off. */
   readonly authorized: readonly string[];
 }
 
@@ -64,33 +66,49 @@ export type SintSiteDeploymentProfile =
 
 /** Runtime identity metadata for the executor handling the request. */
 export interface SintExecutorIdentity {
+  /** Logical runtime identifier (e.g. "ros2-bridge", "mcp-server"). */
   readonly runtimeId?: string;
+  /** Physical or logical node this runtime is executing on. */
   readonly nodeId?: string;
+  /** Decentralized identifier (did:key / did:web) for the executor. */
   readonly did?: string;
+  /** Network hostname or address of the executor. */
   readonly host?: string;
 }
 
 /** Model runtime metadata attached to a request. */
 export interface SintModelRuntimeContext {
+  /** Model identifier (e.g. "claude-opus-4-7", "gpt-4.1"). Checked against `modelConstraints.allowedModelIds`. */
   readonly modelId?: string;
+  /** Model version string; compared against `modelConstraints.maxModelVersion` as semver. */
   readonly modelVersion?: string;
+  /** Model weight fingerprint for tamper detection. */
   readonly modelFingerprintHash?: string;
 }
 
 /** Attestation metadata attached to a request. */
 export interface SintAttestationContext {
+  /** Attestation grade: 0 none, 1 self-attested, 2 TEE-backed, 3 remote-attested TEE. */
   readonly grade?: 0 | 1 | 2 | 3;
+  /** Trusted execution environment backend reporting the attestation. */
   readonly teeBackend?: "intel-sgx" | "arm-trustzone" | "amd-sev" | "tpm2" | "none";
+  /** Opaque reference to the TEE quote (URL, hash, or handle). */
   readonly quoteRef?: string;
 }
 
 /** Verifiable compute proof metadata attached to a request. */
 export interface SintVerifiableComputeContext {
+  /** Proof system in use (e.g. "risc0-groth16", "snark"). */
   readonly proofType?: SintVerifiableComputeProofType;
+  /** Reference to the serialized proof object (URL or storage handle). */
   readonly proofRef?: string;
+  /** SHA-256 hash of the proof bytes for integrity. */
   readonly proofHash?: string;
+  /** SHA-256 hash of the public-inputs tuple committed to by the proof. */
   readonly publicInputsHash?: string;
+  /** When the proof was generated (ISO 8601); used with `maxProofAgeMs`. */
   readonly generatedAt?: ISO8601;
+  /** Reference to the verifier used to check this proof. */
   readonly verifierRef?: string;
 }
 
@@ -113,23 +131,42 @@ export interface SintHardwareSafetyContext {
 
 /** Pre-approved execution corridor metadata attached to a request. */
 export interface SintPreapprovedCorridor {
+  /** Identifier of the corridor envelope previously approved for this agent. */
   readonly corridorId: string;
+  /** Corridor expiry; requests arriving after this must re-seek approval. */
   readonly expiresAt: ISO8601;
+  /** Maximum allowed deviation from the corridor centerline, in metres. */
   readonly maxDeviationMeters?: number;
+  /** Maximum allowed heading deviation from the corridor direction, in degrees. */
   readonly maxHeadingDeviationDeg?: number;
 }
 
-/** Execution context metadata for cross-bridge/audit interoperability. */
+/**
+ * Execution context metadata for cross-bridge/audit interoperability.
+ * Every field is optional — bridges populate whatever they know so the
+ * gateway can reason about model identity, attestation, safety interlocks,
+ * and pre-approved corridors when making tier assignments.
+ */
 export interface SintExecutionContext {
+  /** Named deployment profile driving policy defaults. */
   readonly deploymentProfile?: SintSiteDeploymentProfile;
+  /** Operator-assigned site identifier (facility, warehouse, cell). */
   readonly siteId?: string;
+  /** Identifier of the bridge that normalized the request. */
   readonly bridgeId?: string;
+  /** Wire protocol the bridge translates (e.g. "ros2", "mcp", "mqtt"). */
   readonly bridgeProtocol?: string;
+  /** Runtime identity of the process dispatching the action. */
   readonly executor?: SintExecutorIdentity;
+  /** Model runtime context for model-bound token constraints. */
   readonly model?: SintModelRuntimeContext;
+  /** TEE attestation context for attestation-bound token constraints. */
   readonly attestation?: SintAttestationContext;
+  /** Verifiable compute proof context for proof-bound token constraints. */
   readonly verifiableCompute?: SintVerifiableComputeContext;
+  /** Hardware safety interlock / permit state observed at request time. */
   readonly hardwareSafety?: SintHardwareSafetyContext;
+  /** Pre-approved execution corridor, if this request is executing under one. */
   readonly preapprovedCorridor?: SintPreapprovedCorridor;
 }
 
@@ -137,7 +174,9 @@ export interface SintExecutionContext {
  * A request entering the Policy Gateway for evaluation.
  */
 export interface SintRequest {
+  /** Unique, client-supplied request identifier. */
   readonly requestId: UUIDv7;
+  /** When the request was emitted by the bridge (ISO 8601, microsecond precision). */
   readonly timestamp: ISO8601;
 
   /** The agent making the request. */


### PR DESCRIPTION
Closes #8.

## What

Audited every export in `packages/core/src/types/` and `packages/core/src/constants/` for JSDoc coverage.

**Type/interface-level coverage was already complete in core** — every exported `type`, `interface`, `enum`, `const`, and `function` had a doc block.

This PR addresses two remaining gaps:

1. Four missing export-level JSDocs:
   - `GEOFENCE_TEMPLATES`, `GeofenceTemplateName` (`constants/geofence-templates.ts`)
   - `JsonSchemaDoc`, `SINT_SCHEMA_CATALOG` (`constants/schema-catalog.ts`)

2. Field-level JSDoc on the most-used public interfaces where individual members lacked docs:
   - `SintCapabilityToken` identity / lifecycle / signature fields + full `SintCapabilityTokenRequest`
   - `SintApprovalQuorum`, `SintExecutorIdentity`, `SintModelRuntimeContext`, `SintAttestationContext`, `SintVerifiableComputeContext`, `SintPreapprovedCorridor`, `SintExecutionContext`, `SintRequest`
   - `SintBilateralProofReceiptPair`, `LedgerQuery`

## Non-goals

- `protocol.ts` CL-1.0 envelope types (`ConstraintEnvelopePhysical` etc.) have self-descriptive field names (`maxVelocityMps`, `maxForceNewtons`, …) and already carry interface-level docs. Not touched to avoid noise.

## Verification

- `pnpm --filter @pshkv/core build` clean
- `pnpm --filter @pshkv/core test` — 53 / 53 pass
- Direct dependents still green:
  - `@pshkv/gate-capability-tokens` — 76 / 76 pass
  - `@pshkv/gate-policy-gateway` — 297 / 297 pass
  - `@pshkv/gate-evidence-ledger` — green

Docs only, no behavior change.