### PR TITLE
sint-mcp: add mcpName + bump version (registry publish unblock)

### DIFF
--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.pshkv/sint-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "title": "SINT MCP",
   "description": "Security-first MCP proxy with policy enforcement, approvals, and audit receipts.",
   "websiteUrl": "https://github.com/sint-ai/sint-protocol/tree/main/apps/sint-mcp",
@@ -9,7 +9,7 @@
     {
       "registryType": "npm",
       "identifier": "sint-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "transport": { "type": "stdio" },
       "packageArguments": [],
       "environmentVariables": [
@@ -27,4 +27,3 @@
     "source": "github"
   }
 }
-

--- a/apps/sint-mcp/package.json
+++ b/apps/sint-mcp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "sint-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
+  "mcpName": "io.github.pshkv/sint-mcp",
   "description": "SINT MCP — Security-first multi-MCP proxy server with policy enforcement",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Fixes MCP Registry publish validation by adding required `mcpName` field to the published npm package metadata and bumping `sint-mcp` to 0.1.1. Updates `.mcp/server.json` to match.