### PR TITLE
feat(core): migrationAttestation as structural precondition on ConstraintEnvelope

### DIFF
--- a/packages/core/__tests__/constraint-language.test.ts
+++ b/packages/core/__tests__/constraint-language.test.ts
@@ -110,6 +110,145 @@ describe("validateConstraintEnvelope", () => {
     expect(result.mode).toBe("legacy");
   });
 
+  // -------------------------------------------------------------------------
+  // migrationAttestation — entity_continuity structural precondition
+  // Refs: aeoess/agent-governance-vocabulary#8
+  // -------------------------------------------------------------------------
+
+  it("migrationAttestation with continuityVerified:true and all fields is valid", () => {
+    const envelope: ConstraintEnvelope = {
+      version: "cl-1.0",
+      migrationAttestation: {
+        schema: "https://soulboundrobots.ai/schemas/sbr-002-v1.json",
+        attestationUri: "https://eas.example/0xabc",
+        agentWallet: "0xdead",
+        continuityVerified: true,
+        issuedAt: "2026-04-20T00:00:00Z",
+      },
+    };
+    const result = validateConstraintEnvelope(envelope);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("migrationAttestation with continuityVerified:false fails validation", () => {
+    const envelope: ConstraintEnvelope = {
+      version: "cl-1.0",
+      migrationAttestation: {
+        schema: "https://soulboundrobots.ai/schemas/sbr-002-v1.json",
+        attestationUri: "https://eas.example/0xabc",
+        agentWallet: "0xdead",
+        continuityVerified: false,
+        issuedAt: "2026-04-20T00:00:00Z",
+      },
+    };
+    const result = validateConstraintEnvelope(envelope);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "migrationAttestation.continuityVerified must be true for envelope to activate",
+    );
+  });
+
+  it("migrationAttestation with empty schema fails validation", () => {
+    const envelope: ConstraintEnvelope = {
+      version: "cl-1.0",
+      migrationAttestation: {
+        schema: "",
+        attestationUri: "https://eas.example/0xabc",
+        agentWallet: "0xdead",
+        continuityVerified: true,
+        issuedAt: "2026-04-20T00:00:00Z",
+      },
+    };
+    const result = validateConstraintEnvelope(envelope);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "migrationAttestation.schema must be a non-empty string",
+    );
+  });
+
+  it("migrationAttestation with empty attestationUri fails validation", () => {
+    const envelope: ConstraintEnvelope = {
+      version: "cl-1.0",
+      migrationAttestation: {
+        schema: "https://soulboundrobots.ai/schemas/sbr-002-v1.json",
+        attestationUri: "",
+        agentWallet: "0xdead",
+        continuityVerified: true,
+        issuedAt: "2026-04-20T00:00:00Z",
+      },
+    };
+    const result = validateConstraintEnvelope(envelope);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "migrationAttestation.attestationUri must be a non-empty string",
+    );
+  });
+
+  it("migrationAttestation with empty agentWallet fails validation", () => {
+    const envelope: ConstraintEnvelope = {
+      version: "cl-1.0",
+      migrationAttestation: {
+        schema: "https://soulboundrobots.ai/schemas/sbr-002-v1.json",
+        attestationUri: "https://eas.example/0xabc",
+        agentWallet: "",
+        continuityVerified: true,
+        issuedAt: "2026-04-20T00:00:00Z",
+      },
+    };
+    const result = validateConstraintEnvelope(envelope);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "migrationAttestation.agentWallet must be a non-empty string",
+    );
+  });
+
+  it("migrationAttestation with empty issuedAt fails validation", () => {
+    const envelope: ConstraintEnvelope = {
+      version: "cl-1.0",
+      migrationAttestation: {
+        schema: "https://soulboundrobots.ai/schemas/sbr-002-v1.json",
+        attestationUri: "https://eas.example/0xabc",
+        agentWallet: "0xdead",
+        continuityVerified: true,
+        issuedAt: "",
+      },
+    };
+    const result = validateConstraintEnvelope(envelope);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "migrationAttestation.issuedAt must be a non-empty ISO8601 string",
+    );
+  });
+
+  it("migrationAttestation validates on legacy envelope too (forward-compatible)", () => {
+    const envelope: ConstraintEnvelope = {
+      migrationAttestation: {
+        schema: "https://soulboundrobots.ai/schemas/sbr-002-v1.json",
+        attestationUri: "https://eas.example/0xabc",
+        agentWallet: "0xdead",
+        continuityVerified: false,
+        issuedAt: "2026-04-20T00:00:00Z",
+      },
+    };
+    const result = validateConstraintEnvelope(envelope);
+    expect(result.valid).toBe(false);
+    expect(result.mode).toBe("legacy");
+    expect(result.errors).toContain(
+      "migrationAttestation.continuityVerified must be true for envelope to activate",
+    );
+  });
+
+  it("envelope without migrationAttestation is unaffected (field is optional)", () => {
+    const envelope: ConstraintEnvelope = {
+      version: "cl-1.0",
+      physical: { maxVelocityMps: 0.5 },
+    };
+    const result = validateConstraintEnvelope(envelope);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
   it("CL-1.0 with mode:corridor-preapproved is valid", () => {
     const envelope: ConstraintEnvelope = {
       version: "cl-1.0",

--- a/packages/core/src/constraint-language.ts
+++ b/packages/core/src/constraint-language.ts
@@ -61,6 +61,29 @@ export function validateConstraintEnvelope(envelope: ConstraintEnvelope): Constr
     }
   }
 
+  // migrationAttestation validation applies regardless of version — the field
+  // is forward-compatible and its presence always requires the full attestation
+  // shape with continuityVerified === true as the structural precondition for
+  // scope grant.
+  if (envelope.migrationAttestation !== undefined) {
+    const ma = envelope.migrationAttestation;
+    if (ma.continuityVerified !== true) {
+      errors.push("migrationAttestation.continuityVerified must be true for envelope to activate");
+    }
+    if (typeof ma.schema !== "string" || ma.schema.length === 0) {
+      errors.push("migrationAttestation.schema must be a non-empty string");
+    }
+    if (typeof ma.attestationUri !== "string" || ma.attestationUri.length === 0) {
+      errors.push("migrationAttestation.attestationUri must be a non-empty string");
+    }
+    if (typeof ma.agentWallet !== "string" || ma.agentWallet.length === 0) {
+      errors.push("migrationAttestation.agentWallet must be a non-empty string");
+    }
+    if (typeof ma.issuedAt !== "string" || ma.issuedAt.length === 0) {
+      errors.push("migrationAttestation.issuedAt must be a non-empty ISO8601 string");
+    }
+  }
+
   return { valid: errors.length === 0, errors, mode };
 }
 

--- a/packages/core/src/types/protocol.ts
+++ b/packages/core/src/types/protocol.ts
@@ -74,6 +74,27 @@ export interface ConstraintEnvelopeAttestation {
 }
 
 /**
+ * CL-1.0 migration attestation — proves agent identity continuity across
+ * embodied-AI migrations (body swaps, wallet rotations, runtime handoffs).
+ *
+ * Shape aligns with the SBR-002 (Soulbound Robots) reference schema. When
+ * this field is present on an envelope, `continuityVerified` must be `true`
+ * for the envelope to validate. This makes entity_continuity a structural
+ * precondition for scope grant rather than an advisory signal.
+ *
+ * Refs:
+ * - aeoess/agent-governance-vocabulary#8 (entity_continuity signal type)
+ * - https://soulboundrobots.ai/schemas/sbr-002-v1.json (reference schema)
+ */
+export interface ConstraintEnvelopeMigrationAttestation {
+  readonly schema: string;
+  readonly attestationUri: string;
+  readonly agentWallet: string;
+  readonly continuityVerified: boolean;
+  readonly issuedAt: ISO8601;
+}
+
+/**
  * CL-1.0 constraint enforcement mode.
  */
 export type ConstraintEnvelopeMode = "static-token" | "dynamic-runtime" | "corridor-preapproved";
@@ -92,6 +113,7 @@ export interface ConstraintEnvelope extends Partial<SintPhysicalConstraints> {
   readonly behavioral?: ConstraintEnvelopeBehavioral;
   readonly model?: ConstraintEnvelopeModel;
   readonly attestation?: ConstraintEnvelopeAttestation;
+  readonly migrationAttestation?: ConstraintEnvelopeMigrationAttestation;
   readonly dynamic?: ConstraintEnvelopeDynamic;
   readonly execution?: ConstraintEnvelopeExecution;
   readonly extensions?: Readonly<Record<string, unknown>>;


### PR DESCRIPTION
## Summary

Follow-through on the commitment made in [aeoess/agent-governance-vocabulary#8](https://github.com/aeoess/agent-governance-vocabulary/issues/8) — adds `migrationAttestation` as a **structural precondition** on `ConstraintEnvelope`. When present, the envelope only validates if `continuityVerified === true` with all four shape fields populated. This makes entity_continuity a scope-grant gate rather than an advisory signal.

## Why this shape

- Matches the SBR-002 (Soulbound Robots) reference schema for embodied-AI migrations (body swaps, wallet rotations, runtime handoffs).
- Validation is applied **regardless of envelope version** — the field is forward-compatible and its presence always demands the full shape.
- Fits the existing `validateConstraintEnvelope` surface without introducing a new "activation gate" concept — invalid envelope = no scope grant, which is functionally equivalent.

## Changes

- `packages/core/src/types/protocol.ts` — new `ConstraintEnvelopeMigrationAttestation` interface; optional `migrationAttestation` field added to `ConstraintEnvelope`
- `packages/core/src/constraint-language.ts` — 5 validation rules on the migration-attestation block
- `packages/core/__tests__/constraint-language.test.ts` — 8 new test cases

## Test plan

- [x] Typecheck: `pnpm --filter @sint/core run typecheck` — passes
- [x] Tests: `pnpm --filter @sint/core test` — 61 passed (previously 53)
- [ ] Downstream: `bridge-a2a` uses `ConstraintEnvelope` — additive-only change, no breaking surface. Running downstream tests recommended before merge.

## Follow-ups (not in this PR)

1. **Crosswalk update** — `aeoess/agent-governance-vocabulary/crosswalk/sint.yaml` adds `entity_continuity` (`no_mapping` + composition note pointing at this field) and `consent_provenance` (`close_match` + gap note). Separate PR against that repo.
2. **Spec version bump** — `docs/specs/sint-protocol-v1.0.md` should document the new field in a v1.1 section (coordinated with the v1.0 → v1.1 promotion from [#168](https://github.com/sint-ai/sint-protocol/pull/168) canonical-signing clarifications).
3. **Descriptor-extension PR in vocab repo** — per aeoess's sequencing: seven new descriptor enum values land before any new signal-type merge.

## Refs

- `aeoess/agent-governance-vocabulary#8` — drove this
- [SBR-002 schema](https://soulboundrobots.ai/schemas/sbr-002-v1.json) — reference shape
