### PR TITLE
test(policy-gateway): harden circuit breaker timing spec

### DIFF
--- a/docs/conformance/owasp-asi-mapping.md
+++ b/docs/conformance/owasp-asi-mapping.md
@@ -153,6 +153,8 @@ SINT is a security enforcement layer for physical AI. Every agent action — too
 
 **Enforcement detail:** Rate limiting is enforced via a sliding-window bucket keyed by `tokenId`. The circuit breaker tracks denials per agent; excess denials open the circuit and block all subsequent requests. The circuit auto-transitions to HALF_OPEN after `halfOpenAfterMs` to test recovery, unless it was manually tripped by an operator.
 
+**Testing note:** CI conformance coverage uses a slightly longer `halfOpenAfterMs` probe window so the HALF_OPEN recovery path stays deterministic across shared runners and does not flap on scheduler variance.
+
 ---
 
 ### ASI09 — Human Oversight Bypass

--- a/packages/policy-gateway/__tests__/gateway-circuit-breaker.test.ts
+++ b/packages/policy-gateway/__tests__/gateway-circuit-breaker.test.ts
@@ -306,11 +306,12 @@ describe("InMemoryCircuitBreaker — state machine", () => {
 
   it("OPEN → HALF_OPEN after halfOpenAfterMs", async () => {
     // Open via recordDenial (not trip) so manualTrip stays false
-    const cb = new InMemoryCircuitBreaker({ failureThreshold: 2, halfOpenAfterMs: 5 });
+    // Use a wider window so CI timing variance does not advance the state early.
+    const cb = new InMemoryCircuitBreaker({ failureThreshold: 2, halfOpenAfterMs: 100 });
     await cb.recordDenial("a", "x");
     await cb.recordDenial("a", "x");
     expect(await cb.getState("a")).toBe("OPEN");
-    await new Promise((r) => setTimeout(r, 10));
+    await new Promise((r) => setTimeout(r, 120));
     expect(await cb.getState("a")).toBe("HALF_OPEN");
   });
 


### PR DESCRIPTION
This fixes a CI flake in \: the OPEN→HALF_OPEN state-machine test used a 5ms window and could advance early on GitHub runners.

Change:
- widen the timeout window in the spec to 100ms
- wait 120ms before asserting HALF_OPEN

This keeps the production circuit-breaker behavior unchanged and makes the test deterministic.