### PR TITLE
docs: update Glama badge and OATR domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue)
 ![License](https://img.shields.io/badge/license-Apache--2.0-blue)
 
-[![Glama](https://glama.ai/mcp/servers/sint-ai/sint-protocol/badges/card.svg)](https://glama.ai/mcp/servers/sint-ai/sint-protocol)
+[![Glama](https://glama.ai/mcp/servers/sint-ai/sint-protocol/badge)](https://glama.ai/mcp/servers/sint-ai/sint-protocol)
 
 **Security, permission, and economic enforcement layer for physical AI.**
 

--- a/docs/oatr/DOMAIN_VERIFICATION.md
+++ b/docs/oatr/DOMAIN_VERIFICATION.md
@@ -4,11 +4,11 @@
 
 - Registry entry: `/tmp/open-agent-trust-registry/registry/issuers/sint-protocol.json` (PR #24 submitted)
 - Domain verification endpoint: `GET /.well-known/agent-trust.json` (implemented in gateway-server)
-- **Pending**: Live deployment at `https://sint.ai/.well-known/agent-trust.json`
+- **Pending**: Live deployment at `https://sint.gg/.well-known/agent-trust.json`
 
 ## Verification Flow
 
-1. OATR registry reads `https://sint.ai/.well-known/agent-trust.json`
+1. OATR registry reads `https://sint.gg/.well-known/agent-trust.json`
 2. Downloads our Ed25519 public key (`kid: sint-registry-2026-04`)
 3. Verifies signature over canonical message `oatr-proof-v1:sint-protocol`
 4. Marks entry as `domain_verified: true`


### PR DESCRIPTION
This is a docs-only publish of the local updates that are safe to ship now:\n\n- switch the Glama badge URL to the current /badge endpoint\n- update the OATR domain verification docs from sint.ai to sint.gg\n\nI intentionally left the unrelated pnpm-lock.yaml workspace entry out of this branch so the PR stays scoped and reviewable.