### PR TITLE
feat(capability-tokens): duress token split-control + coercion signals

### DIFF
--- a/docs/guides/duress-token.md
+++ b/docs/guides/duress-token.md
@@ -1,0 +1,23 @@
+# Duress Token Pattern
+
+The duress-token module in `@pshkv/gate-capability-tokens` provides a
+survivor-centered control pattern for high-risk domestic safety contexts.
+
+## What it adds
+
+- Split control metadata: survivor identity + trusted third-party identity
+- Dual-approval validation for sensitive resolution paths
+- Evidence escrow metadata for judicially controlled access
+- Coercion signal detection from access-log patterns
+
+## Core API
+
+- `createDuressCapabilityToken(baseToken, profile, escrow)`
+- `validateDuressResolution(token, approvers)`
+- `detectCoercion(logs, options)`
+
+## Operational guidance
+
+- Issue duress tokens only from revocable base capabilities.
+- Require dual approval for irreversible actions (for example, disabling alarms or revoking active safe-access tokens).
+- Persist coercion-detection reasons alongside audit records for post-incident review.

--- a/packages/capability-tokens/__tests__/duress-token.test.ts
+++ b/packages/capability-tokens/__tests__/duress-token.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  createDuressCapabilityToken,
+  detectCoercion,
+  generateKeypair,
+  issueCapabilityToken,
+  validateDuressResolution,
+} from "../src/index.js";
+import type { SintCapabilityTokenRequest } from "@pshkv/core";
+
+function futureISO(hoursFromNow: number): string {
+  const d = new Date(Date.now() + hoursFromNow * 3600_000);
+  return d.toISOString().replace(/\.(\d{3})Z$/, ".$1000Z");
+}
+
+describe("Duress token helpers", () => {
+  const issuer = generateKeypair();
+  const subject = generateKeypair();
+
+  const request: SintCapabilityTokenRequest = {
+    issuer: issuer.publicKey,
+    subject: subject.publicKey,
+    resource: "home://lock/front-door",
+    actions: ["unlock", "lock"],
+    constraints: { maxRepetitions: 20 },
+    delegationChain: { parentTokenId: null, depth: 0, attenuated: false },
+    expiresAt: futureISO(8),
+    revocable: true,
+  };
+
+  it("creates duress token profile with split control metadata", () => {
+    const base = issueCapabilityToken(request, issuer.privateKey);
+    expect(base.ok).toBe(true);
+    if (!base.ok) return;
+
+    const result = createDuressCapabilityToken(
+      base.value,
+      {
+        survivorId: "did:key:z6Mksurvivor",
+        trustedPartyId: "did:key:z6Mktrusted",
+        requiresDualApproval: true,
+      },
+      {
+        evidenceHash: "a".repeat(64),
+        judicialPublicKeyRef: "did:key:z6Mkjurisdiction",
+        encryptedEvidenceKey: "ciphertext:abc123",
+      },
+      "2026-05-14T02:30:00.000000Z",
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.duressControl.requiresDualApproval).toBe(true);
+    expect(result.value.createdAt).toBe("2026-05-14T02:30:00.000000Z");
+  });
+
+  it("enforces survivor + trusted-party dual approval", () => {
+    const base = issueCapabilityToken(request, issuer.privateKey);
+    if (!base.ok) throw new Error("token issuance failed");
+
+    const duress = createDuressCapabilityToken(
+      base.value,
+      {
+        survivorId: "did:key:z6Mksurvivor",
+        trustedPartyId: "did:key:z6Mktrusted",
+        requiresDualApproval: true,
+      },
+      {
+        evidenceHash: "b".repeat(64),
+        judicialPublicKeyRef: "did:key:z6Mkjurisdiction",
+        encryptedEvidenceKey: "ciphertext:def456",
+      },
+      "2026-05-14T02:30:00.000000Z",
+    );
+    if (!duress.ok) throw new Error("duress token creation failed");
+
+    const missingTrusted = validateDuressResolution(duress.value, [
+      "did:key:z6Mksurvivor",
+    ]);
+    expect(missingTrusted.ok).toBe(false);
+
+    const full = validateDuressResolution(duress.value, [
+      "did:key:z6Mksurvivor",
+      "did:key:z6Mktrusted",
+    ]);
+    expect(full.ok).toBe(true);
+  });
+
+  it("detects coercion patterns from action logs", () => {
+    const logs = [
+      {
+        timestamp: "2026-05-14T02:20:00.000000Z",
+        actorId: "actor-a",
+        action: "unlock" as const,
+        sourceNetwork: "10.0.0.10",
+      },
+      {
+        timestamp: "2026-05-14T02:21:00.000000Z",
+        actorId: "actor-a",
+        action: "unlock" as const,
+        sourceNetwork: "10.0.0.11",
+      },
+      {
+        timestamp: "2026-05-14T02:22:00.000000Z",
+        actorId: "actor-a",
+        action: "revoke_token" as const,
+        sourceNetwork: "10.0.0.12",
+      },
+    ];
+
+    const result = detectCoercion(logs);
+    expect(result.coercionDetected).toBe(true);
+    expect(result.riskScore).toBeGreaterThanOrEqual(0.5);
+    expect(result.reasons.length).toBeGreaterThan(0);
+  });
+});
+

--- a/packages/capability-tokens/src/duress-token.ts
+++ b/packages/capability-tokens/src/duress-token.ts
@@ -1,0 +1,154 @@
+import {
+  type CapabilityTokenError,
+  type Result,
+  type SintCapabilityToken,
+  err,
+  ok,
+} from "@pshkv/core";
+
+export interface DuressEvidenceEscrow {
+  readonly evidenceHash: string;
+  readonly judicialPublicKeyRef: string;
+  readonly encryptedEvidenceKey: string;
+}
+
+export interface DuressControlProfile {
+  readonly survivorId: string;
+  readonly trustedPartyId: string;
+  readonly requiresDualApproval: boolean;
+}
+
+export interface DuressCapabilityToken {
+  readonly baseToken: SintCapabilityToken;
+  readonly duressControl: DuressControlProfile;
+  readonly evidenceEscrow: DuressEvidenceEscrow;
+  readonly createdAt: string;
+}
+
+export interface DuressAccessLog {
+  readonly timestamp: string;
+  readonly actorId: string;
+  readonly action: "unlock" | "lock" | "disable_alarm" | "enable_alarm" | "revoke_token";
+  readonly sourceNetwork?: string;
+  readonly approvedBy?: readonly string[];
+}
+
+export interface CoercionDetectionResult {
+  readonly coercionDetected: boolean;
+  readonly riskScore: number;
+  readonly reasons: readonly string[];
+}
+
+export interface CoercionDetectionOptions {
+  readonly lookbackMs?: number;
+  readonly repeatedAttemptsThreshold?: number;
+}
+
+const ISO8601_MICRO = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$/;
+
+export function createDuressCapabilityToken(
+  baseToken: SintCapabilityToken,
+  profile: DuressControlProfile,
+  escrow: DuressEvidenceEscrow,
+  createdAt: string = nowIso8601Micros(),
+): Result<DuressCapabilityToken, CapabilityTokenError> {
+  if (!profile.survivorId || !profile.trustedPartyId) {
+    return err("MALFORMED_TOKEN");
+  }
+  if (profile.survivorId === profile.trustedPartyId) {
+    return err("MALFORMED_TOKEN");
+  }
+  if (!escrow.evidenceHash || !escrow.judicialPublicKeyRef || !escrow.encryptedEvidenceKey) {
+    return err("MALFORMED_TOKEN");
+  }
+  if (!ISO8601_MICRO.test(createdAt)) {
+    return err("MALFORMED_TOKEN");
+  }
+  if (!baseToken.revocable) {
+    return err("INSUFFICIENT_PERMISSIONS");
+  }
+
+  return ok({
+    baseToken,
+    duressControl: profile,
+    evidenceEscrow: escrow,
+    createdAt,
+  });
+}
+
+export function validateDuressResolution(
+  token: DuressCapabilityToken,
+  approvers: readonly string[],
+): Result<true, CapabilityTokenError> {
+  if (!token.duressControl.requiresDualApproval) {
+    return ok(true);
+  }
+  const unique = new Set(approvers);
+  if (!unique.has(token.duressControl.survivorId)) {
+    return err("INSUFFICIENT_PERMISSIONS");
+  }
+  if (!unique.has(token.duressControl.trustedPartyId)) {
+    return err("INSUFFICIENT_PERMISSIONS");
+  }
+  return ok(true);
+}
+
+export function detectCoercion(
+  logs: readonly DuressAccessLog[],
+  options: CoercionDetectionOptions = {},
+): CoercionDetectionResult {
+  const lookbackMs = options.lookbackMs ?? 15 * 60 * 1000;
+  const repeatedAttemptsThreshold = options.repeatedAttemptsThreshold ?? 3;
+  const reasons: string[] = [];
+
+  if (logs.length === 0) {
+    return { coercionDetected: false, riskScore: 0, reasons };
+  }
+
+  const newestMs = Math.max(...logs.map((entry) => new Date(entry.timestamp).getTime()));
+  const activeWindow = logs.filter(
+    (entry) => newestMs - new Date(entry.timestamp).getTime() <= lookbackMs,
+  );
+
+  const actorCounts = new Map<string, number>();
+  const networkSet = new Set<string>();
+  for (const entry of activeWindow) {
+    actorCounts.set(entry.actorId, (actorCounts.get(entry.actorId) ?? 0) + 1);
+    if (entry.sourceNetwork) {
+      networkSet.add(entry.sourceNetwork);
+    }
+  }
+
+  const maxActorAttempts = Math.max(...actorCounts.values());
+  let riskScore = 0;
+
+  if (maxActorAttempts >= repeatedAttemptsThreshold) {
+    riskScore += 0.45;
+    reasons.push("Repeated high-risk actions by a single actor in short window");
+  }
+
+  if (networkSet.size >= 3) {
+    riskScore += 0.35;
+    reasons.push("Action stream originated from multiple networks in short window");
+  }
+
+  const revocationAttempts = activeWindow.filter(
+    (entry) => entry.action === "revoke_token",
+  ).length;
+  if (revocationAttempts > 0) {
+    riskScore += 0.3;
+    reasons.push("Revocation attempts detected during active duress window");
+  }
+
+  const cappedScore = Math.min(1, riskScore);
+  return {
+    coercionDetected: cappedScore >= 0.5,
+    riskScore: cappedScore,
+    reasons,
+  };
+}
+
+function nowIso8601Micros(): string {
+  return new Date().toISOString().replace(/\.(\d{3})Z$/, ".$1000Z");
+}
+

--- a/packages/capability-tokens/src/index.ts
+++ b/packages/capability-tokens/src/index.ts
@@ -19,3 +19,16 @@ export { RevocationStore } from "./revocation.js";
 export type { RevocationRecord } from "./revocation.js";
 export { generateUUIDv7, nowISO8601 } from "./utils.js";
 export { keyToDid, didToKey, isValidDid } from "./did.js";
+export {
+  createDuressCapabilityToken,
+  validateDuressResolution,
+  detectCoercion,
+} from "./duress-token.js";
+export type {
+  DuressEvidenceEscrow,
+  DuressControlProfile,
+  DuressCapabilityToken,
+  DuressAccessLog,
+  CoercionDetectionResult,
+  CoercionDetectionOptions,
+} from "./duress-token.js";


### PR DESCRIPTION
## Summary
- add duress-token module in @pshkv/gate-capability-tokens
- add split-control token metadata (survivor + trusted-party)
- add dual-approval validation helper for sensitive resolution paths
- add coercion signal detection helper over access logs
- add duress token guide in docs/guides/duress-token.md

## Verification
- pnpm --filter @pshkv/gate-capability-tokens test -- duress-token
- pnpm --filter @pshkv/gate-capability-tokens build