### PR TITLE
docs(security): publish May 2026 bulletin

### DIFF
--- a/docs/security-bulletins/2026-05.md
+++ b/docs/security-bulletins/2026-05.md
@@ -1,0 +1,39 @@
+# SINT Security Bulletin — May 2026
+
+Published: 2026-05-13
+Scope: Protocol, runtime enforcement, and integration hardening updates.
+
+## Highlights
+
+- Hardened capability-token signing payload canonicalization for deterministic signatures across runtime/object-order variations.
+- Landed PostgreSQL token persistence round-trip fixes to preserve full signed token envelope fields.
+- Added emergency bypass protocol baseline in policy gateway with bounded override windows and deterministic audit hashing.
+- Added duress-token split-control primitives (survivor + trusted-party dual-approval support) and coercion-signal helpers.
+
+## Security-Relevant Changes
+
+- Signature verification drift risks reduced by deterministic canonical signing payload generation.
+- Persistence/reload mismatch risks reduced by storing and reconstructing optional signed token fields end-to-end.
+- High-risk emergency override paths now carry explicit bounded context windows and mandatory post-hoc audit records.
+- Duress scenarios now have first-class split-control modeling and detection helpers for suspicious access patterns.
+
+## Recommended Operator Actions
+
+1. Pull latest `main` and rerun core token + gateway tests in staging.
+2. Review emergency override SOPs to ensure operator role mapping aligns with emergency bypass controls.
+3. Add survivor/trusted-party identity mapping to deployment policy docs before enabling duress-token paths.
+4. Re-run revocation and escalation drills with persistence enabled to confirm round-trip behavior under restart conditions.
+
+## Validation Commands
+
+```bash
+pnpm run build
+pnpm run test
+pnpm --filter @pshkv/gate-capability-tokens test -- duress-token
+pnpm --filter @pshkv/gate-policy-gateway test -- emergency-bypass
+```
+
+## Forward Look (June 2026)
+
+- Extend coercion-signal heuristics with deployment-specific thresholds and telemetry hooks.
+- Continue production-readiness sequencing around CI stability, release gates, and supportability.


### PR DESCRIPTION
## Summary
- add monthly security bulletin at docs/security-bulletins/2026-05.md
- capture May protocol/runtime hardening items (canonical signing, persistence round-trip, emergency bypass, duress controls)
- include operator action items and validation commands

## Related
- closes #182

## Verification
- docs content reviewed for bulletin checklist coverage
- note: `pnpm run docs:build` currently fails on an existing unrelated dead link in docs/guides/consumer-smart-home-integration.md