### PR TITLE
test(conformance): add physical AI runtime safety fixtures

### DIFF
--- a/packages/conformance-tests/fixtures/physical-ai/README.md
+++ b/packages/conformance-tests/fixtures/physical-ai/README.md
@@ -1,0 +1,16 @@
+# Physical AI Runtime Safety Fixtures
+
+This fixture pack defines protocol-neutral checks for the boundary between AI
+agents and physical systems.
+
+The v0.1 scope is intentionally small:
+
+- pre-action authorization before actuation
+- ROS2/SROS2 transport non-bypass behavior
+- e-stop rollback semantics
+- evidence pointers that bind request, action intent, and policy verdict
+
+SINT provides one reference runner, but other implementations can translate the
+same cases into their own gateway, transport, or simulator. The important
+interop question is whether independent systems agree on the expected decision,
+transport outcome, and evidence contract.

--- a/packages/conformance-tests/fixtures/physical-ai/runtime-safety-fixtures.v0.1.json
+++ b/packages/conformance-tests/fixtures/physical-ai/runtime-safety-fixtures.v0.1.json
@@ -1,0 +1,168 @@
+{
+  "fixtureId": "physical-ai-runtime-safety-v0.1",
+  "schemaVersion": "0.1.0",
+  "description": "Protocol-neutral fixtures for physical AI runtime safety boundaries: pre-action authorization, transport non-bypass, e-stop rollback, and decision evidence.",
+  "profile": {
+    "transport": "ros2/sros2",
+    "actionBoundary": "pre-actuation",
+    "decisionVocabulary": ["allow", "deny", "escalate", "rollback"],
+    "transportOutcomes": [
+      "forwarded",
+      "held_for_review",
+      "publish_rejected",
+      "discovery_rejected",
+      "execution_rolled_back"
+    ],
+    "evidenceRequirements": {
+      "decisionRefRequired": true,
+      "actionIntentRefRequired": true,
+      "hashChainRequired": true
+    }
+  },
+  "defaultToken": {
+    "resource": "ros2:///cmd_vel",
+    "actions": ["publish"],
+    "constraints": {
+      "maxVelocityMps": 0.5,
+      "maxForceNewtons": 50
+    }
+  },
+  "cases": [
+    {
+      "id": "ros2_cmd_vel_authorized_escalates",
+      "name": "Authorized /cmd_vel publish is held for T2 review",
+      "description": "The token scope and physical limits allow the command, but /cmd_vel is a physical-state-change action and must not auto-forward.",
+      "request": {
+        "resource": "ros2:///cmd_vel",
+        "action": "publish",
+        "params": {
+          "linear_velocity": 0.2
+        }
+      },
+      "expected": {
+        "decisionAction": "escalate",
+        "assignedTier": "T2_act",
+        "transportOutcome": "held_for_review",
+        "evidenceEventType": "policy.decision.escalate"
+      }
+    },
+    {
+      "id": "ros2_cmd_vel_denied_by_scope",
+      "name": "Movement publish is denied when token scope does not cover /cmd_vel",
+      "description": "A token scoped to sensor reads cannot authorize a movement command.",
+      "tokenOverride": {
+        "resource": "ros2:///sensor/*",
+        "actions": ["subscribe"],
+        "constraints": {}
+      },
+      "request": {
+        "resource": "ros2:///cmd_vel",
+        "action": "publish",
+        "params": {
+          "linear_velocity": 0.2
+        }
+      },
+      "expected": {
+        "decisionAction": "deny",
+        "policyViolated": "INSUFFICIENT_PERMISSIONS",
+        "transportOutcome": "publish_rejected"
+      }
+    },
+    {
+      "id": "ros2_cmd_vel_escalates_human_present",
+      "name": "Human presence escalates /cmd_vel from T2 to T3",
+      "description": "A human detected in the workspace raises the consequence tier for motion commands.",
+      "request": {
+        "resource": "ros2:///cmd_vel",
+        "action": "publish",
+        "params": {
+          "linear_velocity": 0.1
+        },
+        "physicalContext": {
+          "humanDetected": true
+        }
+      },
+      "expected": {
+        "decisionAction": "escalate",
+        "assignedTier": "T3_commit",
+        "transportOutcome": "held_for_review",
+        "evidenceEventType": "policy.decision.escalate"
+      }
+    },
+    {
+      "id": "sros2_bypass_publish_fails",
+      "name": "Direct SROS2 publisher without topic permission cannot bypass the gate",
+      "description": "The transport layer rejects a direct publisher that lacks publish permission for /cmd_vel.",
+      "transportCheck": {
+        "enclave": {
+          "enclavePath": "/agents/reviewer",
+          "domainId": 42,
+          "allowPublish": ["/diagnostics"],
+          "allowSubscribe": ["/cmd_vel", "/diagnostics"],
+          "denyPublish": ["/cmd_vel"],
+          "denySubscribe": [],
+          "governanceEnforced": true
+        },
+        "topicName": "/cmd_vel",
+        "operation": "publish"
+      },
+      "expected": {
+        "decisionAction": "deny",
+        "transportOutcome": "publish_rejected",
+        "transportDecision": "deny",
+        "evidenceEventType": "transport.sros2.publish_rejected"
+      }
+    },
+    {
+      "id": "estop_always_rolls_back",
+      "name": "E-stop rolls back regardless of token state",
+      "description": "Hardware e-stop preempts software approvals and token checks for any non-terminal physical path.",
+      "request": {
+        "resource": "ros2:///cmd_vel",
+        "action": "publish",
+        "params": {
+          "linear_velocity": 0.1
+        },
+        "executionContext": {
+          "deploymentProfile": "warehouse-amr",
+          "hardwareSafety": {
+            "permitState": "granted",
+            "interlockState": "closed",
+            "estopState": "triggered",
+            "observedAt": "__NOW__"
+          }
+        }
+      },
+      "expected": {
+        "decisionAction": "rollback",
+        "policyViolated": "HARDWARE_ESTOP_ACTIVE",
+        "transportOutcome": "execution_rolled_back",
+        "evidenceEventType": "safety.estop.triggered"
+      }
+    },
+    {
+      "id": "receipt_verifies_policy_decision",
+      "name": "Decision evidence binds request, action intent, and policy verdict",
+      "description": "A verifier can correlate the decision receipt to the attempted action without embedding provider-specific evidence in the fixture.",
+      "request": {
+        "resource": "ros2:///cmd_vel",
+        "action": "publish",
+        "params": {
+          "linear_velocity": 0.2
+        }
+      },
+      "expected": {
+        "decisionAction": "escalate",
+        "assignedTier": "T2_act",
+        "transportOutcome": "held_for_review",
+        "evidenceEventType": "policy.decision.escalate",
+        "evidence": {
+          "decisionRefRequired": true,
+          "actionIntentRefRequired": true,
+          "hashChainRequired": true,
+          "providerSpecificReceiptAllowed": true
+        }
+      }
+    }
+  ]
+}

--- a/packages/conformance-tests/package.json
+++ b/packages/conformance-tests/package.json
@@ -7,7 +7,7 @@
     "build": "echo 'no build needed'",
     "test": "vitest run",
     "test:watch": "vitest watch",
-    "test:fixtures": "vitest run src/canonical-fixtures-conformance.test.ts src/a2a-fixtures-conformance.test.ts src/security-iot-fixtures-conformance.test.ts src/economy-fixtures-conformance.test.ts src/autogen-interop-conformance.test.ts src/agentskill-authz-fixtures-conformance.test.ts src/action-ref-explainability-conformance.test.ts src/payment-governance-fixtures-conformance.test.ts",
+    "test:fixtures": "vitest run src/canonical-fixtures-conformance.test.ts src/a2a-fixtures-conformance.test.ts src/security-iot-fixtures-conformance.test.ts src/economy-fixtures-conformance.test.ts src/autogen-interop-conformance.test.ts src/agentskill-authz-fixtures-conformance.test.ts src/action-ref-explainability-conformance.test.ts src/payment-governance-fixtures-conformance.test.ts src/physical-ai-runtime-safety-fixtures-conformance.test.ts",
     "test:ros2-loop": "vitest run src/ros2-control-loop-latency.test.ts"
   },
   "devDependencies": {

--- a/packages/conformance-tests/src/fixture-loader.ts
+++ b/packages/conformance-tests/src/fixture-loader.ts
@@ -16,6 +16,7 @@ const ROOT = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_ROOT = resolve(ROOT, "../fixtures");
 
 type DecisionAction = PolicyDecision["action"];
+type PhysicalAiDecisionAction = DecisionAction | "rollback";
 
 export interface TokenFixture {
   readonly resource: string;
@@ -103,6 +104,83 @@ export interface HardwareSafetyHandshakeFixture {
       readonly assignedTier?: ApprovalTier;
       readonly policyViolated?: string;
       readonly expectedEvidenceEvent?: string;
+    };
+  }>;
+}
+
+export interface PhysicalAiRuntimeSafetyFixture {
+  readonly fixtureId: string;
+  readonly schemaVersion: string;
+  readonly description: string;
+  readonly profile: {
+    readonly transport: "ros2/sros2";
+    readonly actionBoundary: "pre-actuation";
+    readonly decisionVocabulary: readonly PhysicalAiDecisionAction[];
+    readonly transportOutcomes: readonly Array<
+      | "forwarded"
+      | "held_for_review"
+      | "publish_rejected"
+      | "discovery_rejected"
+      | "execution_rolled_back"
+    >;
+    readonly evidenceRequirements: {
+      readonly decisionRefRequired: boolean;
+      readonly actionIntentRefRequired: boolean;
+      readonly hashChainRequired: boolean;
+    };
+  };
+  readonly defaultToken: TokenFixture & {
+    readonly constraints?: {
+      readonly maxVelocityMps?: number;
+      readonly maxForceNewtons?: number;
+    };
+  };
+  readonly cases: readonly Array<{
+    readonly id: string;
+    readonly name: string;
+    readonly description: string;
+    readonly tokenOverride?: TokenFixture & {
+      readonly constraints?: {
+        readonly maxVelocityMps?: number;
+        readonly maxForceNewtons?: number;
+      };
+    };
+    readonly request?: RequestTemplate & {
+      readonly resource: string;
+      readonly action: string;
+      readonly executionContext?: Record<string, unknown>;
+    };
+    readonly transportCheck?: {
+      readonly enclave: {
+        readonly enclavePath: string;
+        readonly domainId: number;
+        readonly allowPublish: readonly string[];
+        readonly allowSubscribe: readonly string[];
+        readonly denyPublish: readonly string[];
+        readonly denySubscribe: readonly string[];
+        readonly governanceEnforced: boolean;
+      };
+      readonly topicName: string;
+      readonly operation: "publish" | "subscribe";
+    };
+    readonly expected: {
+      readonly decisionAction: PhysicalAiDecisionAction;
+      readonly assignedTier?: ApprovalTier;
+      readonly policyViolated?: string;
+      readonly transportOutcome:
+        | "forwarded"
+        | "held_for_review"
+        | "publish_rejected"
+        | "discovery_rejected"
+        | "execution_rolled_back";
+      readonly transportDecision?: "allow" | "deny" | "not-covered";
+      readonly evidenceEventType?: string;
+      readonly evidence?: {
+        readonly decisionRefRequired?: boolean;
+        readonly actionIntentRefRequired?: boolean;
+        readonly hashChainRequired?: boolean;
+        readonly providerSpecificReceiptAllowed?: boolean;
+      };
     };
   }>;
 }
@@ -514,6 +592,12 @@ export function loadOpcUaSafetyControlFixture(): OpcUaSafetyControlFixture {
 export function loadHardwareSafetyHandshakeFixture(): HardwareSafetyHandshakeFixture {
   return loadFixture<HardwareSafetyHandshakeFixture>(
     "industrial/hardware-safety-handshake.v1.json",
+  );
+}
+
+export function loadPhysicalAiRuntimeSafetyFixture(): PhysicalAiRuntimeSafetyFixture {
+  return loadFixture<PhysicalAiRuntimeSafetyFixture>(
+    "physical-ai/runtime-safety-fixtures.v0.1.json",
   );
 }
 

--- a/packages/conformance-tests/src/physical-ai-runtime-safety-fixtures-conformance.test.ts
+++ b/packages/conformance-tests/src/physical-ai-runtime-safety-fixtures-conformance.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Physical AI Runtime Safety fixture conformance.
+ *
+ * Covers the v0.1 working-group fixture pack for pre-actuation policy checks,
+ * transport non-bypass, e-stop rollback semantics, and evidence vocabulary.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import type {
+  SintCapabilityToken,
+  SintCapabilityTokenRequest,
+  SintRequest,
+} from "@pshkv/core";
+import {
+  generateKeypair,
+  generateUUIDv7,
+  issueCapabilityToken,
+  nowISO8601,
+  RevocationStore,
+} from "@pshkv/gate-capability-tokens";
+import { PolicyGateway } from "@pshkv/gate-policy-gateway";
+import { checkSros2Permission } from "@pshkv/bridge-ros2";
+import { loadPhysicalAiRuntimeSafetyFixture } from "./fixture-loader.js";
+
+function futureISO(hoursFromNow: number): string {
+  const d = new Date(Date.now() + hoursFromNow * 3_600_000);
+  return d.toISOString().replace(/\.(\d{3})Z$/, ".$1000Z");
+}
+
+function replaceNowPlaceholder<T>(value: T): T {
+  return JSON.parse(
+    JSON.stringify(value).replace(/"__NOW__"/g, JSON.stringify(nowISO8601())),
+  ) as T;
+}
+
+describe("Physical AI runtime safety fixtures v0.1", () => {
+  const fixture = loadPhysicalAiRuntimeSafetyFixture();
+  const root = generateKeypair();
+  const agent = generateKeypair();
+  const revocationStore = new RevocationStore();
+
+  let tokenStore: Map<string, SintCapabilityToken>;
+  let gateway: PolicyGateway;
+  let events: Array<{ eventType: string; payload: Record<string, unknown> }>;
+
+  function issueFixtureToken(
+    tokenTemplate = fixture.defaultToken,
+  ): SintCapabilityToken {
+    const req: SintCapabilityTokenRequest = {
+      issuer: root.publicKey,
+      subject: agent.publicKey,
+      resource: tokenTemplate.resource,
+      actions: [...tokenTemplate.actions],
+      constraints: { ...(tokenTemplate.constraints ?? {}) },
+      delegationChain: { parentTokenId: null, depth: 0, attenuated: false },
+      expiresAt: futureISO(4),
+      revocable: true,
+    };
+    const issued = issueCapabilityToken(req, root.privateKey);
+    if (!issued.ok) {
+      throw new Error(`Fixture token issuance failed: ${issued.error}`);
+    }
+    tokenStore.set(issued.value.tokenId, issued.value);
+    return issued.value;
+  }
+
+  function semanticEventTypes(): string[] {
+    const types = new Set(events.map((event) => event.eventType));
+    for (const event of events) {
+      if (event.eventType !== "policy.evaluated") continue;
+      const decision = event.payload["decision"];
+      if (decision === "allow" || decision === "deny" || decision === "escalate") {
+        types.add(`policy.decision.${decision}`);
+      }
+    }
+    return [...types];
+  }
+
+  beforeEach(() => {
+    tokenStore = new Map();
+    events = [];
+    revocationStore.clear();
+    gateway = new PolicyGateway({
+      resolveToken: (tokenId) => tokenStore.get(tokenId),
+      revocationStore,
+      emitLedgerEvent: (event) => events.push(event as (typeof events)[number]),
+    });
+  });
+
+  it("declares a stable physical-AI interoperability profile", () => {
+    expect(fixture.fixtureId).toBe("physical-ai-runtime-safety-v0.1");
+    expect(fixture.profile.transport).toBe("ros2/sros2");
+    expect(fixture.profile.actionBoundary).toBe("pre-actuation");
+    expect(fixture.profile.decisionVocabulary).toEqual([
+      "allow",
+      "deny",
+      "escalate",
+      "rollback",
+    ]);
+    expect(fixture.profile.evidenceRequirements).toEqual({
+      decisionRefRequired: true,
+      actionIntentRefRequired: true,
+      hashChainRequired: true,
+    });
+
+    const ids = fixture.cases.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const c of fixture.cases) {
+      expect(fixture.profile.decisionVocabulary).toContain(c.expected.decisionAction);
+      expect(fixture.profile.transportOutcomes).toContain(c.expected.transportOutcome);
+    }
+  });
+
+  it.each(fixture.cases.filter((c) => c.transportCheck !== undefined))(
+    "enforces SROS2 transport non-bypass: $id",
+    (c) => {
+      const transportCheck = c.transportCheck;
+      expect(transportCheck).toBeDefined();
+      if (!transportCheck) return;
+
+      const decision = checkSros2Permission(
+        {
+          ...transportCheck.enclave,
+          allowPublish: [...transportCheck.enclave.allowPublish],
+          allowSubscribe: [...transportCheck.enclave.allowSubscribe],
+          denyPublish: [...transportCheck.enclave.denyPublish],
+          denySubscribe: [...transportCheck.enclave.denySubscribe],
+        },
+        transportCheck.topicName,
+        transportCheck.operation,
+      );
+
+      expect(decision).toBe(c.expected.transportDecision);
+      expect(c.expected.decisionAction).toBe("deny");
+      expect(c.expected.transportOutcome).toBe("publish_rejected");
+      expect(c.expected.evidenceEventType).toBe("transport.sros2.publish_rejected");
+    },
+  );
+
+  it.each(fixture.cases.filter((c) => c.request !== undefined))(
+    "matches gateway decision semantics: $id",
+    async (c) => {
+      const requestTemplate = c.request;
+      expect(requestTemplate).toBeDefined();
+      if (!requestTemplate) return;
+
+      const token = issueFixtureToken(c.tokenOverride ?? fixture.defaultToken);
+      const renderedRequest = replaceNowPlaceholder(requestTemplate);
+      const request: SintRequest = {
+        requestId: generateUUIDv7(),
+        timestamp: nowISO8601(),
+        agentId: agent.publicKey,
+        tokenId: token.tokenId,
+        resource: renderedRequest.resource,
+        action: renderedRequest.action,
+        params: renderedRequest.params ?? {},
+        physicalContext: renderedRequest.physicalContext,
+        recentActions: renderedRequest.recentActions,
+        executionContext: renderedRequest.executionContext,
+      };
+
+      const decision = await gateway.intercept(request);
+
+      if (c.expected.decisionAction === "rollback") {
+        expect(decision.action).toBe("deny");
+        expect(decision.denial?.policyViolated).toBe(c.expected.policyViolated);
+      } else {
+        expect(decision.action).toBe(c.expected.decisionAction);
+      }
+
+      if (c.expected.assignedTier) {
+        expect(decision.assignedTier).toBe(c.expected.assignedTier);
+      }
+      if (c.expected.policyViolated && c.expected.decisionAction !== "rollback") {
+        expect(decision.denial?.policyViolated).toBe(c.expected.policyViolated);
+      }
+      if (c.expected.evidenceEventType) {
+        expect(semanticEventTypes()).toContain(c.expected.evidenceEventType);
+      }
+
+      if (c.expected.evidence) {
+        expect(events.length).toBeGreaterThan(0);
+        expect(c.expected.evidence.decisionRefRequired).toBe(true);
+        expect(c.expected.evidence.actionIntentRefRequired).toBe(true);
+        expect(c.expected.evidence.hashChainRequired).toBe(true);
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- add a v0.1 Physical AI Runtime Safety fixture pack for ROS2/SROS2 pre-actuation checks
- cover held-for-review motion, token scope denial, human-presence T3 escalation, SROS2 non-bypass, e-stop rollback semantics, and receipt evidence requirements
- add a typed fixture loader and wire the new conformance test into test:fixtures

## Verification
- pnpm --filter @pshkv/conformance-tests test -- src/physical-ai-runtime-safety-fixtures-conformance.test.ts
- pnpm --filter @pshkv/conformance-tests run test:fixtures
- pnpm run build
- pnpm run test

Tracks #187