### PR TITLE
test(gateway): add production slice verification path

### DIFF
--- a/NEXT_PRIORITIES.md
+++ b/NEXT_PRIORITIES.md
@@ -48,6 +48,10 @@ Status in this checkout:
   `verifiableComputeRequirements`, `executionEnvelope`,
   and `revocationEndpoint`.
 - Regression tests now cover canonical payload stability and full token persistence.
+- `apps/gateway-server/__tests__/production-slice.test.ts` now covers the
+  minimal supported HTTP path:
+  token issuance, policy enforcement, ledger persistence, proof generation,
+  and revocation fail-closed behavior.
 
 ### 2. Production Slice Definition
 
@@ -108,7 +112,7 @@ That means Phase 3/4/6 work stays valuable, but it moves behind reliability and 
 
 - keep token canonicalization and persistence fixes merged and verified
 - fresh CI pass on `main`
-- add one end-to-end production-slice verification path
+- keep the end-to-end production-slice verification path green
 - confirm docs build and package build from clean checkout
 
 ### Sprint B

--- a/apps/gateway-server/__tests__/production-slice.test.ts
+++ b/apps/gateway-server/__tests__/production-slice.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Production-slice verification path.
+ *
+ * This is the smallest supported runtime story from NEXT_PRIORITIES.md:
+ * issue a capability token, enforce through the gateway HTTP API, persist
+ * the decision trail, prove the ledger chain, then revoke and fail closed.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ApprovalTier, type SintCapabilityToken } from "@pshkv/core";
+import {
+  generateKeypair,
+  generateUUIDv7,
+  nowISO8601,
+} from "@pshkv/gate-capability-tokens";
+import { createApp, createContext } from "../src/server.js";
+
+function futureISO(hoursFromNow: number): string {
+  const d = new Date(Date.now() + hoursFromNow * 3_600_000);
+  return d.toISOString().replace(/\.(\d{3})Z$/, ".$1000Z");
+}
+
+async function eventually<T>(
+  read: () => Promise<T>,
+  predicate: (value: T) => boolean,
+): Promise<T> {
+  let last = await read();
+  for (let i = 0; i < 20; i++) {
+    if (predicate(last)) return last;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    last = await read();
+  }
+  return last;
+}
+
+describe("Gateway production slice", () => {
+  it("issues, enforces, persists evidence, proves chain, and revokes via the supported HTTP surface", async () => {
+    const ctx = createContext();
+    const app = createApp(ctx);
+    const issuer = generateKeypair();
+    const agent = generateKeypair();
+
+    const tokenRequest = {
+      issuer: issuer.publicKey,
+      subject: agent.publicKey,
+      resource: "mcp://filesystem/*",
+      actions: ["call"],
+      constraints: {},
+      delegationChain: { parentTokenId: null, depth: 0, attenuated: false },
+      expiresAt: futureISO(4),
+      revocable: true,
+    };
+
+    const issueRes = await app.request("/v1/tokens", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        request: tokenRequest,
+        privateKey: issuer.privateKey,
+      }),
+    });
+    expect(issueRes.status).toBe(201);
+    const token = (await issueRes.json()) as SintCapabilityToken;
+
+    const storedToken = await ctx.tokenStore.get(token.tokenId);
+    expect(storedToken?.tokenId).toBe(token.tokenId);
+    expect(storedToken?.resource).toBe(tokenRequest.resource);
+
+    const interceptRes = await app.request("/v1/intercept", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        requestId: generateUUIDv7(),
+        timestamp: nowISO8601(),
+        agentId: agent.publicKey,
+        tokenId: token.tokenId,
+        resource: "mcp://filesystem/readFile",
+        action: "call",
+        params: { path: "/var/sint/readiness.json" },
+      }),
+    });
+    expect(interceptRes.status).toBe(200);
+    const decision = await interceptRes.json();
+    expect(decision.action).toBe("allow");
+    expect(decision.assignedTier).toBe(ApprovalTier.T0_OBSERVE);
+
+    const persistedPolicyEvents = await eventually(
+      () => ctx.ledgerStore.query({ eventType: "policy.evaluated" }),
+      (events) => events.length > 0,
+    );
+    expect(persistedPolicyEvents.length).toBeGreaterThan(0);
+    expect(persistedPolicyEvents[0]?.payload["decision"]).toBe("allow");
+    expect(await ctx.ledgerStore.verifyChain()).toBe(true);
+
+    const ledgerRes = await app.request("/v1/ledger?eventType=policy.evaluated");
+    expect(ledgerRes.status).toBe(200);
+    const ledgerBody = await ledgerRes.json();
+    expect(ledgerBody.chainIntegrity).toBe(true);
+    expect(ledgerBody.events.length).toBeGreaterThan(0);
+
+    const proofRes = await app.request(`/v1/ledger/${ledgerBody.events[0].eventId}/proof`);
+    expect(proofRes.status).toBe(200);
+    const proof = await proofRes.json();
+    expect(proof.eventId).toBe(ledgerBody.events[0].eventId);
+    expect(proof.proofValid).toBe(true);
+    expect(proof.verificationSteps.every((step: { valid: boolean }) => step.valid)).toBe(true);
+
+    const revokeRes = await app.request("/v1/tokens/revoke", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        tokenId: token.tokenId,
+        reason: "production-slice verification complete",
+        revokedBy: issuer.publicKey,
+      }),
+    });
+    expect(revokeRes.status).toBe(200);
+
+    const revokedInterceptRes = await app.request("/v1/intercept", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        requestId: generateUUIDv7(),
+        timestamp: nowISO8601(),
+        agentId: agent.publicKey,
+        tokenId: token.tokenId,
+        resource: "mcp://filesystem/readFile",
+        action: "call",
+        params: { path: "/var/sint/readiness.json" },
+      }),
+    });
+    expect(revokedInterceptRes.status).toBe(200);
+    const revokedDecision = await revokedInterceptRes.json();
+    expect(revokedDecision.action).toBe("deny");
+    expect(revokedDecision.denial.policyViolated).toBe("TOKEN_REVOKED");
+  });
+});

--- a/docs/guides/production-slice-verification.md
+++ b/docs/guides/production-slice-verification.md
@@ -1,0 +1,57 @@
+# Production Slice Verification
+
+This guide defines the smallest supported production-readiness path for SINT's
+first operator-facing surface. It intentionally avoids broad bridge coverage and
+focuses on the core path needed to make one deployment claim repeatable:
+
+1. Issue a capability token through the gateway HTTP API.
+2. Persist the issued token through the configured token store.
+3. Submit a request through `PolicyGateway.intercept()` via `/v1/intercept`.
+4. Record the policy decision in the append-only Evidence Ledger.
+5. Persist the ledger event through the configured ledger store.
+6. Return a chain-of-custody proof for the decision event.
+7. Revoke the token and verify the same request fails closed.
+
+The executable guard for this path is
+`apps/gateway-server/__tests__/production-slice.test.ts`.
+
+## Local Verification
+
+Run the production-slice gate directly:
+
+```bash
+pnpm --filter @pshkv/gateway-server test -- __tests__/production-slice.test.ts
+```
+
+Run the full gateway package checks:
+
+```bash
+pnpm --filter @pshkv/gateway-server test
+pnpm --filter @pshkv/gateway-server build
+```
+
+Run the workspace build gate:
+
+```bash
+pnpm run build
+```
+
+## Supported Surface
+
+The current production slice covers:
+
+- `apps/gateway-server`
+- `packages/capability-tokens`
+- `packages/policy-gateway`
+- `packages/evidence-ledger`
+- `packages/persistence`
+
+The test uses in-memory stores, but it asserts only the shared persistence
+interfaces: token lookup, ledger event query, and ledger chain verification.
+PostgreSQL adapters must preserve the same behavior for production deployments.
+
+## Out Of Scope
+
+This verification path does not certify every bridge, dashboard workflow,
+economy route, memory route, or external runtime integration. Those remain
+separate conformance and integration gates.


### PR DESCRIPTION
## Summary
- add a narrow gateway production-slice test for the roadmap's first supported surface
- verify HTTP token issuance, policy intercept, backing ledger persistence, proof generation, and revocation fail-closed behavior
- update NEXT_PRIORITIES.md so Sprint A tracks keeping this gate green

## Verification
- pnpm --filter @pshkv/gateway-server test -- __tests__/production-slice.test.ts
- pnpm --filter @pshkv/gateway-server test
- pnpm --filter @pshkv/gateway-server build
- pnpm run build