### PR TITLE
Remove temporary Node 24 action override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [main, master]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -10,9 +10,6 @@ on:
       - ".github/workflows/docs-site.yml"
   workflow_dispatch:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 permissions:
   contents: read
   pages: write

--- a/.github/workflows/industrial-benchmark-report.yml
+++ b/.github/workflows/industrial-benchmark-report.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
     branches: [main, master]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   generate-benchmark-report:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,9 +5,6 @@ on:
     tags:
       - 'v*.*.*'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 permissions:
   contents: read
   id-token: write  # Required for npm provenance (SLSA Level 2)

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -7,9 +7,6 @@ on:
     tags:
       - "v*"
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/runtime-change-guardrails.yml
+++ b/.github/workflows/runtime-change-guardrails.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches: [main, master]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   guardrails:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-bulletin-reminder.yml
+++ b/.github/workflows/security-bulletin-reminder.yml
@@ -5,9 +5,6 @@ on:
     - cron: "0 16 1 * *"
   workflow_dispatch:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 permissions:
   issues: write
 


### PR DESCRIPTION
## Summary
- remove the temporary FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 workflow override
- rely on the upgraded GitHub and pnpm actions directly
- verify the workflow stack stays clean without the fallback

## Validation
- ruby YAML parse for all workflows
- confirmed no remaining FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 references