### PR TITLE
Document upstream Pages deploy warning

### DIFF
--- a/docs/community/website-sync-checklist.md
+++ b/docs/community/website-sync-checklist.md
@@ -20,6 +20,9 @@ Important:
 - feature branches do not automatically deploy to `docs.sint.gg`
 - if a branch-triggered deploy is attempted, GitHub Pages environment rules may
   reject it
+- a successful `Deploy` step may still log a `punycode` deprecation warning
+  from upstream GitHub Pages action dependencies; treat that as non-blocking
+  unless the deploy itself fails
 
 ### `sint.gg`
 

--- a/docs/guides/developer-documentation-site.md
+++ b/docs/guides/developer-documentation-site.md
@@ -34,6 +34,16 @@ Branch deploy note:
 - GitHub Pages environment rules may reject deployments from non-`main` branches
 - if you need the public site updated, merge the docs change to `main`
 
+Runtime warning note:
+
+- if the `Deploy` step logs only a `punycode` deprecation warning and the job
+  still succeeds, treat it as a non-blocking upstream GitHub Pages action
+  warning rather than a docs build regression
+- current source of that warning is the `actions/deploy-pages` dependency chain
+  through `@actions/artifact -> @azure/core-http -> node-fetch@2 -> whatwg-url`
+- if the workflow starts failing or the warning surface changes, re-check the
+  latest `actions/deploy-pages` release before changing the site build
+
 ## Content Organization
 
 - Root docs landing page: `docs/index.md`


### PR DESCRIPTION
## Summary
- document the remaining non-blocking punycode warning in the docs deploy workflow
- note that the warning originates upstream in the GitHub Pages deploy action dependency chain
- clarify that successful deploys with only that warning should not be treated as docs regressions

## Validation
- pnpm run docs:build