### PR TITLE
Add factory action pack upgrade sprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@
 
 SINT is the missing governance layer between AI agents and the physical world. Every tool call, robot command, and actuator movement flows through a single Policy Gateway that enforces capability-based permissions, graduated approval tiers, and tamper-evident audit logging.
 
+The next upgrade lane is factory control. As prompt-to-hardware and
+prompt-to-factory tooling gets better at generating industrial plans, SINT is
+expanding toward the control layer that decides what can be simulated,
+approved, executed, audited, and settled before AI-generated factory actions
+touch real machines. See
+[`docs/roadmaps/factory-action-pack-upgrade-sprints.md`](docs/roadmaps/factory-action-pack-upgrade-sprints.md).
+
 > **Academic grounding:** SINT is designed with reference to IEC 62443 FR1–FR7, EU AI Act Article 13, and NIST AI RMF. The evaluation framework references the ROSClaw empirical safety study ([arXiv:2603.26997](https://arxiv.org/abs/2603.26997)) and MCP security analysis ([arXiv:2601.17549](https://arxiv.org/abs/2601.17549)).
 
 ```

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -95,6 +95,7 @@ export default defineConfig({
           { text: "End-of-Year 2026 Execution Plan", link: "/roadmaps/end-of-year-2026-execution-plan" },
           { text: "AAIF Resubmission 2026", link: "/roadmaps/aaif-resubmission-2026" },
           { text: "Ecosystem Outreach 2026", link: "/roadmaps/ecosystem-outreach-2026" },
+          { text: "Factory Action Pack Upgrade Sprints", link: "/roadmaps/factory-action-pack-upgrade-sprints" },
           { text: "Humanoid Robotics Integrations", link: "/roadmaps/humanoid-robotics-integrations-2026" },
           { text: "Post-Quantum Crypto Agility", link: "/roadmaps/post-quantum-crypto-agility" },
           { text: "Physical AI Governance", link: "/roadmaps/PHYSICAL_AI_GOVERNANCE_2026-2029" },

--- a/docs/community/lovable-sint-gg-refresh-prompt.md
+++ b/docs/community/lovable-sint-gg-refresh-prompt.md
@@ -37,6 +37,7 @@ Source of truth for content:
 - docs/protocol.md
 - docs/roadmap.md
 - docs/roadmaps/end-of-year-2026-execution-plan.md
+- docs/roadmaps/factory-action-pack-upgrade-sprints.md
 - docs/community/website-sync-checklist.md
 - docs/guides/gateway-production-hardening.md
 - docs/guides/production-slice-verification.md
@@ -100,6 +101,9 @@ Section: Production direction
   - cleaner release gates
   - external collaboration
   - maintainership credibility
+- Add one compact note that SINT is also expanding toward prompt-generated
+  factory control, where simulation proof and approval sit between generated
+  industrial plans and execution.
 
 Section: Footer CTA
 - Invite readers to explore docs, roadmap, and GitHub.
@@ -153,6 +157,8 @@ Section: Q4 2026
   - 2 to 3 meaningful deployment or pilot signals if outreach lands
   - evidence-backed AAIF resubmission packet
   - cleaner examples and templates
+  - a factory-control upgrade track that reads like a real sprint sequence, not
+    a hand-wavy future plan
 
 Section: End-of-year scorecard
 - Show 5 simple year-end checks:

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -81,6 +81,44 @@ is tightening the surfaces that matter:
 - security and OpenSSF hygiene
 - collaborator-facing fixtures that let other projects critique the boundary
 
+## Factory Action Pack Direction
+
+The next industrial upgrade for SINT is not "support more vendors" in the
+abstract.
+
+It is to become the control layer between AI-generated factory plans and
+real-world execution.
+
+As tools like [iOrchestra](https://iorchestra.ai/),
+[Siemens Industrial Copilot](https://www.siemens.com/en-us/company/insights/generative-ai-industrial-copilot/),
+[ABB RobotStudio AI Assistant](https://www.abb.com/global/en/areas/robotics/products/software/robotstudio-suite/robotstudio-ai-assistant),
+and [Rockwell Emulate3D](https://www.rockwellautomation.com/en-us/products/software/factorytalk/designsuite/emulate3d-digital-twin.html)
+make prompt-generated industrial engineering more real, the missing layer shifts
+from creation to control.
+
+SINT should own the questions that matter once a generated plan gets close to a
+real floor:
+
+- who is allowed to run it
+- what machine or controller can execute it
+- what simulation proof is required
+- what safety envelope applies
+- what human approval is required
+- what receipt gets written after execution or refusal
+
+The planned factory-control primitives are:
+
+- `FactoryIntent`
+- `CellGraph`
+- `RobotActionProfile`
+- `SimulationReceipt`
+- industrial policy packs
+- settlement metadata for reusable industrial skills and adapters
+
+The active roadmap for that lane lives here:
+
+- [Factory Action Pack Upgrade Sprints](./roadmaps/factory-action-pack-upgrade-sprints.md)
+
 ## Where To Start
 
 - [Getting Started](./getting-started.md)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,7 +27,7 @@ The near-term goal is to finish tightening the core:
 - [x] OpenSSF baseline tracker and dependency review lane
 - [x] external contributor onboarding and scorecard workflows
 - [x] robotics collaboration fixture pack
-- [ ] merge the current production-readiness branch
+- [x] merge the current production-readiness branch
 - [ ] keep docs, README, and public protocol copy aligned
 
 ## Q3 2026
@@ -44,6 +44,8 @@ environment.
 - [ ] named adopter or pilot evidence improves beyond the immediate co-design
   cluster
 - [ ] highest-priority OpenSSF and dependency-review gaps are materially reduced
+- [ ] Sprint 1 of the Factory Action Pack lands as a control-standard pack for
+  prompt-generated industrial automation
 
 ## Q4 2026
 
@@ -55,12 +57,15 @@ Q4 is about packaging the protocol so the story is stronger than the pitch.
   reuse
 - [ ] 2-3 external deployment or pilot signals exist if the outreach lanes land
 - [ ] AAIF resubmission packet can be assembled from shipped evidence only
+- [ ] factory-control demo proves simulation-first execution and human approval
+  before robot or PLC actions
 
 ## Through December 2026
 
 For the fuller execution plan, use:
 
 - [End-of-Year 2026 Execution Plan](./roadmaps/end-of-year-2026-execution-plan.md)
+- [Factory Action Pack Upgrade Sprints](./roadmaps/factory-action-pack-upgrade-sprints.md)
 
 ## Detailed Tracks
 
@@ -68,6 +73,7 @@ For the fuller execution plan, use:
 - [Legacy phase plan](./roadmap-phases-legacy.md)
 - [Ecosystem outreach 2026](./roadmaps/ecosystem-outreach-2026.md)
 - [AAIF resubmission 2026](./roadmaps/aaif-resubmission-2026.md)
+- [Factory Action Pack upgrade sprints](./roadmaps/factory-action-pack-upgrade-sprints.md)
 - [Humanoid robotics integrations 2026](./roadmaps/humanoid-robotics-integrations-2026.md)
 - [Post-quantum crypto agility](./roadmaps/post-quantum-crypto-agility.md)
 

--- a/docs/roadmaps/end-of-year-2026-execution-plan.md
+++ b/docs/roadmaps/end-of-year-2026-execution-plan.md
@@ -59,6 +59,30 @@ The strongest Q3 collaboration lanes are:
 - PX4 offboard boundary
 - solar field robot motion boundary
 
+### Factory Control Upgrade
+
+Q3 should also start the factory-control track explicitly.
+
+The thesis is that AI-generated factory plans are getting easier to produce,
+while safe execution remains fragmented across simulation tools, PLC stacks,
+robot vendors, approval workflows, and audit systems.
+
+The goal for SINT is not to become another industrial design copilot. The goal
+is to become the control layer between generated industrial intent and real
+execution.
+
+Planned sprint sequence:
+
+- Sprint 1: factory intent, cell graph, robot action, simulation receipt, and
+  industrial policy standard pack
+- Sprint 2: simulation-first factory demo with refusal, approval, and receipt
+  chain
+- Sprint 3: industrial adapter and simulator pack for multi-vendor execution
+
+Reference plan:
+
+- [Factory Action Pack Upgrade Sprints](./factory-action-pack-upgrade-sprints.md)
+
 ## Q4 2026 — Package It For Reuse
 
 ### Protocol Surface
@@ -66,6 +90,8 @@ The strongest Q3 collaboration lanes are:
 - cut a cleaner release candidate path for the reference gateway and SDKs
 - keep protocol, conformance, and deployment docs in sync
 - publish deployment and adapter examples that are small enough to copy
+- keep the factory-control story tied to shipped control surfaces, not vague
+  industrial ambition
 
 ### Ecosystem and Governance
 
@@ -81,6 +107,7 @@ By Q4, `sint.gg/protocol` and `sint.gg/roadmap` should describe:
 - what is being hardened right now
 - what will be finished by year-end
 - where collaborators can plug in
+- how SINT fits between AI-generated factory plans and real industrial execution
 
 ## What Not To Do
 
@@ -105,3 +132,4 @@ Use this simple year-end check:
 - OpenSSF gaps are materially reduced
 - at least one external project has engaged on a concrete fixture or adapter
 - public roadmap and protocol pages no longer read like placeholders
+- the factory-control upgrade track is legible as a real execution plan

--- a/docs/roadmaps/factory-action-pack-upgrade-sprints.md
+++ b/docs/roadmaps/factory-action-pack-upgrade-sprints.md
@@ -1,0 +1,287 @@
+# Factory Action Pack Upgrade Sprints
+
+This roadmap turns the recent industrial research into a concrete upgrade track
+for SINT.
+
+The key shift is simple: prompt-to-hardware and prompt-to-factory tooling is
+getting better at generation. The missing layer is still control.
+
+SINT should not try to out-compete design copilots on schematic generation,
+offline programming, or factory layout authoring. It should become the control,
+simulation, approval, audit, and settlement layer between AI-generated factory
+plans and real execution.
+
+## Research Verdict
+
+The strongest public signal is that natural-language industrial engineering is
+already arriving from multiple directions:
+
+- [iOrchestra](https://iorchestra.ai/) is positioning around prompt-to-hardware
+  and prompt-to-production documentation
+- [Siemens Industrial Copilot](https://www.siemens.com/en-us/company/insights/generative-ai-industrial-copilot/)
+  is pushing natural-language automation engineering and multi-vendor robot
+  integration
+- [ABB RobotStudio AI Assistant](https://www.abb.com/global/en/areas/robotics/products/software/robotstudio-suite/robotstudio-ai-assistant)
+  and HyperReality are leaning into AI-assisted programming and simulation
+- [Rockwell Emulate3D](https://www.rockwellautomation.com/en-us/products/software/factorytalk/designsuite/emulate3d-digital-twin.html)
+  is pushing digital twins and virtual commissioning
+- [SRCI](https://www.profibus.com/technologies/robotics-srci-standard-robot-command-interface)
+  shows the cross-vendor robot-control trend is real
+- [OPC UA](https://opcfoundation.org/) remains the vendor-neutral industrial
+  data backbone
+- [EU AI Act Article 14](https://ai-act-service-desk.ec.europa.eu/en/ai-act/article-14)
+  keeps human oversight and override in scope for high-risk systems
+
+The conclusion for SINT is larger than "support more robots."
+
+```text
+iOrchestra and industrial copilots: generate the factory plan
+SINT: authorize, simulate, approve, execute, audit, and settle the factory action
+```
+
+## Category And Positioning
+
+Category:
+
+- Agentic Industrial Control Protocol
+
+Working one-liner:
+
+- prompt-generated factories need a control layer before they touch machines
+
+Founder-facing line:
+
+- the next factory will be generated from intent; SINT makes that safe enough
+  to run
+
+## Core Upgrade Surface
+
+The factory-control lane should add six protocol primitives on top of the
+existing gateway, token, tier, and evidence model.
+
+### 1. Factory Intent
+
+Structured intent turns "build me a packaging line" into auditable planning
+input.
+
+Planned object:
+
+- `FactoryIntent`
+- goal, industry, materials, stations, throughput, capex, floor-space,
+  collaboration, and safety-standard targets
+
+### 2. Cell Graph
+
+A canonical production-cell graph lets SINT reason about assets, flows,
+approval tiers, and safety boundaries.
+
+Planned object:
+
+- `CellGraph`
+- assets, vendor/controller metadata, adapters, safety zones, and material
+  flows
+
+### 3. Robot Action Profile
+
+SINT needs one action language that adapters can translate into RAPID, KRL,
+TP/LS, URScript, ROS 2, SRCI, or PLC logic.
+
+Planned object:
+
+- `RobotActionProfile`
+- motion, tool, force, velocity, collision, approval, and zone-clearance
+  requirements
+
+### 4. Simulation Receipt
+
+Real-world execution should require simulation proof whenever the action
+crosses into meaningful physical risk.
+
+Planned object:
+
+- `SimulationReceipt`
+- simulator identity, program hash, collision status, cycle time, safety-zone
+  violations, force envelope, and execution-readiness signature
+
+### 5. Industrial Policy Engine
+
+The existing `PolicyGateway` needs factory-grade rules layered on top of the
+current tier and constraint model.
+
+Examples:
+
+- deny if human detected in zone
+- deny if simulation receipt missing
+- deny if motion exceeds approved velocity or force envelope
+- require human approval for motion, weld, cut, lift, or dispense
+- require lockout-tagout when maintenance mode is active
+
+### 6. Factory Settlement
+
+If SINT is going to host reusable industrial skills, adapters, policies, and
+simulation templates, it should also model how those contributors get paid.
+
+Planned object:
+
+- `FactorySettlement`
+- workcell ID, contributor shares, payment method, and settlement network
+
+## Upgrade Architecture
+
+```text
+Prompt
+  -> FactoryIntent compiler
+  -> CellGraph + asset manifest
+  -> simulation gateway
+  -> PolicyGateway
+  -> human approval / override
+  -> vendor adapter
+  -> PLC / robot / digital twin / MES
+  -> execution receipt
+  -> EvidenceLedger + settlement
+```
+
+## Sprint Plan
+
+### Sprint 1. Control Standard Pack
+
+Target:
+
+- next 14 days
+
+Status:
+
+- planned
+
+Goal:
+
+- ship the factory-control standard before chasing hardware claims
+
+Deliverables:
+
+- `docs/specs/sint-industrial-action-profile.md`
+- `docs/specs/factory-intent.schema.json`
+- `docs/specs/cell-graph.schema.json`
+- `docs/specs/robot-action.schema.json`
+- `docs/specs/simulation-receipt.schema.json`
+- `docs/specs/industrial-policy.yaml`
+- one repo demo narrative covering prompt to cell plan, simulation-required
+  refusal, human approval, and signed refusal or execution receipt
+
+Exit criteria:
+
+- prompt-generated factory intent compiles into structured planning objects
+- the default path fail-closes without simulation proof
+- the demo shows refusal first, then controlled approval
+
+### Sprint 2. Simulation-First Factory Demo
+
+Target:
+
+- next 30 days
+
+Status:
+
+- planned
+
+Goal:
+
+- prove the control loop in simulation before touching real industrial
+  execution
+
+Deliverables:
+
+- ROS 2 adapter upgraded to speak the factory action profile
+- Universal Robots ROS 2 demo path
+- ABB RAPID export stub
+- FANUC LS/TP export stub
+- SRCI command-profile mapping
+- Isaac Sim, RoboDK, or Visual Components simulation receipt stub
+- approval dashboard flow for industrial execution requests
+- receipt-chain demo across plan, simulation, approval, and execution
+
+Exit criteria:
+
+- SINT refuses execution when simulation proof is missing
+- after simulation passes, SINT still requires tier-appropriate approval
+- the same action profile can fan out into at least two vendor execution stubs
+
+### Sprint 3. Industrial Pack
+
+Target:
+
+- next 60 to 90 days
+
+Status:
+
+- planned
+
+Goal:
+
+- package SINT as a real industrial control surface, not just a robotics demo
+
+Deliverables:
+
+- `/sint-industrial/schemas`
+- `/sint-industrial/policies`
+- `/sint-industrial/adapters/ros2`
+- `/sint-industrial/adapters/srci`
+- `/sint-industrial/adapters/opcua`
+- `/sint-industrial/adapters/mqtt`
+- `/sint-industrial/adapters/modbus`
+- `/sint-industrial/adapters/abb-rapid`
+- `/sint-industrial/adapters/kuka-krl`
+- `/sint-industrial/adapters/fanuc-ls`
+- `/sint-industrial/adapters/ur-script`
+- `/sint-industrial/adapters/beckhoff-twincat`
+- `/sint-industrial/adapters/rockwell-factorytalk`
+- `/sint-industrial/simulators/isaac-sim`
+- `/sint-industrial/simulators/robodk`
+- `/sint-industrial/simulators/robotstudio`
+- `/sint-industrial/simulators/roboguide`
+- `/sint-industrial/simulators/kuka-sim`
+- `/sint-industrial/simulators/emulate3d`
+- example cells for pick-place, inspection, palletizing, and hybrid workflows
+
+Exit criteria:
+
+- SINT can express one shared factory-control surface across at least three
+  industrial execution paths
+- simulation receipts, approvals, and audit receipts stay first-class across
+  all examples
+- the story is clear enough that a collaborator can plug in a real vendor API
+  without changing SINT's governance model
+
+## Adapter Priorities
+
+The first vendor surfaces worth targeting are the ones that already sit near
+multi-vendor industrial workflows:
+
+- Siemens TIA Portal, SIMATIC robot integration, and SRCI
+- ABB RobotStudio and RAPID
+- KUKA.Sim and KRL
+- Rockwell FactoryTalk and Emulate3D
+- Beckhoff TwinCAT and EtherCAT
+- FANUC ROBOGUIDE and LS/TP export
+- Universal Robots PolyScope, URScript, ROS 2, and SRCI
+
+## What Not To Do
+
+Do not position SINT as another robot-programming suite.
+
+That would put the project directly against vendor engineering environments and
+offline programming tools.
+
+The strategic wedge is narrower and stronger:
+
+- SINT is the layer between AI-generated industrial automation and real-world
+  execution
+- SINT is where permission, simulation proof, human approval, audit, and
+  settlement become mandatory
+
+## Short Version
+
+If this lane works, the message becomes very simple:
+
+SINT Protocol is the control, safety, and settlement layer for AI-generated
+factories.


### PR DESCRIPTION
## Summary
- add a dedicated factory action pack sprint roadmap based on the recent industrial research
- thread the factory-control lane into the protocol page, active roadmap, end-of-year plan, and site-refresh prompt
- align the README with the new factory-control direction

## Validation
- pnpm run docs:build