### PR TITLE
Add explicit priority stack to roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,6 +17,86 @@ The current repo already includes:
 - collaborator-facing physical AI fixtures for Open-RMF, MoveIt, Nav2, PX4,
   LeRobot, and solar field operations
 - public onboarding and contribution docs for external collaborators
+- one real external security-readiness contribution cycle through bug bounty
+  planning and review
+
+## Current Priority Order
+
+As of May 2026, the repo should optimize for this order:
+
+1. close the trust and evidence gaps that block serious adoption
+2. turn external contributor signal into sustained maintainer signal
+3. ship Sprint 1 of the Factory Action Pack as a control standard, not a
+   marketing promise
+4. convert one collaborator lane into a shared external artifact or adapter
+5. refresh public site copy only after the shipped story is sharper
+
+### Priority 1. Trust And Evidence
+
+These items matter most because they improve submission quality, production
+credibility, and external trust at the same time.
+
+- issue [#192](https://github.com/sint-ai/sint-protocol/issues/192):
+  verify `SECURITY.md` disclosure path and response SLA
+- issue [#193](https://github.com/sint-ai/sint-protocol/issues/193):
+  publish external production-slice validation artifact
+- issue [#195](https://github.com/sint-ai/sint-protocol/issues/195):
+  run the first tagged RC checklist with evidence links
+- closed issue [#72](https://github.com/sint-ai/sint-protocol/issues/72) and
+  merged PR
+  [#196](https://github.com/sint-ai/sint-protocol/pull/196):
+  keep the bug bounty launch path concrete and non-binding until funded
+
+### Priority 2. External Maintainer Signal
+
+The strongest recent message in the repo is not another self-authored plan. It
+is outside participation.
+
+That means the next maintainer priority is:
+
+- keep Peter Xing's contribution cycle warm after PR
+  [#196](https://github.com/sint-ai/sint-protocol/pull/196)
+- look for one follow-up task that can become a second independent PR
+- keep the maintainer scorecard and onboarding path current
+- fix issue [#165](https://github.com/sint-ai/sint-protocol/issues/165) because
+  it is another clean external-facing paper cut
+
+### Priority 3. Factory Action Pack Sprint 1
+
+This is the right product-expansion lane, but it should ship as a control
+standard pack first.
+
+Use:
+
+- [Factory Action Pack Upgrade Sprints](./roadmaps/factory-action-pack-upgrade-sprints.md)
+- issue [#202](https://github.com/sint-ai/sint-protocol/issues/202)
+
+The immediate Sprint 1 target is:
+
+- industrial action profile spec
+- `FactoryIntent` schema
+- `CellGraph` schema
+- robot action schema
+- simulation receipt schema
+- industrial policy pack
+- one refusal-first demo narrative
+
+### Priority 4. External Artifact Conversion
+
+The collaborator fixtures are valuable, but the next proof point is shared work
+with another project, not just more internal fixture coverage.
+
+Best conversion targets:
+
+- Open-RMF handoff receipts
+- Sunnybotics ROS 2 integration questions
+- one industrial or factory-control design thread
+
+### Priority 5. Public Story Sync
+
+`sint.gg/protocol` and `sint.gg/roadmap` should be refreshed after the above
+lanes move, because the best copy update is the one that reflects shipped
+control surfaces and real outside signal.
 
 ## Through June 2026
 

--- a/docs/roadmaps/end-of-year-2026-execution-plan.md
+++ b/docs/roadmaps/end-of-year-2026-execution-plan.md
@@ -17,6 +17,28 @@ By the end of 2026, SINT should be able to show:
 4. sustained independent maintainership evidence
 5. a cleaner protocol story across docs, repo, and public site
 
+## Next 30 Days
+
+The immediate order matters more than the total number of open ideas.
+
+For the next 30 days, prioritize:
+
+1. evidence and trust gaps that directly affect adoption credibility
+2. external contributor retention and maintainer-signal compounding
+3. Factory Action Pack Sprint 1 as the next protocol-standard upgrade
+4. one shared external artifact from an existing collaborator lane
+5. public site sync after the shipped story improves
+
+In practice, that means:
+
+- close OpenSSF evidence work that still points to missing proof rather than
+  missing words
+- convert the bug bounty planning contribution into a repeatable security lane
+- start the factory-control pack with schemas, policy, and simulation-proof
+  structure
+- avoid broad new workstreams that do not improve trust, production evidence,
+  or outside signal
+
 ## Q2 2026 — Tighten The Core
 
 ### Finish and Merge

--- a/docs/roadmaps/factory-action-pack-upgrade-sprints.md
+++ b/docs/roadmaps/factory-action-pack-upgrade-sprints.md
@@ -152,6 +152,8 @@ Target:
 Status:
 
 - planned
+- tracking issue:
+  [#202](https://github.com/sint-ai/sint-protocol/issues/202)
 
 Goal:
 


### PR DESCRIPTION
## Summary
- add an explicit current priority order to the active roadmap
- add a next-30-days execution order to the end-of-year plan
- link the new Factory Action Pack Sprint 1 tracking issue into the roadmap docs

## Live repo signal folded into this pass
- PR #196 was merged as a real external security-readiness contribution
- issue #72 is now closed
- issue #202 tracks Factory Action Pack Sprint 1

## Validation
- pnpm run docs:build