### PR TITLE
Ship Factory Action Pack Sprint 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ expanding toward the control layer that decides what can be simulated,
 approved, executed, audited, and settled before AI-generated factory actions
 touch real machines. See
 [`docs/roadmaps/factory-action-pack-upgrade-sprints.md`](docs/roadmaps/factory-action-pack-upgrade-sprints.md).
+Sprint 1 now ships a control-standard pack with an industrial action profile,
+factory intent and cell graph schemas, a robot action schema, a simulation
+receipt schema, an industrial policy pack, and a refusal-first demo narrative.
 
 > **Academic grounding:** SINT is designed with reference to IEC 62443 FR1–FR7, EU AI Act Article 13, and NIST AI RMF. The evaluation framework references the ROSClaw empirical safety study ([arXiv:2603.26997](https://arxiv.org/abs/2603.26997)) and MCP security analysis ([arXiv:2601.17549](https://arxiv.org/abs/2601.17549)).
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -49,6 +49,7 @@ export default defineConfig({
           { text: "EU AI Act Conformity Pack", link: "/guides/eu-ai-act-conformity-pack" },
           { text: "Multi-Vendor Fleet Governance", link: "/guides/multivendor-fleet-governance" },
           { text: "Industrial Cell Safety Pack", link: "/guides/industrial-cell-safety-pack" },
+          { text: "Factory Action Pack Demo", link: "/guides/factory-action-pack-demo" },
           { text: "Regulated Consent Extensions", link: "/guides/regulated-consent-extensions" },
           { text: "Open-RMF Handoff Policy Receipts", link: "/guides/open-rmf-handoff-policy-receipts" },
           { text: "MoveIt Manipulation Policy Receipts", link: "/guides/moveit-manipulation-policy-receipts" },

--- a/docs/guides/factory-action-pack-demo.md
+++ b/docs/guides/factory-action-pack-demo.md
@@ -1,0 +1,227 @@
+# Factory Action Pack Demo
+
+This guide is the refusal-first demo narrative for Sprint 1 of the Factory
+Action Pack.
+
+The purpose is not to claim live industrial execution. The purpose is to show
+the control boundary clearly:
+
+```text
+prompt -> structured factory plan -> simulation required -> human approval -> signed receipt
+```
+
+## Demo Goal
+
+Show that SINT behaves like a control layer for AI-generated factory actions.
+
+In this first pack, the most important proof is refusal:
+
+- the factory plan is generated
+- the action profile is structured
+- execution is blocked when simulation proof is missing
+- after simulation proof exists, approval is still required
+- the final outcome is receipt-backed
+
+## Prompt
+
+```text
+Create a robotic inspection and palletizing line for 60 boxes per minute using
+ABB or FANUC robots, a Siemens PLC, and human-safe collaborative zones.
+```
+
+## Step 1. Compile The Intent
+
+The prompt compiles into a `FactoryIntent` object:
+
+```json
+{
+  "intent_id": "fi_packaging_001",
+  "goal": "Build a robotic inspection and palletizing line for 60 boxes per minute",
+  "industry": "consumer_goods",
+  "materials": ["corrugated_box"],
+  "stations": ["inspection", "palletize", "outfeed"],
+  "constraints": {
+    "max_capex_usd": 500000,
+    "floor_space_m2": 80,
+    "takt_time_seconds": 1,
+    "human_collaboration": true,
+    "safety_standard_targets": ["ISO_10218", "ISO_TS_15066", "IEC_62443"]
+  }
+}
+```
+
+Reference:
+
+- [Factory Intent Schema](../specs/factory-intent.schema.json)
+
+## Step 2. Build The Cell Graph
+
+That intent turns into a `CellGraph`:
+
+```json
+{
+  "cell_id": "packaging_cell_001",
+  "assets": [
+    {
+      "asset_id": "robot_abb_irb_1200_01",
+      "type": "robot_arm",
+      "vendor": "ABB",
+      "controller": "OmniCore",
+      "adapter": "sint-adapter-abb-rapid",
+      "safety_zone": "zone_A"
+    },
+    {
+      "asset_id": "plc_siemens_1500_01",
+      "type": "plc",
+      "vendor": "Siemens",
+      "controller": "S7-1500",
+      "adapter": "sint-adapter-siemens-tia-srci"
+    }
+  ],
+  "flows": [
+    {
+      "from": "inspection",
+      "to": "palletize",
+      "material": "corrugated_box",
+      "rate_per_minute": 60
+    }
+  ],
+  "approval_tier": "T3_HUMAN_REQUIRED",
+  "simulation_required": true
+}
+```
+
+Reference:
+
+- [Cell Graph Schema](../specs/cell-graph.schema.json)
+
+## Step 3. Request Robot Action
+
+The first real action becomes a `RobotActionProfile`:
+
+```json
+{
+  "action_type": "robot.motion.pick_and_place",
+  "target_robot": "robot_abb_irb_1200_01",
+  "motion": {
+    "source_pose": "inspection_conveyor_exit",
+    "target_pose": "pallet_station_A",
+    "max_velocity_mps": 0.25,
+    "max_force_newtons": 80,
+    "collision_check": true
+  },
+  "tool": {
+    "type": "vacuum_gripper",
+    "payload_kg": 2.4
+  },
+  "requires": {
+    "simulation_receipt": true,
+    "human_approval": true,
+    "safety_zone_clear": true
+  }
+}
+```
+
+Reference:
+
+- [Robot Action Schema](../specs/robot-action.schema.json)
+
+## Step 4. Refuse Without Simulation
+
+The correct first outcome is denial or escalation, not motion.
+
+Expected reasoning:
+
+- the action crosses into `T2_act` or `T3_commit`
+- `simulation_receipt_present == false`
+- industrial policy blocks execution
+
+Illustrative decision:
+
+```json
+{
+  "action": "deny",
+  "assignedTier": "T3_commit",
+  "denial": {
+    "reason": "SIMULATION_RECEIPT_MISSING",
+    "policyViolated": "sint.factory.robot.motion.v1"
+  }
+}
+```
+
+Reference:
+
+- [Industrial Policy Pack](../specs/industrial-policy.yaml)
+
+## Step 5. Attach Simulation Proof
+
+After a valid simulator run, the action can carry a `SimulationReceipt`:
+
+```json
+{
+  "simulation_receipt_id": "simr_packaging_001",
+  "cell_id": "packaging_cell_001",
+  "simulator": "RobotStudio",
+  "vendor_program_hash": "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+  "collision_free": true,
+  "cycle_time_seconds": 2.4,
+  "safety_zone_violations": 0,
+  "max_force_newtons": 62,
+  "approved_for_execution": false,
+  "signed_by": "sint-simulation-gateway"
+}
+```
+
+Reference:
+
+- [Simulation Receipt Schema](../specs/simulation-receipt.schema.json)
+
+## Step 6. Require Approval Before Execution
+
+Simulation proof should not silently imply execution permission.
+
+The next correct state is escalation:
+
+```json
+{
+  "action": "escalate",
+  "assignedTier": "T3_commit",
+  "escalation": {
+    "requiredTier": "T3_commit",
+    "timeoutMs": 300000
+  }
+}
+```
+
+Only after approval does the action proceed to an execution receipt.
+
+## Step 7. Emit A Signed Outcome
+
+The useful story is that SINT can explain all three outcomes:
+
+- refused because simulation proof was missing
+- escalated because physical execution required approval
+- allowed with a receipt after simulation and approval requirements were met
+
+That is a stronger industrial story than "we support robots."
+
+## Files In This Demo Pack
+
+- [Industrial Action Profile](../specs/sint-industrial-action-profile.md)
+- [Factory Intent Schema](../specs/factory-intent.schema.json)
+- [Cell Graph Schema](../specs/cell-graph.schema.json)
+- [Robot Action Schema](../specs/robot-action.schema.json)
+- [Simulation Receipt Schema](../specs/simulation-receipt.schema.json)
+- [Industrial Policy Pack](../specs/industrial-policy.yaml)
+
+## What This Demo Is
+
+- a control-standard pack
+- a refusal-first execution story
+- a clear explanation of where simulation proof and approval fit
+
+## What This Demo Is Not
+
+- a live Siemens, ABB, FANUC, or UR adapter
+- a claim of certified industrial deployment
+- a replacement for safety PLCs, vendor engineering tools, or assessors

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -115,6 +115,16 @@ The planned factory-control primitives are:
 - industrial policy packs
 - settlement metadata for reusable industrial skills and adapters
 
+The first shipped factory-control pack now includes:
+
+- [Industrial Action Profile](./specs/sint-industrial-action-profile.md)
+- [Factory Intent Schema](./specs/factory-intent.schema.json)
+- [Cell Graph Schema](./specs/cell-graph.schema.json)
+- [Robot Action Schema](./specs/robot-action.schema.json)
+- [Simulation Receipt Schema](./specs/simulation-receipt.schema.json)
+- [Industrial Policy Pack](./specs/industrial-policy.yaml)
+- [Factory Action Pack Demo](./guides/factory-action-pack-demo.md)
+
 The active roadmap for that lane lives here:
 
 - [Factory Action Pack Upgrade Sprints](./roadmaps/factory-action-pack-upgrade-sprints.md)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -124,7 +124,7 @@ environment.
 - [ ] named adopter or pilot evidence improves beyond the immediate co-design
   cluster
 - [ ] highest-priority OpenSSF and dependency-review gaps are materially reduced
-- [ ] Sprint 1 of the Factory Action Pack lands as a control-standard pack for
+- [x] Sprint 1 of the Factory Action Pack lands as a control-standard pack for
   prompt-generated industrial automation
 
 ## Q4 2026

--- a/docs/roadmaps/end-of-year-2026-execution-plan.md
+++ b/docs/roadmaps/end-of-year-2026-execution-plan.md
@@ -34,8 +34,8 @@ In practice, that means:
 - close OpenSSF evidence work that still points to missing proof rather than
   missing words
 - convert the bug bounty planning contribution into a repeatable security lane
-- start the factory-control pack with schemas, policy, and simulation-proof
-  structure
+- move from the factory-control standard pack into the simulation-first demo
+  lane and adapter stubs
 - avoid broad new workstreams that do not improve trust, production evidence,
   or outside signal
 

--- a/docs/roadmaps/factory-action-pack-upgrade-sprints.md
+++ b/docs/roadmaps/factory-action-pack-upgrade-sprints.md
@@ -151,7 +151,7 @@ Target:
 
 Status:
 
-- planned
+- completed
 - tracking issue:
   [#202](https://github.com/sint-ai/sint-protocol/issues/202)
 
@@ -161,20 +161,31 @@ Goal:
 
 Deliverables:
 
-- `docs/specs/sint-industrial-action-profile.md`
-- `docs/specs/factory-intent.schema.json`
-- `docs/specs/cell-graph.schema.json`
-- `docs/specs/robot-action.schema.json`
-- `docs/specs/simulation-receipt.schema.json`
-- `docs/specs/industrial-policy.yaml`
-- one repo demo narrative covering prompt to cell plan, simulation-required
-  refusal, human approval, and signed refusal or execution receipt
+- `docs/specs/sint-industrial-action-profile.md` (shipped)
+- `docs/specs/factory-intent.schema.json` (shipped)
+- `docs/specs/cell-graph.schema.json` (shipped)
+- `docs/specs/robot-action.schema.json` (shipped)
+- `docs/specs/simulation-receipt.schema.json` (shipped)
+- `docs/specs/industrial-policy.yaml` (shipped)
+- `docs/guides/factory-action-pack-demo.md` with prompt to cell plan,
+  simulation-required refusal, human approval, and signed receipt path
+  (shipped)
 
 Exit criteria:
 
 - prompt-generated factory intent compiles into structured planning objects
 - the default path fail-closes without simulation proof
 - the demo shows refusal first, then controlled approval
+
+Artifact links:
+
+- [Industrial Action Profile](../specs/sint-industrial-action-profile.md)
+- [Factory Intent Schema](../specs/factory-intent.schema.json)
+- [Cell Graph Schema](../specs/cell-graph.schema.json)
+- [Robot Action Schema](../specs/robot-action.schema.json)
+- [Simulation Receipt Schema](../specs/simulation-receipt.schema.json)
+- [Industrial Policy Pack](../specs/industrial-policy.yaml)
+- [Factory Action Pack Demo](../guides/factory-action-pack-demo.md)
 
 ### Sprint 2. Simulation-First Factory Demo
 

--- a/docs/specs/cell-graph.schema.json
+++ b/docs/specs/cell-graph.schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.sint.gg/specs/cell-graph.schema.json",
+  "title": "CellGraph",
+  "description": "Canonical production-cell graph for industrial planning and execution control.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "cell_id",
+    "assets",
+    "flows",
+    "approval_tier"
+  ],
+  "properties": {
+    "cell_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9._-]+$"
+    },
+    "assets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "asset_id",
+          "type",
+          "vendor",
+          "adapter"
+        ],
+        "properties": {
+          "asset_id": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9._-]+$"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "robot_arm",
+              "plc",
+              "safety_plc",
+              "camera",
+              "conveyor",
+              "gripper",
+              "amr",
+              "sensor",
+              "digital_twin",
+              "workstation",
+              "custom"
+            ]
+          },
+          "vendor": {
+            "type": "string",
+            "minLength": 1
+          },
+          "controller": {
+            "type": "string"
+          },
+          "adapter": {
+            "type": "string",
+            "pattern": "^sint-adapter-[A-Za-z0-9._-]+$"
+          },
+          "safety_zone": {
+            "type": "string"
+          },
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "flows": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "from",
+          "to",
+          "material",
+          "rate_per_minute"
+        ],
+        "properties": {
+          "from": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          },
+          "material": {
+            "type": "string"
+          },
+          "rate_per_minute": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          }
+        }
+      }
+    },
+    "approval_tier": {
+      "type": "string",
+      "enum": [
+        "T0_observe",
+        "T1_prepare",
+        "T2_act",
+        "T3_commit",
+        "T3_HUMAN_REQUIRED"
+      ]
+    },
+    "simulation_required": {
+      "type": "boolean",
+      "default": true
+    }
+  }
+}

--- a/docs/specs/factory-intent.schema.json
+++ b/docs/specs/factory-intent.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.sint.gg/specs/factory-intent.schema.json",
+  "title": "FactoryIntent",
+  "description": "Structured planning intent for prompt-generated industrial automation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "intent_id",
+    "goal",
+    "industry",
+    "materials",
+    "stations",
+    "constraints"
+  ],
+  "properties": {
+    "intent_id": {
+      "type": "string",
+      "pattern": "^fi_[A-Za-z0-9._-]+$"
+    },
+    "goal": {
+      "type": "string",
+      "minLength": 8
+    },
+    "industry": {
+      "type": "string",
+      "enum": [
+        "consumer_goods",
+        "automotive",
+        "electronics",
+        "food_beverage",
+        "life_sciences",
+        "logistics",
+        "energy",
+        "general_industrial",
+        "other"
+      ]
+    },
+    "materials": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "stations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": [
+          "infeed",
+          "pick_place",
+          "inspection",
+          "case_pack",
+          "palletize",
+          "weld",
+          "dispense",
+          "screwdrive",
+          "sort",
+          "test",
+          "outfeed",
+          "custom"
+        ]
+      }
+    },
+    "constraints": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "max_capex_usd",
+        "floor_space_m2",
+        "takt_time_seconds",
+        "human_collaboration",
+        "safety_standard_targets"
+      ],
+      "properties": {
+        "max_capex_usd": {
+          "type": "number",
+          "minimum": 0
+        },
+        "floor_space_m2": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "takt_time_seconds": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "human_collaboration": {
+          "type": "boolean"
+        },
+        "safety_standard_targets": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "ISO_10218",
+              "ISO_TS_15066",
+              "IEC_62443",
+              "EU_AI_ACT_ARTICLE_14",
+              "NIST_AI_RMF",
+              "OPC_UA_FX",
+              "CUSTOM"
+            ]
+          }
+        }
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "authoring_source": {
+          "type": "string"
+        },
+        "created_by_agent": {
+          "type": "string"
+        },
+        "currency": {
+          "type": "string",
+          "default": "USD"
+        }
+      }
+    }
+  }
+}

--- a/docs/specs/industrial-policy.yaml
+++ b/docs/specs/industrial-policy.yaml
@@ -1,0 +1,59 @@
+policy_id: sint.factory.robot.motion.v1
+status: draft
+risk_tier: T3_commit
+description: >
+  Baseline industrial robot-motion policy for prompt-generated factory actions.
+  This profile exists to force simulation proof, workspace clarity, and
+  tier-appropriate human oversight before execution.
+applies_to:
+  resources:
+    - "factory://cell/*/robot/*/action/*"
+  actions:
+    - "plan"
+    - "simulate"
+    - "approve"
+    - "execute"
+required_context:
+  - human_detected_in_zone
+  - simulation_receipt_present
+  - approved_envelope.max_velocity_mps
+  - approved_envelope.max_force_newtons
+  - maintenance_mode
+  - safety_zone_clear
+rules:
+  - id: deny-human-in-zone
+    deny_if: human_detected_in_zone == true
+    reason: HUMAN_IN_ZONE
+  - id: deny-missing-simulation
+    deny_if: simulation_receipt_present == false
+    reason: SIMULATION_RECEIPT_MISSING
+  - id: deny-excess-velocity
+    deny_if: motion.max_velocity_mps > approved_envelope.max_velocity_mps
+    reason: VELOCITY_ENVELOPE_EXCEEDED
+  - id: deny-excess-force
+    deny_if: motion.max_force_newtons > approved_envelope.max_force_newtons
+    reason: FORCE_ENVELOPE_EXCEEDED
+  - id: require-human-approval
+    require_human_approval_if:
+      action_type_in:
+        - "robot.motion.pick_and_place"
+        - "robot.motion.weld"
+        - "robot.motion.cut"
+        - "robot.motion.lift"
+        - "robot.motion.dispense"
+  - id: require-lockout
+    require_lockout_if: maintenance_mode == true
+    reason: LOCKOUT_TAGOUT_REQUIRED
+  - id: require-zone-clear
+    deny_if: safety_zone_clear == false
+    reason: SAFETY_ZONE_NOT_CLEAR
+  - id: require-receipt-chain
+    require_receipt_chain: true
+evidence:
+  emit:
+    - policy.decision
+    - simulation.receipt.checked
+    - approval.requested
+    - execution.allowed
+    - execution.denied
+    - safety.rollback

--- a/docs/specs/robot-action.schema.json
+++ b/docs/specs/robot-action.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.sint.gg/specs/robot-action.schema.json",
+  "title": "RobotActionProfile",
+  "description": "Vendor-neutral robot action request for industrial execution control.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "action_type",
+    "target_robot",
+    "motion",
+    "tool",
+    "requires"
+  ],
+  "properties": {
+    "action_type": {
+      "type": "string",
+      "pattern": "^robot\\.[a-z0-9_]+\\.[a-z0-9_]+$"
+    },
+    "target_robot": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9._-]+$"
+    },
+    "motion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_pose",
+        "target_pose",
+        "max_velocity_mps",
+        "max_force_newtons",
+        "collision_check"
+      ],
+      "properties": {
+        "source_pose": {
+          "type": "string"
+        },
+        "target_pose": {
+          "type": "string"
+        },
+        "max_velocity_mps": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "max_force_newtons": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "collision_check": {
+          "type": "boolean"
+        }
+      }
+    },
+    "tool": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "payload_kg"
+      ],
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "payload_kg": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "requires": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "simulation_receipt",
+        "human_approval",
+        "safety_zone_clear"
+      ],
+      "properties": {
+        "simulation_receipt": {
+          "type": "boolean"
+        },
+        "human_approval": {
+          "type": "boolean"
+        },
+        "safety_zone_clear": {
+          "type": "boolean"
+        }
+      }
+    },
+    "adapter_hint": {
+      "type": "string"
+    }
+  }
+}

--- a/docs/specs/simulation-receipt.schema.json
+++ b/docs/specs/simulation-receipt.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.sint.gg/specs/simulation-receipt.schema.json",
+  "title": "SimulationReceipt",
+  "description": "Simulation proof artifact required before selected factory actions may execute.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "simulation_receipt_id",
+    "cell_id",
+    "simulator",
+    "vendor_program_hash",
+    "collision_free",
+    "cycle_time_seconds",
+    "safety_zone_violations",
+    "max_force_newtons",
+    "approved_for_execution",
+    "signed_by"
+  ],
+  "properties": {
+    "simulation_receipt_id": {
+      "type": "string",
+      "pattern": "^simr_[A-Za-z0-9._-]+$"
+    },
+    "cell_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9._-]+$"
+    },
+    "simulator": {
+      "type": "string",
+      "enum": [
+        "RobotStudio",
+        "KUKA.Sim",
+        "ROBOGUIDE",
+        "Emulate3D",
+        "TIA_Simulation",
+        "TwinCAT_Simulation",
+        "Isaac_Sim",
+        "RoboDK",
+        "Visual_Components",
+        "Custom"
+      ]
+    },
+    "vendor_program_hash": {
+      "type": "string",
+      "pattern": "^sha256:[A-Fa-f0-9]{64}$"
+    },
+    "collision_free": {
+      "type": "boolean"
+    },
+    "cycle_time_seconds": {
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "safety_zone_violations": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "max_force_newtons": {
+      "type": "number",
+      "minimum": 0
+    },
+    "approved_for_execution": {
+      "type": "boolean"
+    },
+    "signed_by": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "decision_digest": {
+          "type": "string"
+        },
+        "artifact_uri": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/docs/specs/sint-industrial-action-profile.md
+++ b/docs/specs/sint-industrial-action-profile.md
@@ -1,0 +1,170 @@
+# SINT Industrial Action Profile
+
+This profile defines the first factory-control standard pack for SINT.
+
+It does not try to replace TIA Portal, RobotStudio, ROBOGUIDE, RoboDK, KUKA.Sim,
+or digital-twin authoring tools. It gives SINT a canonical control surface for
+what happens after a prompt-generated industrial plan gets close to execution.
+
+## Goal
+
+Turn generated industrial intent into structured objects that can be:
+
+- simulated
+- approved
+- denied
+- executed
+- audited
+- settled
+
+The control question is the core of the profile:
+
+```text
+factory intent -> structured plan -> simulation proof -> approval gate -> execution receipt
+```
+
+## Profile Objects
+
+The first profile pack introduces four primary objects:
+
+1. `FactoryIntent`
+2. `CellGraph`
+3. `RobotActionProfile`
+4. `SimulationReceipt`
+
+Supporting artifacts:
+
+- `industrial-policy.yaml`
+- the refusal-first demo narrative in
+  [Factory Action Pack Demo](../guides/factory-action-pack-demo.md)
+
+## Canonical Flow
+
+### 1. Factory Intent
+
+`FactoryIntent` captures the requested outcome:
+
+- production goal
+- industry context
+- materials and stations
+- throughput, capex, and floor-space constraints
+- target safety standards
+
+This is not an execution object. It is the auditable planning request.
+
+### 2. Cell Graph
+
+`CellGraph` normalizes the planned workcell:
+
+- assets
+- controllers
+- adapters
+- safety zones
+- material flows
+- approval tier
+
+The graph is where generated planning turns into a bounded execution surface.
+
+### 3. Robot Action Profile
+
+`RobotActionProfile` gives SINT one canonical robot action language across
+vendors.
+
+The same action shape can later be translated into:
+
+- RAPID
+- KRL
+- FANUC LS/TP
+- URScript
+- ROS 2
+- SRCI
+- PLC or motion-controller profiles
+
+### 4. Simulation Receipt
+
+`SimulationReceipt` is the proof object for simulation-first control.
+
+It binds:
+
+- cell identity
+- simulator identity
+- vendor program hash
+- collision result
+- cycle time
+- force envelope
+- execution-readiness decision
+
+The point is simple: no serious physical action should rely on vibes when a
+simulation proof object can exist.
+
+## URI And Resource Guidance
+
+The factory-control pack uses canonical resource URIs so the existing
+`PolicyGateway` can reason about industrial actions without special-case hacks.
+
+Recommended forms:
+
+- `factory://intent/<intent_id>`
+- `factory://cell/<cell_id>`
+- `factory://cell/<cell_id>/asset/<asset_id>`
+- `factory://cell/<cell_id>/simulation/<simulation_receipt_id>`
+- `factory://cell/<cell_id>/robot/<robot_id>/action/<action_type>`
+
+These URIs should remain boring and stable. The adapter-specific details belong
+in adapter metadata, not in the canonical control surface.
+
+## Tier Guidance
+
+Default tier expectations:
+
+| Surface | Default tier | Notes |
+| --- | --- | --- |
+| Read factory plan metadata | `T0_observe` | review only |
+| Save or modify intent draft | `T1_prepare` | planning surface |
+| Request simulation run | `T1_prepare` | no real actuation |
+| Approve simulated robot motion | `T2_act` or `T3_commit` | depends on action and environment |
+| Send live robot or PLC action | `T2_act` or `T3_commit` | requires policy evaluation |
+| Disable safety envelope or execute irreversible cell change | `T3_commit` | mandatory human oversight |
+
+## Adapter Contract
+
+The first industrial adapters should preserve these rules:
+
+- adapters translate, but do not authorize
+- all authorization still flows through `PolicyGateway.intercept()`
+- simulation artifacts produce receipts, not trust by assertion
+- vendor code generation is gated by the same structured control objects
+
+Target adapter families:
+
+- Siemens TIA / SRCI
+- ABB RAPID / RobotStudio
+- KUKA KRL / KUKA.Sim
+- FANUC LS/TP / ROBOGUIDE
+- Universal Robots URScript / PolyScope / ROS 2 / SRCI
+- Beckhoff TwinCAT / EtherCAT
+- Rockwell FactoryTalk / Emulate3D
+
+## Files In This Pack
+
+- [Factory Intent Schema](./factory-intent.schema.json)
+- [Cell Graph Schema](./cell-graph.schema.json)
+- [Robot Action Schema](./robot-action.schema.json)
+- [Simulation Receipt Schema](./simulation-receipt.schema.json)
+- [Industrial Policy Pack](./industrial-policy.yaml)
+- [Factory Action Pack Demo](../guides/factory-action-pack-demo.md)
+
+## Why This Matters
+
+Prompt-generated industrial design is becoming easier.
+
+The missing control layer is not another generator. It is the thing that can
+say:
+
+- simulation proof is missing
+- human approval is required
+- force exceeds the approved envelope
+- the safety zone is occupied
+- the action is denied and the denial itself is auditable
+
+That is the job of this profile.


### PR DESCRIPTION
## Summary
- ship the Factory Action Pack Sprint 1 control-standard pack
- add the industrial action profile, factory intent, cell graph, robot action, simulation receipt, and industrial policy artifacts
- add a refusal-first demo guide and mark Sprint 1 as shipped in the roadmap docs

## Validation
- pnpm run docs:build