### PR TITLE
docs: align security disclosure path and SLA

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,9 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers via [GitHub Security Advisories](https://github.com/sint-ai/sint-protocol/security/advisories). All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers at `i@pshkv.com`. All complaints will be
+reviewed and investigated promptly and fairly.
 
 ## Attribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,10 @@ test(bridge-mcp): add forbidden combo detection tests
 
 Email security reports to: **i@pshkv.com** with subject line `[SINT-SECURITY]`.
 
-We will acknowledge within 48 hours and provide a timeline for fix and disclosure.
+We will acknowledge within 48 hours and provide a timeline for fix and
+disclosure. See [SECURITY.md](./SECURITY.md) and
+[`docs/security/vulnerability-reporting-and-response.md`](docs/security/vulnerability-reporting-and-response.md)
+for the current disclosure path and response expectations.
 
 ## Code of Conduct
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,15 +6,21 @@ SINT Protocol is currently in active development. Security fixes are applied to 
 
 ## Bug Bounty Launch Plan
 
-The public bounty program is not live until maintainers choose a platform, approve funding, and publish the final scope. The current non-binding launch draft is tracked in [docs/security/bug-bounty-launch-plan.md](docs/security/bug-bounty-launch-plan.md).
+The public bounty program is not live until maintainers choose a platform,
+approve funding, and publish the final scope. The current non-binding launch
+draft is tracked in [docs/security/bug-bounty-launch-plan.md](docs/security/bug-bounty-launch-plan.md).
 
 ## Reporting a Vulnerability
 
 If you discover a vulnerability, do not open a public issue.
 
-Please report privately to:
+Please report privately by email to:
 
-- `security@sint.ai`
+- `i@pshkv.com`
+
+Use subject line:
+
+- `[SINT-SECURITY]`
 
 Include:
 
@@ -23,11 +29,26 @@ Include:
 - Potential impact
 - Suggested remediation (if available)
 
+Operational details for the disclosure path and response SLA are documented in:
+
+- [Vulnerability Reporting and Response](docs/security/vulnerability-reporting-and-response.md)
+
 ## Response Expectations
 
-We will acknowledge receipt as quickly as possible and triage based on severity.
-For valid reports, we will coordinate remediation and disclosure timing with the reporter.
+We will:
+
+- acknowledge receipt within 48 hours
+- classify severity and confirm next steps within 10 business days
+- send weekly status updates for valid reports until a remediation or disclosure
+  plan is agreed
+
+For valid reports, we will coordinate remediation and disclosure timing with
+the reporter.
 
 ## Disclosure
 
-Please avoid public disclosure until a fix is released or a coordinated disclosure date is agreed.
+Please avoid public disclosure until a fix is released or a coordinated
+disclosure date is agreed.
+
+When a public advisory is needed, maintainers will publish it through GitHub
+Security Advisories.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -77,6 +77,7 @@ export default defineConfig({
           { text: "AAIF Proposal Template", link: "/community/aaif-resubmission-proposal-template" },
           { text: "Adopters And Evidence", link: "/community/adopters" },
           { text: "OpenSSF Gap Tracker", link: "/community/openssf-gap-tracker" },
+          { text: "Vulnerability Reporting And Response", link: "/security/vulnerability-reporting-and-response" },
           { text: "Discord Launch Runbook", link: "/community/discord-launch-runbook" },
           { text: "Discord Launch Kit", link: "/community/discord-launch-kit" },
           { text: "External Contributor Onboarding", link: "/community/external-contributor-onboarding" },

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -38,4 +38,5 @@ See CONTRIBUTING.md and the "good first issue" label on GitHub Issues.
 
 - All TSC decisions recorded in `docs/tsc/`
 - All SIPs in `docs/sip/`
-- Security advisories via GitHub Security Advisories
+- Public security advisories via GitHub Security Advisories
+- Private vulnerability intake via the path documented in `SECURITY.md`

--- a/docs/community/openssf-gap-tracker.md
+++ b/docs/community/openssf-gap-tracker.md
@@ -16,7 +16,7 @@ what still blocks release-readiness claims.
 | Area | Current status | Evidence | Owner | Target date | Notes |
 | --- | --- | --- | --- | --- | --- |
 | OpenSSF Best Practices project profile started | in-progress | [Issue #191](https://github.com/sint-ai/sint-protocol/issues/191) | core maintainers | 2026-06-01 | Baseline assessment and gap filing task opened |
-| Security policy and vuln reporting path verified | in-progress | [Issue #192](https://github.com/sint-ai/sint-protocol/issues/192) | core maintainers | 2026-06-01 | Track disclosure channel and SLA verification work |
+| Security policy and vuln reporting path verified | done | [Issue #192](https://github.com/sint-ai/sint-protocol/issues/192), [Vulnerability Reporting and Response](../security/vulnerability-reporting-and-response) | core maintainers | 2026-06-01 | Disclosure contact and SLA are now aligned with verified repo documentation |
 | Release candidate checklist used on tagged RC | in-progress | [Issue #195](https://github.com/sint-ai/sint-protocol/issues/195) | release owner | 2026-06-15 | First completed issue should link CI and conformance evidence |
 | SBOM or dependency review path documented | in-progress | [Issue #194](https://github.com/sint-ai/sint-protocol/issues/194), [Dependency Review And SBOM Path](../guides/dependency-review-and-sbom) | core maintainers | 2026-06-15 | Baseline workflow added; awaiting first published review artifact |
 | Signed production-slice validation artifact published | in-progress | [Issue #193](https://github.com/sint-ai/sint-protocol/issues/193) | gateway team | 2026-06-15 | Public artifact for external evaluator evidence |

--- a/docs/security/vulnerability-reporting-and-response.md
+++ b/docs/security/vulnerability-reporting-and-response.md
@@ -1,0 +1,75 @@
+# Vulnerability Reporting And Response
+
+This page documents the current private disclosure path and response
+expectations for SINT.
+
+Use it as the source of truth for security-intake guidance referenced by
+`SECURITY.md`, OpenSSF readiness work, and coordinated disclosure planning.
+
+## Current Intake Path
+
+The supported private intake path is:
+
+- `i@pshkv.com`
+
+Required subject line:
+
+- `[SINT-SECURITY]`
+
+Do not open a public GitHub issue for a vulnerability report.
+
+## Why This Is The Supported Path
+
+The repo previously pointed to `security@sint.ai`, but the public
+infrastructure did not support that as a verified disclosure path.
+
+Verification performed on 2026-05-21:
+
+- `pshkv.com` publishes live Google Workspace MX records
+- `sint.ai` resolves as a web domain, but has no public MX record
+- `sint.ai` currently redirects to an Atom landing page rather than an active
+  project site
+
+The practical outcome is simple:
+
+- use `i@pshkv.com` for private vulnerability intake until a dedicated SINT
+  security mailbox is actually live and verifiable
+
+## Response SLA
+
+| Stage | Current expectation |
+| --- | --- |
+| Initial acknowledgement | within 48 hours |
+| Severity classification and next-step response | within 10 business days |
+| Status updates for valid reports | at least weekly until remediation or disclosure plan is agreed |
+| Public advisory publication | after fix, mitigation, or coordinated disclosure decision |
+
+## Report Contents
+
+Please include:
+
+1. affected package, path, or deployment slice
+2. reproduction steps or proof artifact
+3. expected vs actual behavior
+4. practical impact
+5. suggested remediation, if known
+
+## Disclosure Expectations
+
+- maintainers will coordinate remediation and disclosure timing with the
+  reporter
+- please avoid public disclosure until a fix is released or a coordinated date
+  is agreed
+- when a public advisory is needed, maintainers will publish it through GitHub
+  Security Advisories
+
+## GitHub Advisory Note
+
+As of 2026-05-21, the repo should not rely on GitHub-hosted private
+vulnerability intake as the only reported path in public docs.
+
+Public advisories remain a supported publication surface.
+
+If repo-native private vulnerability reporting is enabled later, this page
+should be updated to list it as an additional intake option rather than a vague
+future reference.


### PR DESCRIPTION
## Summary
- replace the unverified `security@sint.ai` contact path with the working disclosure inbox
- document the current vulnerability response SLA and link it from repo governance docs
- mark the OpenSSF disclosure-path gap as complete and make the page discoverable in docs navigation

## Validation
- pnpm run docs:build

Closes #192