### PR TITLE
Add AutoGen runtime adapter blueprint and evidence mapping

### DIFF
--- a/docs/guides/autogen-interop-fixtures.md
+++ b/docs/guides/autogen-interop-fixtures.md
@@ -65,6 +65,60 @@ Silent drops are non-conformant.
 3. Edge disconnect fail-closed denial for trust-escalated actions
 4. Evidence event presence for deny/escalate paths
 
+## Reference adapter blueprint
+
+The conformance test provides the canonical callback chain:
+
+- trust gate callback (pre-policy)
+- `PolicyGateway.intercept()` callback (authorization)
+- trust-to-tier merge callback (post-policy)
+
+Minimal TypeScript shape:
+
+```ts
+import type { PolicyGateway, SintRequest, PolicyDecision } from "@pshkv/gate-policy-gateway";
+
+type TrustSignal = "unrestricted" | "low_risk" | "medium_risk" | "high_risk" | "blocked";
+
+export async function authorizeAutogenToolCall(
+  gateway: PolicyGateway,
+  request: SintRequest,
+  trustSignal: TrustSignal,
+): Promise<PolicyDecision> {
+  // 1) Pre-policy trust gate
+  if (trustSignal === "blocked") {
+    return {
+      requestId: request.requestId,
+      timestamp: new Date().toISOString(),
+      action: "deny",
+      assignedTier: "T3_commit",
+      assignedRisk: "T3_irreversible",
+      denial: { reason: "Trust signal blocked execution", policyViolated: "TRUST_BLOCKED" },
+    };
+  }
+
+  // 2) Mandatory choke point
+  const decision = await gateway.intercept(request);
+
+  // 3) Runtime action mapping
+  // allow     -> execute tool
+  // deny      -> fail closed
+  // escalate  -> suspend and await approval
+  // transform -> apply overrides and execute
+  return decision;
+}
+```
+
+### Evidence extraction
+
+Adapters should return `requestId` with decision payloads and expose the evidence stream references for operators:
+
+- `policy.evaluated` for policy decisions
+- `economy.trust.evaluated` for trust escalation
+- `economy.trust.blocked` for trust gate denials
+
+If your runtime cannot surface event IDs directly, `requestId` is the minimum trace key and is required.
+
 ## Run locally
 
 ```bash

--- a/sdks/python/tests/test_openai_agents_adapter.py
+++ b/sdks/python/tests/test_openai_agents_adapter.py
@@ -82,6 +82,10 @@ def _decision(action: str, *, with_approval_id: bool = False) -> PolicyDecision:
         }
         if with_approval_id:
             payload["approvalRequestId"] = "req-approve-001"
+    if action == "transform":
+        payload["transformations"] = {
+            "constraintOverrides": {"maxVelocityMps": 0.15},
+        }
     return PolicyDecision.model_validate(payload)
 
 
@@ -91,6 +95,14 @@ async def test_authorize_allow_returns_decision() -> None:
     adapter = OpenAIAgentsGovernanceAdapter(client)  # type: ignore[arg-type]
     result = await adapter.authorize_tool_call(_request())
     assert result.action == "allow"
+
+
+@pytest.mark.asyncio
+async def test_authorize_transform_returns_decision() -> None:
+    client = _FakeGatewayClient(_decision("transform"))
+    adapter = OpenAIAgentsGovernanceAdapter(client)  # type: ignore[arg-type]
+    result = await adapter.authorize_tool_call(_request())
+    assert result.action == "transform"
 
 
 @pytest.mark.asyncio
@@ -152,6 +164,16 @@ async def test_escalation_with_denied_resolution_raises_typed_error() -> None:
 async def test_evidence_for_request_filters_by_payload_request_id() -> None:
     events = [
         LedgerEvent.model_validate({
+            "eventId": "e0",
+            "sequenceNumber": "0",
+            "timestamp": "2026-04-06T11:59:59.000000Z",
+            "eventType": "economy.trust.evaluated",
+            "agentId": "a" * 64,
+            "payload": {"requestId": "target-1", "trustSignal": "medium_risk"},
+            "previousHash": "f" * 64,
+            "hash": "0" * 64,
+        }),
+        LedgerEvent.model_validate({
             "eventId": "e1",
             "sequenceNumber": "1",
             "timestamp": "2026-04-06T12:00:00.000000Z",
@@ -185,5 +207,4 @@ async def test_evidence_for_request_filters_by_payload_request_id() -> None:
     client = _FakeGatewayClient(_decision("allow"), ledger_events=events)
     adapter = OpenAIAgentsGovernanceAdapter(client)  # type: ignore[arg-type]
     matched = await adapter.evidence_for_request("target-1")
-    assert [e.event_id for e in matched] == ["e1", "e2"]
-
+    assert [e.event_id for e in matched] == ["e0", "e1", "e2"]


### PR DESCRIPTION
## Summary\n- extend AutoGen interop fixture guide with a runnable adapter blueprint\n- codify trust-gate -> intercept -> outcome mapping callback chain\n- document required evidence trace events and requestId trace key\n\n## Validation\n- 
> sint-protocol@0.1.0 docs:build /Users/pshkv/sint-protocol
> vitepress build docs


  vitepress v1.6.4

build complete in 7.57s.\n\n## Tracking\n- Part of #213