### PR TITLE
Add reusable governed tool-call helper for OpenAI runtime

### DIFF
--- a/docs/guides/openai-agents-sdk-integration.md
+++ b/docs/guides/openai-agents-sdk-integration.md
@@ -27,6 +27,7 @@ from sint import (
     GatewayClient,
     GatewayConfig,
     OpenAIAgentsGovernanceAdapter,
+    governed_tool_call,
     SintRequest,
     ApprovalResolution,
 )
@@ -42,6 +43,18 @@ decision = await adapter.authorize_tool_call(
     request,
     on_escalation=resolver,      # optional async callback for human approval
     approval_timeout_s=30.0,     # fail-closed timeout path
+)
+```
+
+Or use the runtime helper to enforce "authorize before execute":
+
+```python
+result = await governed_tool_call(
+    adapter,
+    request,
+    execute=lambda decision: my_tool_runner(decision),  # called only after allow/transform or approved escalation
+    on_escalation=resolver,
+    approval_timeout_s=30.0,
 )
 ```
 

--- a/sdks/python/sint/__init__.py
+++ b/sdks/python/sint/__init__.py
@@ -20,6 +20,16 @@ from .crewai import (
     CrewAIGuardrailProviderCompat,
     GuardrailDecision,
 )
+from .openai_agents import (
+    ApprovalResolution as OpenAIAgentsApprovalResolution,
+    OpenAIAgentsGovernanceAdapter,
+    SintApprovalDeniedError,
+    SintApprovalRequiredError,
+    SintApprovalTimeoutError,
+    SintDeniedError,
+    SintGovernanceError,
+)
+from .openai_agents_runtime import governed_tool_call
 
 __version__ = "0.1.0"
 
@@ -45,4 +55,13 @@ __all__ = [
     "CrewAIGuardrailProviderCompat",
     "GuardrailDecision",
     "CrewAIApprovalResolution",
+    # openai agents adapter
+    "OpenAIAgentsGovernanceAdapter",
+    "OpenAIAgentsApprovalResolution",
+    "SintGovernanceError",
+    "SintDeniedError",
+    "SintApprovalRequiredError",
+    "SintApprovalTimeoutError",
+    "SintApprovalDeniedError",
+    "governed_tool_call",
 ]

--- a/sdks/python/sint/openai_agents_runtime.py
+++ b/sdks/python/sint/openai_agents_runtime.py
@@ -1,0 +1,45 @@
+"""
+SINT Protocol — OpenAI Agents runtime wrapper helpers.
+
+Small execution helpers that compose:
+- SINT authorization (`OpenAIAgentsGovernanceAdapter`)
+- tool execution callback
+- typed error behavior from the adapter
+"""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, TypeVar
+
+from .openai_agents import ApprovalResolver, OpenAIAgentsGovernanceAdapter
+from .types import PolicyDecision, SintRequest
+
+T = TypeVar("T")
+
+
+ToolExecutor = Callable[[PolicyDecision], Awaitable[T]]
+
+
+async def governed_tool_call(
+    adapter: OpenAIAgentsGovernanceAdapter,
+    request: SintRequest,
+    execute: ToolExecutor[T],
+    *,
+    on_escalation: ApprovalResolver | None = None,
+    approval_timeout_s: float | None = None,
+    fail_closed_reviewer: str = "openai-agents/fail-closed",
+) -> T:
+    """
+    Authorize a tool call and execute only after permission is granted.
+
+    The wrapper intentionally relies on typed exceptions raised by the adapter
+    (`SintDeniedError`, `SintApprovalRequiredError`, etc.) for fail-closed control.
+    """
+    decision = await adapter.authorize_tool_call(
+        request,
+        on_escalation=on_escalation,
+        approval_timeout_s=approval_timeout_s,
+        fail_closed_reviewer=fail_closed_reviewer,
+    )
+    return await execute(decision)
+

--- a/sdks/python/tests/test_openai_agents_adapter.py
+++ b/sdks/python/tests/test_openai_agents_adapter.py
@@ -12,6 +12,7 @@ from sint.openai_agents import (
     SintApprovalTimeoutError,
     SintDeniedError,
 )
+from sint.openai_agents_runtime import governed_tool_call
 from sint.types import LedgerEvent, PolicyDecision, SintRequest
 
 
@@ -208,3 +209,33 @@ async def test_evidence_for_request_filters_by_payload_request_id() -> None:
     adapter = OpenAIAgentsGovernanceAdapter(client)  # type: ignore[arg-type]
     matched = await adapter.evidence_for_request("target-1")
     assert [e.event_id for e in matched] == ["e0", "e1", "e2"]
+
+
+@pytest.mark.asyncio
+async def test_governed_tool_call_executes_only_after_authorization() -> None:
+    client = _FakeGatewayClient(_decision("allow"))
+    adapter = OpenAIAgentsGovernanceAdapter(client)  # type: ignore[arg-type]
+    executed: list[str] = []
+
+    async def _execute(decision: PolicyDecision) -> str:
+        executed.append(decision.action)
+        return "ok"
+
+    result = await governed_tool_call(adapter, _request(), _execute)
+    assert result == "ok"
+    assert executed == ["allow"]
+
+
+@pytest.mark.asyncio
+async def test_governed_tool_call_does_not_execute_on_denial() -> None:
+    client = _FakeGatewayClient(_decision("deny"))
+    adapter = OpenAIAgentsGovernanceAdapter(client)  # type: ignore[arg-type]
+    executed: list[str] = []
+
+    async def _execute(_decision: PolicyDecision) -> str:
+        executed.append("ran")
+        return "should-not-run"
+
+    with pytest.raises(SintDeniedError):
+        await governed_tool_call(adapter, _request(), _execute)
+    assert executed == []


### PR DESCRIPTION
## Summary\n- add  runtime helper for authorize-then-execute control flow\n- export OpenAI governance adapter types/errors at top-level  package\n- expand adapter tests for runtime helper behavior and typed outcomes\n- document helper usage in OpenAI Agents integration guide\n\n## Validation\n- ..........                                                               [100%]
10 passed in 0.09s\n- 
> sint-protocol@0.1.0 docs:build /Users/pshkv/sint-protocol
> vitepress build docs


  vitepress v1.6.4

build complete in 6.10s.\n\n## Tracking\n- Part of #213