### PR TITLE
Add PX4 log-encryption evidence lane to roadmap

### DIFF
--- a/docs/guides/px4-log-encryption-evidence-integration.md
+++ b/docs/guides/px4-log-encryption-evidence-integration.md
@@ -1,0 +1,47 @@
+# PX4 Log Encryption -> SINT Evidence Integration
+
+This guide defines the minimum integration flow to use encrypted PX4 logs as
+supporting evidence for SINT-governed physical actions.
+
+## Why this lane matters
+
+SINT already records policy decisions and approvals. PX4 encrypted logs add a
+second, independently generated telemetry trail for flight behavior. Together,
+they strengthen incident replay and external auditability.
+
+## Minimum flow
+
+1. Execute governed flight actions through SINT (MAVLink bridge path).
+2. Download encrypted PX4 logs (`.ulge`).
+3. Decrypt logs in a controlled review environment (never on runtime nodes).
+4. Correlate:
+   - SINT `requestId`, decision tier, and policy event timestamps
+   - PX4 ULog event windows (arming, mode switches, setpoints, failsafes)
+5. Emit a review artifact with:
+   - evidence hash of decrypted log bundle
+   - log key identifier reference (not private key material)
+   - timeline match results and anomaly notes
+
+## Security posture
+
+- Keep log decryption private keys in separate key-management scope.
+- Do not store decrypted raw logs in long-lived hot paths.
+- Store only evidence digests and bounded references in SINT-facing artifacts.
+
+## Suggested first implementation tasks
+
+1. Add a conformance fixture that requires ULog-correlation evidence for
+   offboard T2/T3 scenarios.
+2. Add a bridge payload extension for `px4LogEvidenceRef`:
+   - `logDigest`
+   - `keyRef`
+   - `timeWindow`
+3. Add an operator runbook section for review-time decryption workflow.
+4. Add one benchmark metric:
+   - decision-to-flight-event correlation latency.
+
+## Non-goals
+
+- Modifying PX4 flight-control internals.
+- Introducing private key material into SINT runtime services.
+- Claiming hardware or regulatory certification by this integration alone.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -95,6 +95,7 @@ Best conversion targets:
 - Open-RMF handoff receipts
 - Sunnybotics ROS 2 integration questions
 - one industrial or factory-control design thread
+- PX4 encrypted-log evidence correlation lane (ULog `.ulge` + policy receipts)
 
 ### Priority 5. Public Story Sync
 
@@ -163,6 +164,7 @@ For the fuller execution plan, use:
 - [Graph-first coordination upgrade 2026](./roadmaps/graph-first-coordination-upgrade-2026.md)
 - [Humanoid robotics integrations 2026](./roadmaps/humanoid-robotics-integrations-2026.md)
 - [Post-quantum crypto agility](./roadmaps/post-quantum-crypto-agility.md)
+- [PX4 log encryption evidence integration](./guides/px4-log-encryption-evidence-integration.md)
 
 ## What We Are Measuring
 

--- a/docs/roadmaps/hardware-safety-controller-integration.md
+++ b/docs/roadmaps/hardware-safety-controller-integration.md
@@ -54,6 +54,40 @@ Integrate SINT policy decisions with dedicated hardware safety controllers (PLC 
 - Provide benchmark report including software + hardware safety handshake timing.
 - Publish design-partner case study with incident-response replay evidence.
 
+### Phase D — Q4 2026: PX4 Encrypted Log Evidence Lane
+
+Use PX4 encrypted ULog (`.ulge`) as a first-class evidence input for SINT
+incident review and policy-receipt correlation.
+
+- Treat encrypted PX4 logs as source-of-truth flight telemetry for high-risk
+  physical actions.
+- Correlate SINT `requestId` / policy events with decrypted ULog timeline
+  during incident replay.
+- Keep private decrypt keys outside runtime nodes; decrypt only in review
+  pipeline.
+
+Reference baseline from PX4 docs:
+
+- encryption algorithm path (`XChaCha20`) and wrapped symmetric key model
+- firmware enablement via crypto modules + board key config
+- `.ulge` single-file format in recent PX4
+- `Tools/log_encryption` download/decrypt workflow
+
+### PX4 integration tasks (execution-ready)
+
+1. Add a conformance fixture profile for "SINT decision timeline matches PX4
+   decrypted ULog event windows" on offboard actions.
+2. Add a guide that documents operator flow:
+   - collect `.ulge`
+   - decrypt in controlled environment
+   - map ULog timestamps to SINT evidence events
+3. Add a bridge-level evidence pointer field for PX4 encrypted log artifacts
+   (file hash + key identifier reference, never private key material).
+4. Add fail-closed policy profile option for safety-critical fleets:
+   - deny T2/T3 if required encrypted logging capability is unavailable.
+5. Publish one benchmark note for correlation latency budget
+   (decision-to-verified-flight-event alignment).
+
 ## KPI Targets
 
 - ROS2 software intercept p99: `< 10ms` (`benchmark:ros2-loop`)


### PR DESCRIPTION
## Summary\n- add a PX4 encrypted-log evidence rollout phase to hardware safety controller roadmap\n- add execution-ready tasks for ULog correlation with SINT policy receipts\n- add a practical integration guide for operator flow and security boundaries\n- update top-level roadmap priority and track links\n\n## Validation\n- 
> sint-protocol@0.1.0 docs:build /Users/pshkv/sint-protocol
> vitepress build docs


  vitepress v1.6.4

build complete in 6.46s.\n\n## Context\nInspired by PX4 log encryption docs (, key wrapping, decrypt workflow), mapped to SINT evidence and incident replay workflows.\n\n## Tracking\n- execution updates posted in #213\n- external follow-up posted in PX4 thread #26261