### PR TITLE
Add PX4 ULog correlation requirement to offboard fixture

### DIFF
--- a/packages/conformance-tests/fixtures/physical-ai/px4-offboard-policy-receipts.v1.json
+++ b/packages/conformance-tests/fixtures/physical-ai/px4-offboard-policy-receipts.v1.json
@@ -14,7 +14,8 @@
     "velocitySetpointsRequireReview": true,
     "humanTakeoffZoneEscalates": true,
     "fenceChangesRequireEvidence": true,
-    "negativeOutcomesCarryReceipt": true
+    "negativeOutcomesCarryReceipt": true,
+    "px4EncryptedLogCorrelationRequired": true
   },
   "deployment": {
     "siteId": "drone-lab-01",
@@ -22,7 +23,9 @@
     "systemId": 11,
     "missionRef": "sint://mission/px4/px4-07/delivery-4481",
     "corridorRef": "sint://corridor/utm/delivery-zone-a",
-    "takeoffZoneId": "pad-3"
+    "takeoffZoneId": "pad-3",
+    "px4LogFormat": "ulge",
+    "px4LogEvidenceRef": "sint://evidence/px4/px4-07/delivery-4481"
   },
   "receiptSchema": {
     "requiredFields": [
@@ -224,6 +227,15 @@
       "corridorReceiptPresent": false,
       "policyViolated": "PX4_CORRIDOR_RECEIPT_REQUIRED",
       "receiptRequired": true
+    },
+    {
+      "id": "offboard_without_ulog_correlation_rejected",
+      "name": "Reject OFFBOARD action when encrypted-log correlation evidence is missing",
+      "expectedResource": "mavlink://11/cmd/mode",
+      "expectedDecision": "deny",
+      "expectedTier": "T3_commit",
+      "policyViolated": "PX4_ULOG_CORRELATION_REQUIRED",
+      "receiptRequired": true
     }
   ],
   "successCriteria": {
@@ -231,6 +243,7 @@
     "velocitySetpointsAreHighConsequence": true,
     "humanPresenceEscalatesToCommit": true,
     "missingCorridorReceiptDenied": true,
-    "allOutcomesCarryReceipts": true
+    "allOutcomesCarryReceipts": true,
+    "missingUlogCorrelationDenied": true
   }
 }

--- a/packages/conformance-tests/src/fixture-loader.ts
+++ b/packages/conformance-tests/src/fixture-loader.ts
@@ -1181,6 +1181,7 @@ export interface Px4OffboardPolicyReceiptsFixture {
     readonly humanTakeoffZoneEscalates: boolean;
     readonly fenceChangesRequireEvidence: boolean;
     readonly negativeOutcomesCarryReceipt: boolean;
+    readonly px4EncryptedLogCorrelationRequired: boolean;
   };
   readonly deployment: {
     readonly siteId: string;
@@ -1189,6 +1190,8 @@ export interface Px4OffboardPolicyReceiptsFixture {
     readonly missionRef: string;
     readonly corridorRef: string;
     readonly takeoffZoneId: string;
+    readonly px4LogFormat?: "ulge";
+    readonly px4LogEvidenceRef?: string;
   };
   readonly receiptSchema: {
     readonly requiredFields: readonly string[];
@@ -1227,7 +1230,7 @@ export interface Px4OffboardPolicyReceiptsFixture {
       readonly currentVelocityMps?: number;
     };
     readonly corridorReceiptPresent?: boolean;
-    readonly policyViolated?: "PX4_CORRIDOR_RECEIPT_REQUIRED";
+    readonly policyViolated?: "PX4_CORRIDOR_RECEIPT_REQUIRED" | "PX4_ULOG_CORRELATION_REQUIRED";
     readonly receiptRequired: boolean;
   }>;
   readonly successCriteria: {
@@ -1236,6 +1239,7 @@ export interface Px4OffboardPolicyReceiptsFixture {
     readonly humanPresenceEscalatesToCommit: boolean;
     readonly missingCorridorReceiptDenied: boolean;
     readonly allOutcomesCarryReceipts: boolean;
+    readonly missingUlogCorrelationDenied?: boolean;
   };
 }
 

--- a/packages/conformance-tests/src/px4-offboard-policy-receipts-conformance.test.ts
+++ b/packages/conformance-tests/src/px4-offboard-policy-receipts-conformance.test.ts
@@ -43,7 +43,11 @@ describe("PX4 offboard policy receipts fixture v1", () => {
       humanTakeoffZoneEscalates: true,
       fenceChangesRequireEvidence: true,
       negativeOutcomesCarryReceipt: true,
+      px4EncryptedLogCorrelationRequired: true,
     });
+
+    expect(fixture.deployment.px4LogFormat).toBe("ulge");
+    expect(fixture.deployment.px4LogEvidenceRef).toMatch(/^sint:\/\/evidence\/px4\//);
   });
 
   it("defines receipt fields that bind vehicle, mission corridor, mode, and decision", () => {
@@ -131,6 +135,18 @@ describe("PX4 offboard policy receipts fixture v1", () => {
     expect(item?.receiptRequired).toBe(true);
   });
 
+  it("rejects OFFBOARD transitions when encrypted-log correlation evidence is missing", () => {
+    const item = fixture.policyCases.find(
+      (caseItem) => caseItem.id === "offboard_without_ulog_correlation_rejected",
+    );
+
+    expect(item?.expectedResource).toBe("mavlink://11/cmd/mode");
+    expect(item?.expectedDecision).toBe("deny");
+    expect(item?.expectedTier).toBe(ApprovalTier.T3_COMMIT);
+    expect(item?.policyViolated).toBe("PX4_ULOG_CORRELATION_REQUIRED");
+    expect(item?.receiptRequired).toBe(true);
+  });
+
   it("keeps all outcomes receipt-backed", () => {
     expect(fixture.successCriteria).toEqual({
       armAndModeStayCommitTier: true,
@@ -138,6 +154,7 @@ describe("PX4 offboard policy receipts fixture v1", () => {
       humanPresenceEscalatesToCommit: true,
       missingCorridorReceiptDenied: true,
       allOutcomesCarryReceipts: true,
+      missingUlogCorrelationDenied: true,
     });
 
     for (const item of fixture.mappingCases) {


### PR DESCRIPTION
## Summary\n- extend PX4 offboard physical-AI fixture with encrypted-log correlation requirement\n- add explicit deny scenario for missing ULog correlation evidence\n- update loader typing for new requirement/policy code\n- extend conformance assertions for this boundary\n\n## Validation\n- 
> @pshkv/conformance-tests@0.1.0 test /Users/pshkv/sint-protocol/packages/conformance-tests
> vitest run "src/px4-offboard-policy-receipts-conformance.test.ts"


 RUN  v3.2.4 /Users/pshkv/sint-protocol/packages/conformance-tests

 ✓ src/px4-offboard-policy-receipts-conformance.test.ts (8 tests) 4ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  10:11:22
   Duration  1.38s (transform 201ms, setup 0ms, collect 312ms, tests 4ms, environment 0ms, prepare 88ms)\n\n## Tracking\n- Executes next step from #213 (PX4 encrypted-log evidence lane)