### PR TITLE
Add PX4 ULog correlation artifact conformance fixture

### DIFF
--- a/packages/conformance-tests/fixtures/physical-ai/px4-ulog-correlation-artifact.v1.json
+++ b/packages/conformance-tests/fixtures/physical-ai/px4-ulog-correlation-artifact.v1.json
@@ -1,0 +1,63 @@
+{
+  "fixtureId": "px4-ulog-correlation-artifact-v1",
+  "schemaVersion": "2026-05-25",
+  "description": "Conformance fixture for PX4 encrypted ULog correlation artifacts linked to SINT policy/evidence timelines.",
+  "requiredFields": [
+    "artifactVersion",
+    "artifactType",
+    "siteId",
+    "vehicleId",
+    "missionRef",
+    "requestId",
+    "tokenId",
+    "policyDecision",
+    "px4LogEvidence",
+    "correlation",
+    "review"
+  ],
+  "sample": {
+    "artifactVersion": "2026-05-25",
+    "artifactType": "px4-ulog-correlation",
+    "siteId": "drone-lab-01",
+    "vehicleId": "px4-07",
+    "missionRef": "sint://mission/px4/px4-07/delivery-4481",
+    "requestId": "01905f7c-0000-7000-8000-000000000011",
+    "tokenId": "01905f7c-0000-7000-8000-000000000012",
+    "policyDecision": {
+      "action": "escalate",
+      "assignedTier": "T3_commit",
+      "decisionEventType": "policy.evaluated",
+      "decisionEventHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "decisionTimestamp": "2026-05-25T17:20:00.000Z"
+    },
+    "px4LogEvidence": {
+      "logFormat": "ulge",
+      "encryptedLogDigest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "decryptedLogDigest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "keyRef": "kms://px4-log-keys/px4-07",
+      "decryptEnvironmentRef": "sint://runtime/review-env/forensics-01",
+      "ulogTimeWindow": {
+        "start": "2026-05-25T17:19:59.000Z",
+        "end": "2026-05-25T17:20:10.000Z"
+      }
+    },
+    "correlation": {
+      "matchedEvents": [
+        {
+          "type": "mavlink.mode_change",
+          "targetMode": "OFFBOARD",
+          "sintEventTimestamp": "2026-05-25T17:20:00.000Z",
+          "ulogTimestamp": "2026-05-25T17:20:00.121Z",
+          "deltaMs": 121
+        }
+      ],
+      "correlationStatus": "matched",
+      "maxAllowedDeltaMs": 1000
+    },
+    "review": {
+      "reviewedBy": "operator@example.com",
+      "reviewTimestamp": "2026-05-25T17:30:00.000Z",
+      "notes": "Mode change and first setpoint matched expected timeline."
+    }
+  }
+}

--- a/packages/conformance-tests/src/fixture-loader.ts
+++ b/packages/conformance-tests/src/fixture-loader.ts
@@ -1323,6 +1323,62 @@ export interface LeRobotPolicyActuationReceiptsFixture {
   };
 }
 
+export interface Px4UlogCorrelationArtifactFixture {
+  readonly fixtureId: string;
+  readonly schemaVersion: string;
+  readonly description: string;
+  readonly requiredFields: readonly string[];
+  readonly sample: {
+    readonly artifactVersion: string;
+    readonly artifactType: "px4-ulog-correlation";
+    readonly siteId: string;
+    readonly vehicleId: string;
+    readonly missionRef: string;
+    readonly requestId: string;
+    readonly tokenId: string;
+    readonly policyDecision: {
+      readonly action: "allow" | "deny" | "escalate" | "transform";
+      readonly assignedTier: ApprovalTier;
+      readonly decisionEventType: string;
+      readonly decisionEventHash: string;
+      readonly decisionTimestamp: string;
+    };
+    readonly px4LogEvidence: {
+      readonly logFormat: "ulge";
+      readonly encryptedLogDigest: string;
+      readonly decryptedLogDigest: string;
+      readonly keyRef: string;
+      readonly decryptEnvironmentRef: string;
+      readonly ulogTimeWindow: {
+        readonly start: string;
+        readonly end: string;
+      };
+    };
+    readonly correlation: {
+      readonly matchedEvents: readonly Array<{
+        readonly type: string;
+        readonly targetMode?: string;
+        readonly sintEventTimestamp: string;
+        readonly ulogTimestamp: string;
+        readonly deltaMs: number;
+      }>;
+      readonly correlationStatus: "matched" | "mismatch";
+      readonly maxAllowedDeltaMs: number;
+    };
+    readonly review: {
+      readonly reviewedBy: string;
+      readonly reviewTimestamp: string;
+      readonly notes: string;
+    };
+  };
+}
+
+export function loadPx4UlogCorrelationArtifactFixture(): Px4UlogCorrelationArtifactFixture {
+  return loadFixture<Px4UlogCorrelationArtifactFixture>(
+    "physical-ai/px4-ulog-correlation-artifact.v1.json",
+  );
+}
+
 export function loadLeRobotPolicyActuationReceiptsFixture(): LeRobotPolicyActuationReceiptsFixture {
   return loadFixture<LeRobotPolicyActuationReceiptsFixture>(
     "physical-ai/lerobot-policy-actuation-receipts.v1.json",

--- a/packages/conformance-tests/src/px4-ulog-correlation-artifact-conformance.test.ts
+++ b/packages/conformance-tests/src/px4-ulog-correlation-artifact-conformance.test.ts
@@ -1,0 +1,50 @@
+/**
+ * PX4 ULog correlation artifact conformance.
+ *
+ * Ensures the encrypted-log correlation artifact has the minimum
+ * fields/operators need for incident replay across SINT + PX4 timelines.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ApprovalTier } from "@pshkv/core";
+import { loadPx4UlogCorrelationArtifactFixture } from "./fixture-loader.js";
+
+describe("PX4 ULog correlation artifact fixture v1", () => {
+  const fixture = loadPx4UlogCorrelationArtifactFixture();
+
+  it("declares canonical artifact metadata", () => {
+    expect(fixture.fixtureId).toBe("px4-ulog-correlation-artifact-v1");
+    expect(fixture.sample.artifactType).toBe("px4-ulog-correlation");
+    expect(fixture.sample.px4LogEvidence.logFormat).toBe("ulge");
+  });
+
+  it("contains all required top-level fields", () => {
+    for (const field of fixture.requiredFields) {
+      expect(fixture.sample[field as keyof typeof fixture.sample], field).toBeTruthy();
+    }
+  });
+
+  it("binds policy decision and telemetry evidence with verifiable digests", () => {
+    const sample = fixture.sample;
+
+    expect(sample.policyDecision.action).toBe("escalate");
+    expect(sample.policyDecision.assignedTier).toBe(ApprovalTier.T3_COMMIT);
+    expect(sample.policyDecision.decisionEventType).toBe("policy.evaluated");
+    expect(sample.policyDecision.decisionEventHash).toMatch(/^[a-f0-9]{64}$/);
+
+    expect(sample.px4LogEvidence.encryptedLogDigest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(sample.px4LogEvidence.decryptedLogDigest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(sample.px4LogEvidence.keyRef).toMatch(/^kms:\/\//);
+  });
+
+  it("declares a bounded correlation window and timing threshold", () => {
+    const sample = fixture.sample;
+
+    expect(sample.correlation.correlationStatus).toBe("matched");
+    expect(sample.correlation.maxAllowedDeltaMs).toBeGreaterThan(0);
+    expect(sample.correlation.matchedEvents.length).toBeGreaterThan(0);
+
+    const first = sample.correlation.matchedEvents[0];
+    expect(first.deltaMs).toBeLessThanOrEqual(sample.correlation.maxAllowedDeltaMs);
+  });
+});


### PR DESCRIPTION
## Summary\n- add canonical PX4 ULog correlation artifact fixture ()\n- extend fixture loader with typed interface + loader helper\n- add conformance test for required fields, digest formats, and timing threshold invariants\n\n## Validation\n- 
> @pshkv/conformance-tests@0.1.0 test /Users/pshkv/sint-protocol/packages/conformance-tests
> vitest run "src/px4-ulog-correlation-artifact-conformance.test.ts" "src/px4-offboard-policy-receipts-conformance.test.ts"


 RUN  v3.2.4 /Users/pshkv/sint-protocol/packages/conformance-tests

 ✓ src/px4-ulog-correlation-artifact-conformance.test.ts (4 tests) 3ms
 ✓ src/px4-offboard-policy-receipts-conformance.test.ts (8 tests) 4ms

 Test Files  2 passed (2)
      Tests  12 passed (12)
   Start at  10:36:02
   Duration  697ms (transform 164ms, setup 0ms, collect 369ms, tests 7ms, environment 0ms, prepare 171ms)\n\n## Tracking\n- continues #213 execution lane