### PR TITLE
Remediate fast-uri dependency advisory path

### DIFF
--- a/docs/reports/px4-ulog-correlation-artifact.sample.json
+++ b/docs/reports/px4-ulog-correlation-artifact.sample.json
@@ -32,12 +32,6 @@
         "sintEventTimestamp": "2026-05-25T17:20:00.000Z",
         "ulogTimestamp": "2026-05-25T17:20:00.121Z",
         "deltaMs": 121
-      },
-      {
-        "type": "mavlink.setpoint_velocity",
-        "sintEventTimestamp": "2026-05-25T17:20:00.230Z",
-        "ulogTimestamp": "2026-05-25T17:20:00.341Z",
-        "deltaMs": 111
       }
     ],
     "correlationStatus": "matched",
@@ -46,6 +40,6 @@
   "review": {
     "reviewedBy": "operator@example.com",
     "reviewTimestamp": "2026-05-25T17:30:00.000Z",
-    "notes": "OFFBOARD transition and first velocity setpoint matched policy timeline. No anomaly observed."
+    "notes": "Mode change and first setpoint matched expected timeline."
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "pnpm": {
     "overrides": {
+      "fast-uri": ">=3.1.2",
       "path-to-regexp": ">=8.4.0",
       "picomatch": ">=4.0.4"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  fast-uri: '>=3.1.2'
   path-to-regexp: '>=8.4.0'
   picomatch: '>=4.0.4'
 
@@ -2426,8 +2427,8 @@ packages:
     resolution: {integrity: sha512-nDA9ADeINN8SA2u2wCtU+siWFTTDqQR37XvgPIDDmboWQeExz7X0mImxuaN+kJddliIqy2FpVRmnvRZ+j8i1/A==}
     engines: {node: '>=18.2.0'}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -4453,7 +4454,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4837,7 +4838,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       tslib: 2.8.1
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:


### PR DESCRIPTION
## Summary\n- add pnpm override for  to \n- refresh lockfile so transitive resolution uses patched version\n\n## Validation\n- Scope: all 48 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date

Done in 1.2s\n- {
  "actions": [
    {
      "action": "update",
      "resolves": [
        {
          "id": 1118827,
          "path": "examples__notes-server>@modelcontextprotocol/sdk>express-rate-limit>ip-address",
          "dev": false,
          "optional": false,
          "bundled": false
        }
      ],
      "module": "express-rate-limit",
      "target": "8.5.2",
      "depth": 3
    },
    {
      "action": "update",
      "resolves": [
        {
          "id": 1119502,
          "path": "examples__notes-server>@modelcontextprotocol/sdk>express>qs",
          "dev": false,
          "optional": false,
          "bundled": false
        }
      ],
      "module": "qs",
      "target": "6.15.2",
      "depth": 4
    },
    {
      "action": "review",
      "module": "hono",
      "resolves": [
        {
          "id": 1116244,
          "path": "apps__badge-server>hono",
          "dev": false,
          "optional": false,
          "bundled": false
        },
        {
          "id": 1116277,
          "path": "apps__badge-server>hono",
          "dev": false,
          "optional": false,
          "bundled": false
        },
        {
          "id": 1116279,
          "path": "apps__badge-server>hono",
          "dev": false,
          "optional": false,
          "bundled": false
        },
        {
          "id": 1116280,
          "path": "apps__badge-server>hono",
          "dev": false,
          "optional": false,
          "bundled": false
        },
        {
          "id": 1116669,
          "path": "apps__badge-server>hono",
          "dev": false,
          "optional": false,
          "bundled": false
        },
        {
          "id": 1117087,
          "path": "apps__badge-server>hono",
          "dev": false,
          "optional": false,
          "bundled": false
        },
        {
          "id": 1117915,
          "path": "apps__badge-server>hono",
          "dev": false,
          "optional": false,
          "bundled": false
        },
        {
          "id": 1118963,
          "path": "apps__badge-server>hono",
          "dev": false,
          "optional": false,
          "bundled": false
        },
        {
          "id": 1118964,
          "path": "apps__badge-server>hono",
          "dev": false,
          "optional": false,
          "bundled": false
        },
        {
          "id": 1118982,
          "path": "apps__badge-server>hono",
          "dev": false,
          "optional": false,
          "bundled": false
        },
        {
          "id": 1118983,
          "path": "apps__badge-server>hono",
          "dev": false,
          "optional": false,
          "bundled": false
        }
      ]
    },
    {
      "action": "review",
      "module": "@hono/node-server",
      "resolves": [
        {
          "id": 1116281,
          "path": "apps__badge-server>@hono/node-server",
          "dev": false,
          "optional": false,
          "bundled": false
        }
      ]
    },
    {
      "action": "review",
      "module": "ws",
      "resolves": [
        {
          "id": 1119108,
          "path": "apps__gateway-server>ws",
          "dev": false,
          "optional": false,
          "bundled": false
        }
      ]
    }
  ],
  "advisories": {
    "1116244": {
      "findings": [
        {
          "version": "4.12.8",
          "paths": [
            "apps/badge-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/badge-server > hono@4.12.8",
            "apps/gateway-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/gateway-server > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > @hono/node-server@1.19.11 > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > hono@4.12.8"
          ]
        }
      ],
      "found_by": null,
      "deleted": null,
      "references": "- https://github.com/honojs/hono/security/advisories/GHSA-26pp-8wgv-hjvm\n- https://github.com/honojs/hono/commit/a586cd72e3f6122792e631ecf1817e5cabb803ec\n- https://github.com/honojs/hono/releases/tag/v4.12.12\n- https://github.com/advisories/GHSA-26pp-8wgv-hjvm",
      "created": "2026-04-08T00:17:02.000Z",
      "id": 1116244,
      "npm_advisory_id": null,
      "overview": "## Summary\n\nCookie names are not validated on the write path when using `setCookie()`, `serialize()`, or `serializeSigned()` to generate Set-Cookie headers.\n\nWhile certain cookie attributes such as domain and path are validated, the cookie name itself may contain invalid characters.\n\nThis results in inconsistent handling of cookie names between parsing (read path) and serialization (write path).\n\n## Details\n\nWhen applications use `setCookie()`, `serialize()`, or `serializeSigned()` with a user-controlled cookie name, invalid values (e.g., containing control characters such as `\\r` or `\\n`) can be used to construct malformed `Set-Cookie` header values.\n\nFor example:\n\n```\nSet-Cookie: legit\nX-Injected: evil=value\n```\n\nHowever, in modern runtimes such as Node.js and Cloudflare Workers, such invalid header values are rejected and result in a runtime error before the response is sent.\n\nAs a result, the reported header injection / response splitting behavior could not be reproduced in these environments.\n\n## Impact\n\nApplications that pass untrusted input as the cookie name to `setCookie()`, `serialize()`, or `serializeSigned()` may encounter runtime errors due to invalid header values.\n\nIn tested environments, malformed `Set-Cookie` headers are rejected before being sent, and the reported header injection behavior could not be reproduced.\n\nThis issue primarily affects correctness and robustness rather than introducing a confirmed exploitable vulnerability.",
      "reported_by": null,
      "title": "Hono missing validation of cookie name on write path in setCookie()",
      "metadata": null,
      "cves": [],
      "access": "public",
      "severity": "moderate",
      "module_name": "hono",
      "vulnerable_versions": "<4.12.12",
      "github_advisory_id": "GHSA-26pp-8wgv-hjvm",
      "recommendation": "Upgrade to version 4.12.12 or later",
      "patched_versions": ">=4.12.12",
      "updated": "2026-04-08T00:17:04.000Z",
      "cvss": {
        "score": 5.3,
        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
      },
      "cwe": [
        "CWE-113"
      ],
      "url": "https://github.com/advisories/GHSA-26pp-8wgv-hjvm"
    },
    "1116277": {
      "findings": [
        {
          "version": "4.12.8",
          "paths": [
            "apps/badge-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/badge-server > hono@4.12.8",
            "apps/gateway-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/gateway-server > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > @hono/node-server@1.19.11 > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > hono@4.12.8"
          ]
        }
      ],
      "found_by": null,
      "deleted": null,
      "references": "- https://github.com/honojs/hono/security/advisories/GHSA-r5rp-j6wh-rvv4\n- https://github.com/honojs/hono/commit/cc067c85592415cb1880ad3c61ed923472452ec0\n- https://github.com/honojs/hono/releases/tag/v4.12.12\n- https://nvd.nist.gov/vuln/detail/CVE-2026-39410\n- https://github.com/advisories/GHSA-r5rp-j6wh-rvv4",
      "created": "2026-04-08T00:17:21.000Z",
      "id": 1116277,
      "npm_advisory_id": null,
      "overview": "## Summary\n\nA discrepancy between browser cookie parsing and `parse()` handling allows cookie prefix protections to be bypassed.\n\nCookie names that are treated as distinct by the browser may be normalized to the same key by `parse()`, allowing attacker-controlled cookies to override legitimate ones.\n\n## Details\n\nBrowsers follow RFC 6265bis and only trim SP (`0x20`) and HTAB (`0x09`) from cookie names. Other characters, such as the non-breaking space (`U+00A0`), are preserved as part of the cookie name.\n\nFor example, the browser treats the following cookies as distinct:\n\n```\n\"dummy-cookie\"\n\"\\u00a0dummy-cookie\"\n```\n\nHowever, `parse()` previously used JavaScript's `trim()`, which removes a broader set of characters including `U+00A0`. As a result, both names are normalized to:\n\n```\n\"dummy-cookie\"\n```\n\nThis mismatch allows attacker-controlled cookies with a `U+00A0` prefix to shadow or override legitimate cookies when accessed via `getCookie()`.\n\n## Impact\n\nAn attacker who can set cookies (e.g., via a man-in-the-middle on a non-secure page or other injection vector) can bypass cookie prefix protections and override sensitive cookies.\n\nThis may lead to:\n\n* Bypassing `__Secure-` and `__Host-` prefix protections\n* Overriding cookies that rely on the Secure attribute\n* Session fixation or session hijacking depending on application usage\n\nThis issue affects applications that rely on `getCookie()` for security-sensitive cookie handling.",
      "reported_by": null,
      "title": "Hono: Non-breaking space prefix bypass in cookie name handling in getCookie()",
      "metadata": null,
      "cves": [
        "CVE-2026-39410"
      ],
      "access": "public",
      "severity": "moderate",
      "module_name": "hono",
      "vulnerable_versions": "<4.12.12",
      "github_advisory_id": "GHSA-r5rp-j6wh-rvv4",
      "recommendation": "Upgrade to version 4.12.12 or later",
      "patched_versions": ">=4.12.12",
      "updated": "2026-04-08T15:34:50.000Z",
      "cvss": {
        "score": 4.8,
        "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
      },
      "cwe": [
        "CWE-20"
      ],
      "url": "https://github.com/advisories/GHSA-r5rp-j6wh-rvv4"
    },
    "1116279": {
      "findings": [
        {
          "version": "4.12.8",
          "paths": [
            "apps/badge-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/badge-server > hono@4.12.8",
            "apps/gateway-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/gateway-server > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > @hono/node-server@1.19.11 > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > hono@4.12.8"
          ]
        }
      ],
      "found_by": null,
      "deleted": null,
      "references": "- https://github.com/honojs/hono/security/advisories/GHSA-xf4j-xp2r-rqqx\n- https://github.com/honojs/hono/commit/b470278920fffcfd6d76002755d6db53db827679\n- https://github.com/honojs/hono/releases/tag/v4.12.12\n- https://nvd.nist.gov/vuln/detail/CVE-2026-39408\n- https://github.com/advisories/GHSA-xf4j-xp2r-rqqx",
      "created": "2026-04-08T00:16:51.000Z",
      "id": 1116279,
      "npm_advisory_id": null,
      "overview": "## Summary\n\nA path traversal issue in `toSSG()` allows files to be written outside the configured output directory during static site generation. When using dynamic route parameters via `ssgParams`, specially crafted values can cause generated file paths to escape the intended output directory.\n\n## Details\n\nThe static site generation process creates output files based on route paths derived from application routes and parameters. When `ssgParams` is used to provide values for dynamic routes, those values are used to construct output file paths. If these values contain traversal sequences (e.g. `..`), the resulting output path may resolve outside the configured output directory. As a result, files may be written to unintended locations instead of being confined within the specified output directory.\n\nFor example:\n \n```ts\nimport { Hono } from 'hono'\nimport { toSSG, ssgParams } from 'hono/ssg'\n\nconst app = new Hono()\n\napp.get('/:id', ssgParams([{ id: '../pwned' }]), (c) => {\n  return c.text('pwned')\n})\n\ntoSSG(app, fs, { dir: './static' })\n```\n\nIn this case, the generated output path may resolve outside `./static`, resulting in a file being written outside the intended output directory.\n\n## Impact\n\nAn attacker who can influence values passed to `ssgParams` during the build process may be able to write files outside the intended output directory.\n\nDepending on the build and deployment environment, this may:\n\n* overwrite unintended files\n* affect generated artifacts\n* impact deployment outputs or downstream tooling\n\nThis issue is limited to build-time static site generation and does not affect request-time routing.",
      "reported_by": null,
      "title": "Hono: Path traversal in toSSG() allows writing files outside the output directory",
      "metadata": null,
      "cves": [
        "CVE-2026-39408"
      ],
      "access": "public",
      "severity": "moderate",
      "module_name": "hono",
      "vulnerable_versions": ">=4.0.0 <=4.12.11",
      "github_advisory_id": "GHSA-xf4j-xp2r-rqqx",
      "recommendation": "Upgrade to version 4.12.12 or later",
      "patched_versions": ">=4.12.12",
      "updated": "2026-04-08T15:34:40.000Z",
      "cvss": {
        "score": 0,
        "vectorString": null
      },
      "cwe": [
        "CWE-22"
      ],
      "url": "https://github.com/advisories/GHSA-xf4j-xp2r-rqqx"
    },
    "1116280": {
      "findings": [
        {
          "version": "4.12.8",
          "paths": [
            "apps/badge-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/badge-server > hono@4.12.8",
            "apps/gateway-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/gateway-server > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > @hono/node-server@1.19.11 > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > hono@4.12.8"
          ]
        }
      ],
      "found_by": null,
      "deleted": null,
      "references": "- https://github.com/honojs/hono/security/advisories/GHSA-wmmm-f939-6g9c\n- https://github.com/honojs/hono/commit/9aff14bd727f8b0435c963363fd803260e7b8e3c\n- https://github.com/honojs/hono/releases/tag/v4.12.12\n- https://nvd.nist.gov/vuln/detail/CVE-2026-39407\n- https://github.com/advisories/GHSA-wmmm-f939-6g9c",
      "created": "2026-04-08T00:16:45.000Z",
      "id": 1116280,
      "npm_advisory_id": null,
      "overview": "## Summary\n\nA path handling inconsistency in `serveStatic` allows protected static files to be accessed by using repeated slashes (`//`) in the request path.\n\nWhen route-based middleware (e.g., `/admin/*`) is used for authorization, the router may not match paths containing repeated slashes, while serveStatic resolves them as normalized paths. This can lead to a middleware bypass.\n\n## Details\n\nThe routing layer and `serveStatic` handle repeated slashes differently.\n\nFor example:\n\n```\n/admin/secret.txt => matches /admin/*\n/admin//secret.txt => may not match /admin/*\n```\n\nHowever, `serveStatic` may interpret both paths as the same file location (e.g., `admin/secret.txt`) and return the file.\n\nThis inconsistency allows a request such as:\n\n```\nGET //admin/secret.txt\n```\n\nto bypass middleware registered on `/admin/*` and access protected files.\n\nThe issue has been fixed by rejecting paths that contain repeated slashes, ensuring consistent behavior between route matching and static file resolution.\n\n## Impact\n\nAn attacker can access static files that are intended to be protected by route-based middleware by using repeated slashes in the request path.\n\nThis can lead to unauthorized access to sensitive files under the static root.\n\nThis issue affects applications that rely on serveStatic together with route-based middleware for access control.",
      "reported_by": null,
      "title": "Hono: Middleware bypass via repeated slashes in serveStatic",
      "metadata": null,
      "cves": [
        "CVE-2026-39407"
      ],
      "access": "public",
      "severity": "moderate",
      "module_name": "hono",
      "vulnerable_versions": "<4.12.12",
      "github_advisory_id": "GHSA-wmmm-f939-6g9c",
      "recommendation": "Upgrade to version 4.12.12 or later",
      "patched_versions": ">=4.12.12",
      "updated": "2026-04-08T15:34:35.000Z",
      "cvss": {
        "score": 5.3,
        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
      },
      "cwe": [
        "CWE-22"
      ],
      "url": "https://github.com/advisories/GHSA-wmmm-f939-6g9c"
    },
    "1116281": {
      "findings": [
        {
          "version": "1.19.11",
          "paths": [
            "apps/badge-server > @hono/node-server@1.19.11",
            "apps/gateway-server > @hono/node-server@1.19.11",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > @hono/node-server@1.19.11"
          ]
        }
      ],
      "found_by": null,
      "deleted": null,
      "references": "- https://github.com/honojs/node-server/security/advisories/GHSA-92pp-h63x-v22m\n- https://github.com/honojs/node-server/commit/025c30f55d589ddbe6048b151d77e904f67a8cc2\n- https://github.com/honojs/node-server/releases/tag/v1.19.13\n- https://nvd.nist.gov/vuln/detail/CVE-2026-39406\n- https://github.com/advisories/GHSA-92pp-h63x-v22m",
      "created": "2026-04-08T00:16:39.000Z",
      "id": 1116281,
      "npm_advisory_id": null,
      "overview": "## Summary\n\nA path handling inconsistency in `serveStatic` allows protected static files to be accessed by using repeated slashes (`//`) in the request path.\n\nWhen route-based middleware (e.g., `/admin/*`) is used for authorization, the router may not match paths containing repeated slashes, while `serveStatic` resolves them as normalized paths. This can lead to a middleware bypass.\n\n## Details\n\nThe routing layer and `serveStatic` handle repeated slashes differently.\n\nFor example:\n\n- `/admin/secret.txt` => matches `/admin/*`\n- `//admin/secret.txt` => may not match `/admin/*`\n\nThis inconsistency allows a request such as:\n\n```\nGET //admin/secret.txt\n```\n\nto bypass middleware registered on `/admin/*` and access protected files.\n\n## Impact\n\nAn attacker can access static files that are intended to be protected by route-based middleware by using repeated slashes in the request path.\n\nThis can lead to unauthorized access to sensitive files under the static root.\n\nThis issue affects applications that rely on `serveStatic` together with route-based middleware for access control.",
      "reported_by": null,
      "title": "@hono/node-server: Middleware bypass via repeated slashes in serveStatic",
      "metadata": null,
      "cves": [
        "CVE-2026-39406"
      ],
      "access": "public",
      "severity": "moderate",
      "module_name": "@hono/node-server",
      "vulnerable_versions": "<1.19.13",
      "github_advisory_id": "GHSA-92pp-h63x-v22m",
      "recommendation": "Upgrade to version 1.19.13 or later",
      "patched_versions": ">=1.19.13",
      "updated": "2026-04-08T15:34:25.000Z",
      "cvss": {
        "score": 5.3,
        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
      },
      "cwe": [
        "CWE-22"
      ],
      "url": "https://github.com/advisories/GHSA-92pp-h63x-v22m"
    },
    "1116669": {
      "findings": [
        {
          "version": "4.12.8",
          "paths": [
            "apps/badge-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/badge-server > hono@4.12.8",
            "apps/gateway-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/gateway-server > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > @hono/node-server@1.19.11 > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > hono@4.12.8"
          ]
        }
      ],
      "found_by": null,
      "deleted": null,
      "references": "- https://github.com/honojs/hono/security/advisories/GHSA-458j-xx4x-4375\n- https://github.com/advisories/GHSA-458j-xx4x-4375",
      "created": "2026-04-16T01:02:24.000Z",
      "id": 1116669,
      "npm_advisory_id": null,
      "overview": "## Summary\n\nImproper handling of JSX attribute names in hono/jsx allows malformed attribute keys to corrupt the generated HTML output.\n\nWhen untrusted input is used as attribute keys during server-side rendering, specially crafted keys can break out of attribute or tag boundaries and inject unintended HTML.\n\n## Details\n\nWhen rendering JSX elements to HTML strings, attribute values are escaped, but attribute names (keys) were previously inserted into the output without validation.\n\nIf an attribute name contains characters such as `\"`, `>`, or whitespace, it can alter the structure of the generated HTML.\n\nFor example, malformed attribute names can:\n\n* Break out of the current attribute and introduce unintended additional attributes\n* Break out of the current HTML tag and inject new elements into the output\n\nThis issue arises when untrusted input (such as query parameters or form data) is used as JSX attribute keys during server-side rendering.\n\n## Impact\n\nAn attacker who can control attribute keys used in JSX rendering may inject unintended attributes or HTML elements into the generated output.\n\nThis may lead to:\n\n* Injection of unexpected HTML attributes\n* Corruption of the HTML structure\n* Potential cross-site scripting (XSS) if combined with unsafe usage patterns\n\nThis issue affects applications that pass untrusted input as JSX attribute keys during server-side rendering.",
      "reported_by": null,
      "title": "hono Improperly Handles JSX Attribute Names Allows HTML Injection in hono/jsx SSR",
      "metadata": null,
      "cves": [],
      "access": "public",
      "severity": "moderate",
      "module_name": "hono",
      "vulnerable_versions": "<4.12.14",
      "github_advisory_id": "GHSA-458j-xx4x-4375",
      "recommendation": "Upgrade to version 4.12.14 or later",
      "patched_versions": ">=4.12.14",
      "updated": "2026-04-16T01:02:26.000Z",
      "cvss": {
        "score": 4.3,
        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N"
      },
      "cwe": [
        "CWE-79"
      ],
      "url": "https://github.com/advisories/GHSA-458j-xx4x-4375"
    },
    "1117087": {
      "findings": [
        {
          "version": "4.12.8",
          "paths": [
            "apps/badge-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/badge-server > hono@4.12.8",
            "apps/gateway-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/gateway-server > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > @hono/node-server@1.19.11 > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > hono@4.12.8"
          ]
        }
      ],
      "found_by": null,
      "deleted": null,
      "references": "- https://github.com/honojs/hono/security/advisories/GHSA-xpcf-pg52-r92g\n- https://github.com/honojs/hono/commit/48fa2233bc092f650119f42df043050737cabf39\n- https://github.com/honojs/hono/releases/tag/v4.12.12\n- https://nvd.nist.gov/vuln/detail/CVE-2026-39409\n- https://github.com/advisories/GHSA-xpcf-pg52-r92g",
      "created": "2026-04-08T00:17:14.000Z",
      "id": 1117087,
      "npm_advisory_id": null,
      "overview": "## Summary\n\n`ipRestriction()` does not canonicalize IPv4-mapped IPv6 client addresses (e.g. `::ffff:127.0.0.1`) before applying IPv4 allow or deny rules. In environments such as Node.js dual-stack, this can cause IPv4 rules to fail to match, leading to unintended authorization behavior.\n\n## Details\n\nThe middleware classifies client addresses based on their textual form. Addresses containing \"`:`\" are treated as IPv6, including IPv4-mapped IPv6 addresses such as `::ffff:127.0.0.1`. These addresses are not normalized to IPv4 before matching.\n\nAs a result:\n\n* IPv4 static rules (e.g. `127.0.0.1`) do not match because the raw string differs\n* IPv4 CIDR rules (e.g. `127.0.0.0/8`, `10.0.0.0/8`) are skipped because the address is treated as IPv6\n\nFor example, with:\n\n`denyList: ['127.0.0.1']`\n\na request from `127.0.0.1` may be represented as `::ffff:127.0.0.1` and bypass the deny rule.\n\nThis behavior commonly occurs in Node.js environments where IPv4 clients are exposed as IPv4-mapped IPv6 addresses.\n\n## Impact\n\nApplications that rely on IPv4-based `ipRestriction()` rules may incorrectly allow or deny requests.\n\nIn affected deployments, a denied IPv4 client may bypass access restrictions. Conversely, legitimate clients may be rejected when using IPv4 allow lists.",
      "reported_by": null,
      "title": "Hono has incorrect IP matching in ipRestriction() for IPv4-mapped IPv6 addresses",
      "metadata": null,
      "cves": [
        "CVE-2026-39409"
      ],
      "access": "public",
      "severity": "moderate",
      "module_name": "hono",
      "vulnerable_versions": "<4.12.12",
      "github_advisory_id": "GHSA-xpcf-pg52-r92g",
      "recommendation": "Upgrade to version 4.12.12 or later",
      "patched_versions": ">=4.12.12",
      "updated": "2026-04-24T21:06:14.000Z",
      "cvss": {
        "score": 5.3,
        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
      },
      "cwe": [
        "CWE-180"
      ],
      "url": "https://github.com/advisories/GHSA-xpcf-pg52-r92g"
    },
    "1117915": {
      "findings": [
        {
          "version": "4.12.8",
          "paths": [
            "apps/badge-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/badge-server > hono@4.12.8",
            "apps/gateway-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/gateway-server > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > @hono/node-server@1.19.11 > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > hono@4.12.8"
          ]
        }
      ],
      "found_by": null,
      "deleted": null,
      "references": "- https://github.com/honojs/hono/security/advisories/GHSA-qp7p-654g-cw7p\n- https://github.com/advisories/GHSA-qp7p-654g-cw7p",
      "created": "2026-05-09T00:46:44.000Z",
      "id": 1117915,
      "npm_advisory_id": null,
      "overview": "### Summary\n\nThe JSX renderer escapes `style` attribute object values for HTML but not for CSS. Untrusted input in a `style` object value or property name can therefore inject additional CSS declarations into the rendered `style` attribute. The impact is limited to CSS and does not allow JavaScript execution or HTML attribute breakout.\n\n### Details\n\n`style` object values are serialized into a CSS declaration list and escaped for HTML attribute context only. Characters that act as CSS declaration boundaries — such as `;`, comment markers, quoted strings, and block delimiters — are valid in HTML attribute content and can extend a value beyond its assigned property.\n\nThis issue arises when untrusted input is interpolated into a JSX `style` object and rendered server-side.\n\n### Impact\n\nAn attacker who can control the value or property name of a `style` object may inject arbitrary CSS declarations. This may lead to:\n\n- Visual manipulation of the page, including full-viewport overlays usable for phishing\n- Outbound requests to attacker-controlled hosts via CSS resource references such as `url(...)`\n- Hijacking of UI affordances through layout, positioning, or visibility changes\n\nThis issue affects applications that render JSX on the server with `style` object values or property names derived from untrusted input.",
      "reported_by": null,
      "title": "Hono has CSS Declaration Injection via Style Object Values in JSX SSR",
      "metadata": null,
      "cves": [
        "CVE-2026-44458"
      ],
      "access": "public",
      "severity": "moderate",
      "module_name": "hono",
      "vulnerable_versions": "<4.12.18",
      "github_advisory_id": "GHSA-qp7p-654g-cw7p",
      "recommendation": "Upgrade to version 4.12.18 or later",
      "patched_versions": ">=4.12.18",
      "updated": "2026-05-09T00:46:44.000Z",
      "cvss": {
        "score": 4.3,
        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N"
      },
      "cwe": [
        "CWE-74",
        "CWE-116"
      ],
      "url": "https://github.com/advisories/GHSA-qp7p-654g-cw7p"
    },
    "1118827": {
      "findings": [
        {
          "version": "10.1.0",
          "paths": [
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > express-rate-limit@8.3.1 > ip-address@10.1.0",
            "packages/bridge-mqtt > mqtt@5.15.1 > socks@2.8.7 > ip-address@10.1.0"
          ]
        }
      ],
      "found_by": null,
      "deleted": null,
      "references": "- https://github.com/beaugunderson/ip-address/security/advisories/GHSA-v2v4-37r5-5v8g\n- https://nvd.nist.gov/vuln/detail/CVE-2026-42338\n- https://github.com/advisories/GHSA-v2v4-37r5-5v8g",
      "created": "2026-05-05T21:50:58.000Z",
      "id": 1118827,
      "npm_advisory_id": null,
      "overview": "### Summary\n\n`Address6.group()` and `Address6.link()` do not HTML-escape attacker-controlled content before embedding it in the HTML strings they return, and `AddressError.parseMessage` (emitted by the `Address6` constructor for invalid input) can contain unescaped attacker-controlled content in one branch. An application that (1) passes untrusted input to `Address6` and (2) renders the output of these methods, or the thrown error's `parseMessage`, as HTML (e.g. via `innerHTML`) is vulnerable to cross-site scripting. A related issue in `v6.helpers.spanAll()` produced malformed markup but was not exploitable; it is hardened in the same release for consistency.\n\n### Details\n\nFour related issues were identified and fixed together:\n\n1. **`Address6.group()`: zone ID injection.** The `Address6` constructor stores the raw input (including any IPv6 zone ID) in `this.address` before zone stripping. `group()` then passed `this.address` to `helpers.simpleGroup()`, which wrapped each `:`-separated segment in a `<span>` element without HTML-escaping the content. A zone ID containing HTML markup was embedded verbatim.\n2. **`Address6.link({ prefix, className })`: attribute-value injection.** `link()` concatenated user-supplied `prefix` and `className` into the `href=\"…\"` and `class=\"…\"` attributes without escaping. A caller passing untrusted content through these options could inject event handlers (e.g. `onmouseover`) and achieve XSS.\n3. **`Address6` constructor: leading-zero IPv4 error path.** The leading-zero branch in `parse4in6()` built `AddressError.parseMessage` by concatenating the raw address through `String.replace()`. Because `parse4in6()` runs before the bad-character check, any characters in the groups preceding the IPv4 suffix flowed into the error's HTML unescaped. Consumers who render `parseMessage` as HTML (its documented purpose — it already contains `<span class=\"parse-error\">` markup) could be XSS'd by a crafted input such as `<img src=x onerror=alert(1)>:10.0.01.1`.\n4. **`v6.helpers.spanAll()`: attribute-value injection (defense in depth).** `spanAll()` embedded each character of its input into a `class=\"digit value-${n} …\"` attribute without escaping. Because `split('')` limits `n` to a single character this was not exploitable in practice, but it produced malformed markup and is fixed for consistency.\n\n### Affected Versions\n\nAll versions up to and including `10.1.0`.\n\n### Patched Version\n\n`10.1.1`.\n\n### Impact\n\nReal-world exposure is believed to be extremely limited. Analysis of all 425 dependent npm packages as well as GitHub code search found zero consumers of `group()`, `link()`, or `spanAll()`: these HTML-emitting surfaces appear to be unused across published npm packages and public repositories. Applications using only the address-parsing and comparison APIs (`isValid`, `correctForm`, `isInSubnet`, `bigInt`, etc.) are not affected.\n\nConsumers who **do** render the output of `group()`, `link()`, `spanAll()`, or `AddressError.parseMessage` as HTML against untrusted input should upgrade.\n\n### PoC\n\n```javascript\nconst { Address6 } = require('ip-address');\nconst addr = new Address6('fe80::1%<img src=x onerror=alert(1)>');\ndocument.body.innerHTML = addr.group();  // fires the onerror handler in 10.1.0\n```\n\n### Workarounds\n\nIf users cannot upgrade immediately:\n\n- Do not pass untrusted input to the `Address6` constructor, or\n- Never render the output of `group()`, `link()`, or `spanAll()`, nor the `parseMessage` field of any thrown `AddressError`, as HTML; treat these values as text only, or run them through [DOMPurify](https://github.com/cure53/DOMPurify) before inserting into the DOM (DOMPurify's default configuration preserves the library's intended `<span>` wrapping while stripping any injected event handlers), or\n- Validate input with `Address6.isValid()` and reject anything that contains a zone identifier (a `%` character) or characters outside `[0-9a-fA-F:/]` before passing it to the constructor.\n\n### Lack of separate CVEs\n\nGiven the evidence that these methods are not used, and given that they are all of the same construction, maintainers do not think it's relevant or useful to create a separate CVE for each library method.\n\n### Credit\n\nip-address thanks @scovetta for reporting this issue.",
      "reported_by": null,
      "title": "ip-address has XSS in Address6 HTML-emitting methods",
      "metadata": null,
      "cves": [
        "CVE-2026-42338"
      ],
      "access": "public",
      "severity": "moderate",
      "module_name": "ip-address",
      "vulnerable_versions": "<=10.1.0",
      "github_advisory_id": "GHSA-v2v4-37r5-5v8g",
      "recommendation": "Upgrade to version 10.1.1 or later",
      "patched_versions": ">=10.1.1",
      "updated": "2026-05-13T16:27:25.000Z",
      "cvss": {
        "score": 0,
        "vectorString": null
      },
      "cwe": [
        "CWE-79"
      ],
      "url": "https://github.com/advisories/GHSA-v2v4-37r5-5v8g"
    },
    "1118963": {
      "findings": [
        {
          "version": "4.12.8",
          "paths": [
            "apps/badge-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/badge-server > hono@4.12.8",
            "apps/gateway-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/gateway-server > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > @hono/node-server@1.19.11 > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > hono@4.12.8"
          ]
        }
      ],
      "found_by": null,
      "deleted": null,
      "references": "- https://github.com/honojs/hono/security/advisories/GHSA-hm8q-7f3q-5f36\n- https://nvd.nist.gov/vuln/detail/CVE-2026-44459\n- https://github.com/advisories/GHSA-hm8q-7f3q-5f36",
      "created": "2026-05-09T00:45:19.000Z",
      "id": 1118963,
      "npm_advisory_id": null,
      "overview": "### Summary\n\nImproper validation of the JWT NumericDate claims `exp`, `nbf`, and `iat` in `hono/utils/jwt` allows tokens with non-spec-compliant claim values to silently bypass time-based checks. This issue is not exploitable by an anonymous attacker; it only manifests when a malformed claim value reaches `verify()` — typically when the application itself issues such tokens, or when the signing key is otherwise under attacker control.\n\n### Details\n\nThe validation routine combined option, presence, and threshold checks in a single short-circuiting expression, so several classes of malformed values were silently skipped instead of rejected:\n\n- A falsy numeric value short-circuited the presence check.\n- A non-finite numeric value compared as never-after-now and never-expired.\n- A non-numeric type produced NaN comparisons that evaluated false.\n\nThis deviates from RFC 7519 §4.1.4, which defines NumericDate as a finite JSON numeric value.\n\n### Impact\n\nAn actor able to issue tokens accepted by the application may craft tokens whose `exp`, `nbf`, or `iat` claims silently bypass time-based enforcement. This may lead to:\n\n- Tokens treated as never expiring even with `exp` configured on the verifier.\n- Tokens with a future `nbf` accepted as currently valid.\n- Tokens with a future `iat` accepted as legitimately issued.\n\nDeployments using a well-formed token issuer and protecting the signing key are not affected.",
      "reported_by": null,
      "title": "Hono has improper validation of NumericDate claims (exp, nbf, iat) in JWT verify()",
      "metadata": null,
      "cves": [
        "CVE-2026-44459"
      ],
      "access": "public",
      "severity": "low",
      "module_name": "hono",
      "vulnerable_versions": "<4.12.18",
      "github_advisory_id": "GHSA-hm8q-7f3q-5f36",
      "recommendation": "Upgrade to version 4.12.18 or later",
      "patched_versions": ">=4.12.18",
      "updated": "2026-05-14T20:35:49.000Z",
      "cvss": {
        "score": 3.8,
        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:N"
      },
      "cwe": [
        "CWE-1284"
      ],
      "url": "https://github.com/advisories/GHSA-hm8q-7f3q-5f36"
    },
    "1118964": {
      "findings": [
        {
          "version": "4.12.8",
          "paths": [
            "apps/badge-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/badge-server > hono@4.12.8",
            "apps/gateway-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/gateway-server > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > @hono/node-server@1.19.11 > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > hono@4.12.8"
          ]
        }
      ],
      "found_by": null,
      "deleted": null,
      "references": "- https://github.com/honojs/hono/security/advisories/GHSA-p77w-8qqv-26rm\n- https://nvd.nist.gov/vuln/detail/CVE-2026-44457\n- https://github.com/advisories/GHSA-p77w-8qqv-26rm",
      "created": "2026-05-09T00:28:46.000Z",
      "id": 1118964,
      "npm_advisory_id": null,
      "overview": "### Summary\n\nCache Middleware does not skip caching for responses that declare per-user variance via `Vary: Authorization` or `Vary: Cookie`. As a result, a response cached for one authenticated user may be served to subsequent requests from different users.\n\n### Details\n\nThe Cache Middleware skips caching when a response carries `Vary: *`, certain `Cache-Control` directives (`private`, `no-store`, `no-cache`), or `Set-Cookie`. However, `Vary: Authorization` and `Vary: Cookie` — the standard signals defined in RFC 9110 / RFC 9111 to indicate per-user responses — are not treated as cache-skip reasons.\n\nThis issue arises when applications use the Cache Middleware on endpoints that return user-specific data and rely on `Vary: Authorization` or `Vary: Cookie` to scope the response per user, without also setting `Cache-Control: private`.\n\n### Impact\n\nA user may receive a cached response that was originally generated for a different authenticated user. This may lead to:\n\n- Disclosure of personally identifiable information or other user-specific data present in the response body\n- Inconsistent or incorrect behavior in user-specific endpoints\n\nThis issue affects applications that use the Cache Middleware on endpoints whose responses vary by `Authorization` or `Cookie` and that do not also set `Cache-Control: private`.",
      "reported_by": null,
      "title": "Hono's Cache Middleware ignores Vary: Authorization / Vary: Cookie leading to cross-user cache leakage",
      "metadata": null,
      "cves": [
        "CVE-2026-44457"
      ],
      "access": "public",
      "severity": "moderate",
      "module_name": "hono",
      "vulnerable_versions": "<4.12.18",
      "github_advisory_id": "GHSA-p77w-8qqv-26rm",
      "recommendation": "Upgrade to version 4.12.18 or later",
      "patched_versions": ">=4.12.18",
      "updated": "2026-05-14T20:35:44.000Z",
      "cvss": {
        "score": 5.3,
        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
      },
      "cwe": [
        "CWE-524"
      ],
      "url": "https://github.com/advisories/GHSA-p77w-8qqv-26rm"
    },
    "1118982": {
      "findings": [
        {
          "version": "4.12.8",
          "paths": [
            "apps/badge-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/badge-server > hono@4.12.8",
            "apps/gateway-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/gateway-server > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > @hono/node-server@1.19.11 > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > hono@4.12.8"
          ]
        }
      ],
      "found_by": null,
      "deleted": null,
      "references": "- https://github.com/honojs/hono/security/advisories/GHSA-9vqf-7f2p-gf9v\n- https://nvd.nist.gov/vuln/detail/CVE-2026-44456\n- https://github.com/advisories/GHSA-9vqf-7f2p-gf9v",
      "created": "2026-05-06T23:50:10.000Z",
      "id": 1118982,
      "npm_advisory_id": null,
      "overview": "## Summary\n\n`bodyLimit()` does not reliably enforce `maxSize` for requests without a usable `Content-Length` (e.g. `Transfer-Encoding: chunked`). Oversized requests can reach handlers and return `200` instead of `413`.\n\n## Details\n\nFor chunked / unknown-length requests, `bodyLimit()` wraps the body in a stream that counts bytes asynchronously, then runs the handler before the size decision is final. The `413` is only applied afterwards by checking `c.error`.\n\nThis lets the limit be bypassed when:\n\n- the handler does not read the body,\n- the handler reads only the first chunk(s) and returns, or\n- the handler reads the body but swallows the read error in `try/catch`.\n\nIn all three cases the handler returns `200` before the limit check completes (or its result is observed).\n\nThe fix is to enforce the size decision before `next()` runs, instead of retrofitting the response via `c.error` afterwards.\n\n## Impact\n\nApplications relying on `bodyLimit()` as a hard boundary can be bypassed: oversized chunked requests can reach handler logic and return successful responses. Per-request data exposure is bounded by `maxSize`, but the documented guarantee — \"oversized requests are rejected before business logic runs\" — does not hold.\n\n## Credits\n\n- @lalalala5678 (slow chunked / early return variants)\n- @Jvr2022 (error handling bypass)",
      "reported_by": null,
      "title": "Hono: bodyLimit() can be bypassed for chunked / unknown-length requests",
      "metadata": null,
      "cves": [
        "CVE-2026-44456"
      ],
      "access": "public",
      "severity": "moderate",
      "module_name": "hono",
      "vulnerable_versions": "<4.12.16",
      "github_advisory_id": "GHSA-9vqf-7f2p-gf9v",
      "recommendation": "Upgrade to version 4.12.16 or later",
      "patched_versions": ">=4.12.16",
      "updated": "2026-05-14T20:32:03.000Z",
      "cvss": {
        "score": 6.5,
        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N"
      },
      "cwe": [
        "CWE-400"
      ],
      "url": "https://github.com/advisories/GHSA-9vqf-7f2p-gf9v"
    },
    "1118983": {
      "findings": [
        {
          "version": "4.12.8",
          "paths": [
            "apps/badge-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/badge-server > hono@4.12.8",
            "apps/gateway-server > @hono/node-server@1.19.11 > hono@4.12.8",
            "apps/gateway-server > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > @hono/node-server@1.19.11 > hono@4.12.8",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > hono@4.12.8"
          ]
        }
      ],
      "found_by": null,
      "deleted": null,
      "references": "- https://github.com/honojs/hono/security/advisories/GHSA-69xw-7hcm-h432\n- https://nvd.nist.gov/vuln/detail/CVE-2026-44455\n- https://github.com/advisories/GHSA-69xw-7hcm-h432",
      "created": "2026-05-06T23:49:43.000Z",
      "id": 1118983,
      "npm_advisory_id": null,
      "overview": "## Summary\n\nImproper handling of JSX element tag names in hono/jsx allowed unvalidated tag names to be directly inserted into the generated HTML output.\n\nWhen untrusted input is used as a tag name via the programmatic `jsx()` or `createElement()` APIs during server-side rendering, specially crafted values may break out of the intended element context and inject unintended HTML.\n\n## Details\n\nWhen rendering JSX elements to HTML strings, attribute values are escaped and attribute names are validated. However, element tag names were previously inserted into the output without validation.\n\nIf a tag name contains characters such as `<`, `>`, quotes, or whitespace, it may alter the structure of the generated HTML.\n\nFor example, malformed tag names can:\n\n* Break out of the intended element and introduce unintended HTML elements\n* Inject attributes or event handlers into the rendered output\n\nThis issue arises when untrusted input (such as query parameters or database content) is used as JSX tag names via `jsx()` or `createElement()` during server-side rendering.\n\n## Impact\n\nAn attacker who can control tag names used in JSX rendering may inject unintended HTML into the generated output.\n\nThis may lead to:\n\n* Injection of unexpected HTML elements or attributes\n* Corruption of the HTML structure\n* Cross-site scripting (XSS) when combined with unsafe usage patterns\n\nThis issue only affects applications that construct JSX tag names from untrusted input. Applications using static or allowlisted tag names are not affected.",
      "reported_by": null,
      "title": "hono/jsx has Unvalidated JSX Tag Names that May Allow HTML Injection",
      "metadata": null,
      "cves": [
        "CVE-2026-44455"
      ],
      "access": "public",
      "severity": "moderate",
      "module_name": "hono",
      "vulnerable_versions": "<4.12.16",
      "github_advisory_id": "GHSA-69xw-7hcm-h432",
      "recommendation": "Upgrade to version 4.12.16 or later",
      "patched_versions": ">=4.12.16",
      "updated": "2026-05-14T20:32:03.000Z",
      "cvss": {
        "score": 4.7,
        "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N"
      },
      "cwe": [
        "CWE-74"
      ],
      "url": "https://github.com/advisories/GHSA-69xw-7hcm-h432"
    },
    "1119108": {
      "findings": [
        {
          "version": "8.19.0",
          "paths": [
            "apps/gateway-server > ws@8.19.0",
            "packages/bridge-mqtt > mqtt@5.15.1 > ws@8.19.0"
          ]
        }
      ],
      "found_by": null,
      "deleted": null,
      "references": "- https://github.com/websockets/ws/security/advisories/GHSA-58qx-3vcg-4xpx\n- https://nvd.nist.gov/vuln/detail/CVE-2026-45736\n- https://github.com/websockets/ws/commit/c0327ec15a54d701eb6ccefaa8bef328cfc03086\n- https://github.com/advisories/GHSA-58qx-3vcg-4xpx",
      "created": "2026-05-18T19:02:40.000Z",
      "id": 1119108,
      "npm_advisory_id": null,
      "overview": "### Impact\n\nThe `websocket.close()` implementation is vulnerable to uninitialized memory disclosure when a `TypedArray` is passed as the reason argument.\n\n### Proof of concept\n\n```js\nimport { deepStrictEqual } from 'node:assert';\nimport { WebSocket, WebSocketServer } from 'ws';\n\nconst wss = new WebSocketServer(\n  { port: 0, skipUTF8Validation: true },\n  function () {\n    const { port } = wss.address();\n    const ws = new WebSocket(`ws://localhost:${port}`, {\n      skipUTF8Validation: true\n    });\n\n    ws.on('close', function (code, reason) {\n      deepStrictEqual(reason, Buffer.alloc(80));\n    });\n  }\n);\n\nwss.on('connection', function (ws) {\n  ws.close(1000, new Float32Array(20));\n});\n```\n\n### Patches\n\nThe vulnerability was fixed in ws@8.20.1 (https://github.com/websockets/ws/commit/c0327ec15a54d701eb6ccefaa8bef328cfc03086).\n\n### Credits\n\nCredit for the private and responsible disclosure of this issue goes to [Nikita Skovoroda](https://github.com/ChALkeR).\n\n### Remarks\n\nAlthough the calculated CVSS severity is medium, the actual severity is believed to be low, as the flaw is only exploitable through misuse that is unlikely in practice.\n\n### Resources\n\n- https://github.com/advisories/GHSA-58qx-3vcg-4xpx\n- https://www.cve.org/CVERecord?id=CVE-2026-45736",
      "reported_by": null,
      "title": "ws: Uninitialized memory disclosure",
      "metadata": null,
      "cves": [
        "CVE-2026-45736"
      ],
      "access": "public",
      "severity": "moderate",
      "module_name": "ws",
      "vulnerable_versions": ">=8.0.0 <8.20.1",
      "github_advisory_id": "GHSA-58qx-3vcg-4xpx",
      "recommendation": "Upgrade to version 8.20.1 or later",
      "patched_versions": ">=8.20.1",
      "updated": "2026-05-18T19:02:42.000Z",
      "cvss": {
        "score": 4.4,
        "vectorString": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:N/A:N"
      },
      "cwe": [
        "CWE-908"
      ],
      "url": "https://github.com/advisories/GHSA-58qx-3vcg-4xpx"
    },
    "1119502": {
      "findings": [
        {
          "version": "6.15.0",
          "paths": [
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > express@5.2.1 > body-parser@2.2.2 > qs@6.15.0",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > express@5.2.1 > qs@6.15.0",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > express-rate-limit@8.3.1 > express@5.2.1 > body-parser@2.2.2 > qs@6.15.0",
            "examples/notes-server > @modelcontextprotocol/sdk@1.29.0 > express-rate-limit@8.3.1 > express@5.2.1 > qs@6.15.0"
          ]
        }
      ],
      "found_by": null,
      "deleted": null,
      "references": "- https://github.com/ljharb/qs/security/advisories/GHSA-q8mj-m7cp-5q26\n- https://nvd.nist.gov/vuln/detail/CVE-2026-8723\n- https://github.com/ljharb/qs/commit/21f80b33e5c8b3f7eba1034fff0da4a4a37a1d41\n- https://github.com/advisories/GHSA-q8mj-m7cp-5q26",
      "created": "2026-05-22T17:27:19.000Z",
      "id": 1119502,
      "npm_advisory_id": null,
      "overview": "### Summary\n\n`qs.stringify` throws `TypeError` when called with `arrayFormat: 'comma'` and `encodeValuesOnly: true` on an array containing `null` or `undefined`. The throw is synchronous and not handled by any of qs's null-related options (`skipNulls`, `strictNullHandling`).\n\n### Details\n\nIn the comma + `encodeValuesOnly` branch, `lib/stringify.js:145` mapped the array through the raw encoder before joining:\n\n```js\nobj = utils.maybeMap(obj, encoder);\n```\n\n`utils.encode` (`lib/utils.js:195`) reads `str.length` with no null guard, so a `null` or `undefined` element throws `TypeError`. `skipNulls` and `strictNullHandling` are both checked in the per-element loop below this line and never get a chance to run.\n\nSame class of bug as the filter-array path fixed in 0c180a4. The vulnerable shape of the comma + `encodeValuesOnly` branch was introduced in 4c4b23d (\"encode comma values more consistently\", PR #463, 2023-01-19), first released in v6.11.1.\n\n#### PoC\n\n```js\nconst qs = require('qs');\n\nqs.stringify({ a: [null, 'b'] },      { arrayFormat: 'comma', encodeValuesOnly: true });\nqs.stringify({ a: [undefined, 'b'] }, { arrayFormat: 'comma', encodeValuesOnly: true });\nqs.stringify({ a: [null] },           { arrayFormat: 'comma', encodeValuesOnly: true });\n// TypeError: Cannot read properties of null (reading 'length')\n//     at encode (lib/utils.js:195:13)\n//     at Object.maybeMap (lib/utils.js:322:37)\n//     at stringify (lib/stringify.js:145:25)\n```\n\n#### Fix\n\n`lib/stringify.js:145`, applied in 21f80b3 on `main`:\n\n```diff\n- obj = utils.maybeMap(obj, encoder);\n+ obj = utils.maybeMap(obj, function (v) {\n+     return v == null ? v : encoder(v);\n+ });\n```\n\n`null` and `undefined` now pass through `maybeMap` unchanged and reach the `join(',')` step as-is. For `{ a: [null, 'b'] }` this produces `a=,b`, matching the non-`encodeValuesOnly` comma path (which already joins before encoding and produces `a=%2Cb` for the same input). Single-element `[null]` arrays still collapse via the existing `obj.join(',') || null` and remain subject to `skipNulls` / `strictNullHandling` in the main loop.\n\n### Affected versions\n\n`>=6.11.1 <=6.15.1`\n\nThe vulnerable code shape was introduced in 4c4b23d and first shipped in v6.11.1. Earlier versions — including all of 6.7.x, 6.8.x, 6.9.x, 6.10.x, and 6.11.0 — implemented the comma + `encodeValuesOnly` path differently (joining before encoding) and are not affected. Empirically verified across released versions.\n\n### Impact\n\nApplication code that calls `qs.stringify` with both `arrayFormat: 'comma'` and `encodeValuesOnly: true` (both non-default) on input that may contain a `null` or `undefined` array element will throw synchronously instead of producing a query string. In a typical Node.js HTTP framework (Express, Fastify, Koa, hapi) the sync throw is caught by the framework's error boundary and the affected request returns a 500; the worker process does not exit and subsequent requests are unaffected. The \"kills the worker process\" framing applies only to call sites outside a request-handler error boundary (background jobs, startup paths, stream pipelines) or to deployments with framework error handling explicitly disabled.\n\nThe vulnerable input is a `null` or `undefined` entry inside an array; this is reachable from JSON request bodies or from application code constructing arrays from user input, but not from standard HTML form submissions (which produce strings or omitted fields, not literal `null`).",
      "reported_by": null,
      "title": "qs has a remotely triggerable DoS: qs.stringify crashes with TypeError on null/undefined entries in comma-format arrays when encodeValuesOnly is set",
      "metadata": null,
      "cves": [
        "CVE-2026-8723"
      ],
      "access": "public",
      "severity": "moderate",
      "module_name": "qs",
      "vulnerable_versions": ">=6.11.1 <=6.15.1",
      "github_advisory_id": "GHSA-q8mj-m7cp-5q26",
      "recommendation": "Upgrade to version 6.15.2 or later",
      "patched_versions": ">=6.15.2",
      "updated": "2026-05-22T17:27:20.000Z",
      "cvss": {
        "score": 5.3,
        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
      },
      "cwe": [
        "CWE-476"
      ],
      "url": "https://github.com/advisories/GHSA-q8mj-m7cp-5q26"
    }
  },
  "muted": [],
  "metadata": {
    "vulnerabilities": {
      "info": 0,
      "low": 1,
      "moderate": 14,
      "high": 0,
      "critical": 0
    },
    "dependencies": 208,
    "devDependencies": 0,
    "optionalDependencies": 0,
    "totalDependencies": 208
  }
}\n\nAudit delta (prod):\n- before:  remediation action present, high severity count = 2\n- after: no  remediation action, high severity count = 0\n\n## Tracking\n- addresses #209