### PR TITLE
Add timestamped PX4 correlation report generator

### DIFF
--- a/docs/guides/px4-log-encryption-evidence-integration.md
+++ b/docs/guides/px4-log-encryption-evidence-integration.md
@@ -27,6 +27,23 @@ Use this template:
 - `docs/reports/px4-ulog-correlation-artifact.template.json`
 - `docs/reports/px4-ulog-correlation-artifact.sample.json` (filled example)
 
+Generate a timestamped report packet:
+
+```bash
+pnpm run px4:artifact:report
+```
+
+Optional request correlation:
+
+```bash
+pnpm run px4:artifact:report -- --requestId=01905f7c-0000-7000-8000-000000000011
+```
+
+Generated outputs are written to:
+
+- `docs/reports/generated/px4-ulog-correlation-artifact.<stamp>.json`
+- `docs/reports/generated/px4-ulog-correlation-artifact.latest.json`
+
 ## Security posture
 
 - Keep log decryption private keys in separate key-management scope.

--- a/docs/reports/generated/.gitignore
+++ b/docs/reports/generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "benchmark:ros2-loop": "pnpm --filter @sint/conformance-tests exec vitest run src/ros2-control-loop-latency.test.ts --reporter=verbose",
     "benchmark:ros2-report": "node ./scripts/generate-ros2-control-loop-report.mjs",
     "px4:artifact:sample": "node ./scripts/generate-px4-ulog-correlation-sample.mjs",
+    "px4:artifact:report": "node ./scripts/generate-px4-ulog-correlation-report.mjs",
     "benchmark:report": "node ./scripts/generate-industrial-benchmark-report.mjs",
     "security:dependency-review": "node ./scripts/generate-dependency-review-report.mjs",
     "security:production-slice-artifact": "node ./scripts/generate-production-slice-validation-artifact.mjs",

--- a/scripts/generate-px4-ulog-correlation-report.mjs
+++ b/scripts/generate-px4-ulog-correlation-report.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+function parseArg(name) {
+  const arg = process.argv.find((a) => a.startsWith(`--${name}=`));
+  return arg ? arg.slice(name.length + 3) : undefined;
+}
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const reportsDir = path.join(repoRoot, "docs", "reports");
+const generatedDir = path.join(reportsDir, "generated");
+const samplePath = path.join(reportsDir, "px4-ulog-correlation-artifact.sample.json");
+
+const now = new Date();
+const stamp = parseArg("stamp") ?? now.toISOString().replace(/[-:]/g, "").replace(/\..+/, "Z");
+const requestId = parseArg("requestId");
+
+const sample = JSON.parse(readFileSync(samplePath, "utf8"));
+const report = {
+  ...sample,
+  generatedAt: now.toISOString(),
+  reportId: `px4-ulog-correlation-${stamp}`,
+};
+
+if (requestId) {
+  report.requestId = requestId;
+}
+
+mkdirSync(generatedDir, { recursive: true });
+
+const timestampedName = `px4-ulog-correlation-artifact.${stamp}.json`;
+const timestampedPath = path.join(generatedDir, timestampedName);
+const latestPath = path.join(generatedDir, "px4-ulog-correlation-artifact.latest.json");
+
+writeFileSync(timestampedPath, JSON.stringify(report, null, 2) + "\n", "utf8");
+writeFileSync(latestPath, JSON.stringify(report, null, 2) + "\n", "utf8");
+
+console.log(`[px4-ulog] wrote docs/reports/generated/${timestampedName}`);
+console.log("[px4-ulog] wrote docs/reports/generated/px4-ulog-correlation-artifact.latest.json");


### PR DESCRIPTION
## Summary\n- add  for timestamped per-request report packets\n- add 
> sint-protocol@0.1.0 px4:artifact:report /Users/pshkv/sint-protocol
> node ./scripts/generate-px4-ulog-correlation-report.mjs

[px4-ulog] wrote docs/reports/generated/px4-ulog-correlation-artifact.20260526T062057Z.json
[px4-ulog] wrote docs/reports/generated/px4-ulog-correlation-artifact.latest.json command\n- route generated outputs to \n- add  to keep generated JSON out of git\n- update PX4 integration guide with command and output locations\n\n## Validation\n- 
> sint-protocol@0.1.0 px4:artifact:report /Users/pshkv/sint-protocol
> node ./scripts/generate-px4-ulog-correlation-report.mjs "--" "--stamp=20260525T210500Z"

[px4-ulog] wrote docs/reports/generated/px4-ulog-correlation-artifact.20260525T210500Z.json
[px4-ulog] wrote docs/reports/generated/px4-ulog-correlation-artifact.latest.json\n- 
> sint-protocol@0.1.0 docs:build /Users/pshkv/sint-protocol
> vitepress build docs


  vitepress v1.6.4

build complete in 8.02s.\n\n## Tracking\n- continues roadmap execution lane in #213