### PR TITLE
Add CI smoke check for PX4 correlation report generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
           pnpm run px4:artifact:sample
           git diff --exit-code -- docs/reports/px4-ulog-correlation-artifact.sample.json
 
+      - name: PX4 ULog Artifact Report Smoke Check
+        run: pnpm run px4:artifact:report -- --stamp=ci-smoke
+
       - name: Typecheck
         run: pnpm run typecheck
 


### PR DESCRIPTION
## Summary\n- add CI step that runs 
> sint-protocol@0.1.0 px4:artifact:report /Users/pshkv/sint-protocol
> node ./scripts/generate-px4-ulog-correlation-report.mjs "--" "--stamp=ci-smoke"

[px4-ulog] wrote docs/reports/generated/px4-ulog-correlation-artifact.ci-smoke.json
[px4-ulog] wrote docs/reports/generated/px4-ulog-correlation-artifact.latest.json\n- ensures timestamped PX4 report generator remains executable in default pipeline\n\n## Validation\n- 
> sint-protocol@0.1.0 px4:artifact:report /Users/pshkv/sint-protocol
> node ./scripts/generate-px4-ulog-correlation-report.mjs "--" "--stamp=ci-smoke"

[px4-ulog] wrote docs/reports/generated/px4-ulog-correlation-artifact.ci-smoke.json
[px4-ulog] wrote docs/reports/generated/px4-ulog-correlation-artifact.latest.json\n- 
> sint-protocol@0.1.0 docs:build /Users/pshkv/sint-protocol
> vitepress build docs


  vitepress v1.6.4

build complete in 6.84s.\n\n## Tracking\n- continues #213 roadmap execution lane