### PR TITLE
AAIF: add RFC-001 submission packet and evidence item

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Deploy note:
 
 Community/adoption assets:
 - [`docs/community/discord-launch-runbook.md`](docs/community/discord-launch-runbook.md)
+- [`docs/community/aaif-rfc001-submission-packet.md`](docs/community/aaif-rfc001-submission-packet.md)
 - [`docs/community/discord-launch-kit.md`](docs/community/discord-launch-kit.md)
 - [`docs/community/external-contributor-onboarding.md`](docs/community/external-contributor-onboarding.md)
 - [`docs/community/good-first-issues-board.md`](docs/community/good-first-issues-board.md)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -74,6 +74,7 @@ export default defineConfig({
         items: [
           { text: "AAIF Gate Labels", link: "/community/aaif-gate-labels" },
           { text: "AAIF Evidence Dossier", link: "/community/aaif-evidence-dossier" },
+          { text: "AAIF RFC-001 Submission Packet", link: "/community/aaif-rfc001-submission-packet" },
           { text: "AAIF Proposal Template", link: "/community/aaif-resubmission-proposal-template" },
           { text: "Adopters And Evidence", link: "/community/adopters" },
           { text: "OpenSSF Gap Tracker", link: "/community/openssf-gap-tracker" },

--- a/docs/community/aaif-evidence-dossier.md
+++ b/docs/community/aaif-evidence-dossier.md
@@ -29,6 +29,7 @@ pnpm run aaif:evidence:new release v0-3-0-rc1 2026-06-15
 
 | Date | Type | Organization | Owner | Link |
 | --- | --- | --- | --- | --- |
+| 2026-05-28 | conformance | SINT Protocol maintainers | @pshkv | [2026-05-28-rfc-001-policy-bundle-submission-draft.md](./aaif-evidence/2026-05-28-rfc-001-policy-bundle-submission-draft.md) |
 | 2026-05-21 | conformance | SINT Protocol maintainers | @pshkv | [2026-05-21-conformance-production-slice-external-validation.md](./aaif-evidence/2026-05-21-conformance-production-slice-external-validation.md) |
 | 2026-05-21 | release | SINT Protocol maintainers | @pshkv | [2026-05-21-release-v0-3-0-rc1-release-gate.md](./aaif-evidence/2026-05-21-release-v0-3-0-rc1-release-gate.md) |
 | _Add next entry_ | _type_ | _organization_ | _owner_ | _link_ |

--- a/docs/community/aaif-evidence/2026-05-28-rfc-001-policy-bundle-submission-draft.md
+++ b/docs/community/aaif-evidence/2026-05-28-rfc-001-policy-bundle-submission-draft.md
@@ -1,0 +1,34 @@
+# AAIF Evidence Item: RFC-001 Policy Bundle Submission Draft
+
+Evidence:
+
+- Type: conformance
+- Organization: SINT Protocol maintainers
+- Independent from current co-design network: no
+- Public URL: `docs/rfcs/RFC-001-policy-bundle.md`
+- Date range: 2026-05-28
+- SINT component used: Policy Bundle RFC-001
+- Verification method: repo-tracked submission packet plus Gmail draft ID
+- Contact or accountable owner: @pshkv
+- Notes: This item records readiness to submit RFC-001 to AAIF. It does not claim AAIF acceptance or external adoption.
+
+## Artifacts
+
+- Submission packet: `docs/community/aaif-rfc001-submission-packet.md`
+- RFC: `docs/rfcs/RFC-001-policy-bundle.md`
+- Related vocabulary PR: `https://github.com/aeoess/agent-governance-vocabulary/pull/11`
+- Gmail draft ID: `r-2078090681071797042`
+
+## Claim Boundary
+
+This evidence supports:
+
+- RFC-001 is prepared as an AAIF working-group contribution.
+- The submission text is drafted and traceable.
+- Follow-up state is tracked in issue `#130`.
+
+This evidence does not support:
+
+- AAIF acceptance.
+- AAIF endorsement.
+- independent production adoption.

--- a/docs/community/aaif-rfc001-submission-packet.md
+++ b/docs/community/aaif-rfc001-submission-packet.md
@@ -1,0 +1,45 @@
+# AAIF RFC-001 Submission Packet
+
+Status: Gmail draft created, awaiting operator send
+
+## Tracking
+
+- GitHub issue: `#130`
+- Gmail draft ID: `r-2078090681071797042`
+- Recipient: `aaif-governance@linuxfoundation.org`
+- Subject: `RFC contribution - SINT Protocol Policy Bundle Specification`
+
+## Submitted Artifact
+
+- RFC: `docs/rfcs/RFC-001-policy-bundle.md`
+- Public URL: `https://github.com/sint-ai/sint-protocol/blob/main/docs/rfcs/RFC-001-policy-bundle.md`
+- Related vocabulary PR: `https://github.com/aeoess/agent-governance-vocabulary/pull/11`
+
+## Draft Body
+
+```text
+The SINT Protocol team is contributing RFC-001 for consideration by the AAIF working group as a proposed governance standard. The specification defines a machine-readable contract for agent authorization covering action allowlists, path constraints, rate limiting, human approval gates, hash-chained receipts, APS identity integration, A2A task extension format, and cascade revocation. Section 11 includes explicit AAIF compliance mapping.
+
+RFC: https://github.com/sint-ai/sint-protocol/blob/main/docs/rfcs/RFC-001-policy-bundle.md
+
+Three-vendor governance_attestation convergence already in progress (APS, MolTrust, SINT) via A2A#1717. We are seeking co-authorship of the AAIF governance spec and the reference implementation designation.
+
+- Illia Pashkov, SINT Labs
+```
+
+## Send Checklist
+
+- [x] RFC-001 published in repo
+- [x] Vocabulary PR open
+- [x] Gmail draft created
+- [ ] Email sent to AAIF
+- [ ] AAIF response recorded
+- [ ] RFC referenced in AAIF docs or follow-up thread
+
+## Follow-Up Template
+
+```text
+Thanks for reviewing RFC-001. We are happy to adapt the Policy Bundle format to the AAIF governance vocabulary and contribute conformance fixtures or reference implementation hooks where helpful.
+
+The repo now tracks evidence separately from claims, so we can scope this as a draft contribution, a reference implementation candidate, or a working-group input depending on what is most useful for AAIF.
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,7 @@ features:
 - Standalone certification tool: [Guide](./guides/standalone-certification-tool.md)
 - NIST submission playbook: [Guide](./guides/nist-submission-playbook.md)
 - Community launch runbook: [Discord Launch](./community/discord-launch-runbook.md)
+- AAIF RFC-001 submission packet: [Community/AAIF Packet](./community/aaif-rfc001-submission-packet.md)
 - Discord launch kit: [Community/Discord Launch Kit](./community/discord-launch-kit.md)
 - Good-first-issues board: [Community/Starter Board](./community/good-first-issues-board.md)
 - Collaboration reply playbook: [Community/Replies](./community/open-source-collaboration-replies.md)


### PR DESCRIPTION
## Summary
- add a repo-tracked AAIF RFC-001 submission packet with recipient, subject, draft body, and checklist
- record the Gmail draft ID for operator review/send tracking
- add an AAIF evidence item with an explicit claim boundary
- link the packet from README and docs navigation

## Validation
- pnpm run docs:build
- git diff --check

Refs #130
