### PR TITLE
Security: add MITRE ATLAS candidate mappings for agent identity/payment attacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,6 +696,7 @@ docker-compose up
 - EU AI Act mapping: [`docs/compliance/eu-ai-act-mapping.md`](docs/compliance/eu-ai-act-mapping.md)
 - ISO 13482 alignment: [`docs/compliance/iso-13482-alignment.md`](docs/compliance/iso-13482-alignment.md)
 - Formal threat model: [`docs/security/formal-threat-model.md`](docs/security/formal-threat-model.md)
+- MITRE ATLAS candidate mappings: [`docs/security/mitre-atlas-agent-technique-mappings.md`](docs/security/mitre-atlas-agent-technique-mappings.md)
 - Getting started: [`docs/getting-started.md`](docs/getting-started.md)
 - Deployment profiles: [`docs/profiles/`](docs/profiles/)
 - Examples: [`examples/`](examples/) (hello-world, warehouse-amr, industrial-cell)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -109,6 +109,7 @@ export default defineConfig({
       {
         text: "Security Bulletins",
         items: [
+          { text: "MITRE ATLAS Candidate Mappings", link: "/security/mitre-atlas-agent-technique-mappings" },
           { text: "April 2026 Bulletin", link: "/security-bulletins/2026-04" },
           { text: "Bulletin Template", link: "/security-bulletins/TEMPLATE" },
         ],

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,7 @@ features:
 - EU AI Act mapping: [Compliance/EU AI Act](./compliance/eu-ai-act-mapping.md)
 - ISO 13482 alignment: [Compliance/ISO 13482](./compliance/iso-13482-alignment.md)
 - Formal threat model: [Security/Formal Threat Model](./security/formal-threat-model.md)
+- MITRE ATLAS candidate mappings: [Security/MITRE ATLAS](./security/mitre-atlas-agent-technique-mappings.md)
 - NIST submission bundle report: [Report](./reports/nist-submission-bundle.md)
 - Latest security bulletin: [May 2026](./security-bulletins/2026-05.md)
 

--- a/docs/security/mitre-atlas-agent-technique-mappings.md
+++ b/docs/security/mitre-atlas-agent-technique-mappings.md
@@ -1,0 +1,71 @@
+# MITRE ATLAS Candidate Mappings: Agent Identity Spoofing and Payment Hijacking
+
+Status: candidate mapping packet, awaiting canonical ATLAS technique IDs
+
+## Tracking
+
+- GitHub issue: `#127`
+- MITRE ATLAS data issue: `https://github.com/mitre-atlas/atlas-data/issues/11`
+- Gmail draft ID: `r-4084736127375409030`
+- Recipient: `atlas@mitre.org`
+- Current ATLAS data note: public ATLAS data uses `AML.T####` technique IDs and v6 distribution files.
+
+## Candidate Technique: Agent Identity Spoofing
+
+Placeholder ID: `T-XXXX`
+
+Description:
+
+An adversary impersonates a legitimate agent, runtime, or delegated principal to gain access to tools, workflows, funds, physical devices, or privileged context.
+
+SINT mitigations:
+
+- `@sint/gate-capability-tokens`: Ed25519 capability tokens bind `issuer`, `subject`, resource, action, constraints, expiry, and delegation chain.
+- `PolicyGateway.intercept()`: validates token signature and verifies `token.subject === request.agentId` before allowing a request to reach a tool or actuator boundary.
+- Memory / credential-funnel detection: flags identity claims and credential-access behavior inconsistent with the established session.
+- APS/SINT interop fixtures: preserve explicit delegated authority and revocation semantics across identity systems.
+
+Evidence and tests:
+
+- `packages/conformance-tests/fixtures/security/owasp-asi-conformance.v1.json`
+- `packages/conformance-tests/src/owasp-asi-conformance.test.ts`
+- `packages/capability-tokens/__tests__/aps-crossverify.test.ts`
+
+Enforcement tier:
+
+- Strong proxy enforcement. SINT sits in the pre-action path and denies nonmatching identity/token pairs before execution.
+
+## Candidate Technique: Agent Payment Hijacking
+
+Placeholder ID: `T-YYYY`
+
+Description:
+
+An adversary redirects, inflates, or forges agent payment flows by manipulating payee identity, budget context, usage receipts, or delegated payment authority.
+
+SINT mitigations:
+
+- `EconomyPlugin`: enforces per-agent budgets, budget exhaustion behavior, and route/cost policy.
+- Tiered approval gates: high-risk or irreversible payment actions can require T2/T3 approval before execution.
+- Receipt binding: payment and route decisions are bound to agent identity, token scope, action intent, and evidence ledger events.
+- Payment governance fixtures: cover unauthorized payee redirection, stale receipts, budget exhaustion, and approval bypass attempts.
+
+Evidence and tests:
+
+- `packages/conformance-tests/fixtures/economy/payment-governance.v1.json`
+- `packages/conformance-tests/src/payment-governance-fixtures-conformance.test.ts`
+- `packages/conformance-tests/src/economy-regression.test.ts`
+
+Enforcement tier:
+
+- Strong proxy enforcement. Payment-related requests are evaluated before settlement or downstream payment execution.
+
+## Machine-Readable Packet
+
+Candidate YAML:
+
+- `docs/security/mitre-atlas-sint-candidate-mappings.yaml`
+
+## Claim Boundary
+
+This packet does not claim that MITRE has accepted or assigned these techniques. It records SINT's candidate mitigation mapping so maintainers can submit or update it once canonical ATLAS IDs are assigned.

--- a/docs/security/mitre-atlas-sint-candidate-mappings.yaml
+++ b/docs/security/mitre-atlas-sint-candidate-mappings.yaml
@@ -1,0 +1,68 @@
+schema: sint-mitre-atlas-candidate-mapping-v0.1
+status: candidate
+source_issue: https://github.com/sint-ai/sint-protocol/issues/127
+atlas_issue: https://github.com/mitre-atlas/atlas-data/issues/11
+atlas_id_status: awaiting_canonical_aml_ids
+submission:
+  recipient: atlas@mitre.org
+  gmail_draft_id: r-4084736127375409030
+  subject: "SINT mappings for proposed ATLAS agent techniques - identity spoofing and payment hijacking"
+techniques:
+  - placeholder_id: T-XXXX
+    canonical_id: null
+    name: Agent Identity Spoofing
+    description: >
+      Impersonation of a legitimate agent, runtime, or delegated principal to
+      gain access to tools, workflows, funds, physical devices, or privileged
+      context.
+    sint_enforcement_tier: strong_proxy
+    mitigations:
+      - id: sint.capability_tokens.subject_binding
+        package: "@sint/gate-capability-tokens"
+        summary: Ed25519 capability tokens bind issuer, subject, resource, action, constraints, expiry, and delegation chain.
+      - id: sint.policy_gateway.subject_match
+        package: "@sint/gate-policy-gateway"
+        summary: PolicyGateway validates signatures and verifies token.subject equals request.agentId before execution.
+      - id: sint.memory_integrity.credential_funnel
+        package: "@sint/gate-policy-gateway"
+        summary: Detects credential-funnel and inconsistent identity claim patterns in agent sessions.
+      - id: sint.aps_interop.cross_verify
+        package: "@sint/gate-capability-tokens"
+        summary: APS/SINT cross-verification preserves delegated authority and revocation semantics.
+    evidence:
+      fixtures:
+        - packages/conformance-tests/fixtures/security/owasp-asi-conformance.v1.json
+        - packages/conformance-tests/fixtures/interop/aps-sint-handshake.v1.json
+      tests:
+        - packages/conformance-tests/src/owasp-asi-conformance.test.ts
+        - packages/capability-tokens/__tests__/aps-crossverify.test.ts
+    claim_boundary: Candidate mitigation mapping only; no MITRE acceptance claimed.
+
+  - placeholder_id: T-YYYY
+    canonical_id: null
+    name: Agent Payment Hijacking
+    description: >
+      Unauthorized redirection, inflation, or forgery of agent payment flows
+      through manipulated payee identity, budget context, usage receipts, or
+      delegated payment authority.
+    sint_enforcement_tier: strong_proxy
+    mitigations:
+      - id: sint.economy_plugin.budget_enforcement
+        package: "@sint/bridge-economy"
+        summary: Enforces per-agent budgets, route/cost policy, and budget exhaustion behavior.
+      - id: sint.approval_tiers.payment_gate
+        package: "@sint/gate-policy-gateway"
+        summary: Promotes high-risk or irreversible payment actions to T2/T3 approval gates.
+      - id: sint.receipt_binding.payment_context
+        package: "@sint/gate-evidence-ledger"
+        summary: Binds payment and route decisions to agent identity, token scope, action intent, and evidence events.
+      - id: sint.payment_governance.fixtures
+        package: "@sint/conformance-tests"
+        summary: Covers unauthorized payee redirection, stale receipts, budget exhaustion, and approval bypass attempts.
+    evidence:
+      fixtures:
+        - packages/conformance-tests/fixtures/economy/payment-governance.v1.json
+      tests:
+        - packages/conformance-tests/src/payment-governance-fixtures-conformance.test.ts
+        - packages/conformance-tests/src/economy-regression.test.ts
+    claim_boundary: Candidate mitigation mapping only; no MITRE acceptance claimed.


### PR DESCRIPTION
## Summary
- add candidate MITRE ATLAS mappings for Agent Identity Spoofing and Agent Payment Hijacking
- include machine-readable candidate YAML with claim boundaries and evidence references
- create a Gmail draft for manual submission to atlas@mitre.org
- link the mappings from README and docs navigation

## Source check
- MITRE ATLAS data repo currently documents v6 distribution shape and AML.T#### ID conventions
- canonical IDs for the two candidate techniques are still treated as pending here

## Validation
- pnpm run docs:build
- git diff --check

Refs #127
