### PR TITLE
OWASP: add Agentic AI landscape submission packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Community/adoption assets:
 - [`docs/community/good-first-issues-board.md`](docs/community/good-first-issues-board.md)
 - [`docs/community/open-source-collaboration-replies.md`](docs/community/open-source-collaboration-replies.md)
 - [`docs/community/physical-ai-runtime-safety-working-group.md`](docs/community/physical-ai-runtime-safety-working-group.md)
+- [`docs/community/owasp-agentic-landscape-submission.md`](docs/community/owasp-agentic-landscape-submission.md)
 - [`docs/security-bulletins/2026-04.md`](docs/security-bulletins/2026-04.md)
 
 ### Run a Single Package

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -78,6 +78,7 @@ export default defineConfig({
           { text: "AAIF Proposal Template", link: "/community/aaif-resubmission-proposal-template" },
           { text: "Adopters And Evidence", link: "/community/adopters" },
           { text: "OpenSSF Gap Tracker", link: "/community/openssf-gap-tracker" },
+          { text: "OWASP Agentic Landscape Submission", link: "/community/owasp-agentic-landscape-submission" },
           { text: "Vulnerability Reporting And Response", link: "/security/vulnerability-reporting-and-response" },
           { text: "Discord Launch Runbook", link: "/community/discord-launch-runbook" },
           { text: "Discord Launch Kit", link: "/community/discord-launch-kit" },

--- a/docs/community/owasp-agentic-landscape-submission.md
+++ b/docs/community/owasp-agentic-landscape-submission.md
@@ -1,0 +1,91 @@
+# OWASP Agentic AI Security Solutions Landscape Submission
+
+Status: submission-ready packet for issue `#125`
+
+## Source Check
+
+- Landscape page: `https://genai.owasp.org/ai-security-solutions-landscape/`
+- Q2 2026 Agentic AI resource: `https://genai.owasp.org/resource/ai-security-solutions-landscape-for-agentic-ai-q2-2026/`
+- Submission path: the landscape page exposes `Submit - Agentic AI Solution`.
+- OWASP description: the landscape is a community resource, not an endorsement, and contributions are reviewed for accuracy.
+
+## Suggested Form Answers
+
+Solution name:
+
+```text
+SINT Protocol
+```
+
+Website / repository:
+
+```text
+https://github.com/sint-ai/sint-protocol
+```
+
+Open source or commercial:
+
+```text
+Open source
+```
+
+Short description:
+
+```text
+SINT Protocol is an open-source runtime security and governance layer for agentic and physical AI. It places a PolicyGateway before tool calls, ROS2 actions, MCP tools, A2A tasks, IoT/industrial bridges, and payment-like actions, enforcing capability tokens, approval tiers, physical constraints, revocation, and tamper-evident evidence receipts.
+```
+
+Lifecycle stages:
+
+```text
+Deploy, Operate, Monitor, Govern, Test & Evaluate
+```
+
+Agentic security coverage:
+
+```text
+SINT maps to OWASP Agentic Security Initiative ASI01-ASI10 with machine-readable fixtures and conformance tests. Core controls include pre-action authorization, scoped capability tokens, Ed25519 subject binding, model fingerprint checks, unsafe-code escalation, memory integrity checks, circuit breakers, T2/T3 human approval, revocation, and evidence-ledger receipts.
+```
+
+Differentiator:
+
+```text
+SINT adds physical-AI and industrial safety enforcement that most agent security tools do not cover: velocity/force/geofence constraints in tokens, ROS2/SROS2 and industrial bridge fixtures, e-stop rollback semantics, hardware safety handshakes, and receipt-backed policy decisions for real-world actions.
+```
+
+Evidence links:
+
+```text
+OWASP ASI mapping:
+https://github.com/sint-ai/sint-protocol/blob/main/docs/conformance/owasp-asi-mapping.md
+
+Machine-readable ASI fixture pack:
+https://github.com/sint-ai/sint-protocol/blob/main/packages/conformance-tests/fixtures/security/owasp-asi-conformance.v1.json
+
+Physical AI runtime safety fixtures:
+https://github.com/sint-ai/sint-protocol/tree/main/packages/conformance-tests/fixtures/physical-ai
+
+Conformance test command:
+pnpm --filter @pshkv/conformance-tests test:fixtures
+```
+
+Contact:
+
+```text
+Illia Pashkov / SINT Protocol maintainers
+GitHub: https://github.com/sint-ai/sint-protocol
+```
+
+## Manual Submission Checklist
+
+- [x] Submission packet prepared
+- [x] Evidence links verified in repo
+- [ ] Form submitted through `Submit - Agentic AI Solution`
+- [ ] OWASP response recorded in issue `#125`
+- [ ] Listing accepted or feedback converted into follow-up issues
+
+## Follow-Up Reply
+
+```text
+Thanks for reviewing SINT for the Agentic AI Security Solutions Landscape. We can provide a smaller evidence bundle if helpful: ASI01-ASI10 mapping, fixture pack, conformance command, and a short note on the physical-AI/ROS2 safety boundary.
+```

--- a/docs/community/owasp-agentic-landscape-submission.yaml
+++ b/docs/community/owasp-agentic-landscape-submission.yaml
@@ -1,0 +1,47 @@
+schema: sint-owasp-agentic-landscape-submission-v0.1
+status: submission_ready
+tracking_issue: https://github.com/sint-ai/sint-protocol/issues/125
+source_pages:
+  landscape: https://genai.owasp.org/ai-security-solutions-landscape/
+  q2_2026_agentic: https://genai.owasp.org/resource/ai-security-solutions-landscape-for-agentic-ai-q2-2026/
+submission_path:
+  label: Submit - Agentic AI Solution
+  page: https://genai.owasp.org/ai-security-solutions-landscape/
+solution:
+  name: SINT Protocol
+  type: open_source
+  repository: https://github.com/sint-ai/sint-protocol
+  category_stages:
+    - Deploy
+    - Operate
+    - Monitor
+    - Govern
+    - Test & Evaluate
+  short_description: >
+    Open-source runtime security and governance layer for agentic and physical
+    AI. SINT places a PolicyGateway before tool calls, ROS2 actions, MCP tools,
+    A2A tasks, IoT/industrial bridges, and payment-like actions.
+  differentiator: >
+    Physical-AI and industrial safety enforcement: velocity/force/geofence
+    constraints in tokens, ROS2/SROS2 and industrial bridge fixtures, e-stop
+    rollback semantics, hardware safety handshakes, and receipt-backed policy
+    decisions for real-world actions.
+evidence:
+  owasp_asi_mapping: docs/conformance/owasp-asi-mapping.md
+  asi_fixture_pack: packages/conformance-tests/fixtures/security/owasp-asi-conformance.v1.json
+  physical_ai_fixture_pack: packages/conformance-tests/fixtures/physical-ai/runtime-safety-fixtures.v0.1.json
+  conformance_command: pnpm --filter @pshkv/conformance-tests test:fixtures
+coverage:
+  ASI01: full
+  ASI02: full
+  ASI03: full
+  ASI04: full
+  ASI05: full
+  ASI06: full
+  ASI07: full
+  ASI08: full
+  ASI09: full
+  ASI10: full
+claim_boundary:
+  - Submission-ready packet only.
+  - Does not claim OWASP inclusion, endorsement, or review acceptance.

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ features:
 - Good-first-issues board: [Community/Starter Board](./community/good-first-issues-board.md)
 - Collaboration reply playbook: [Community/Replies](./community/open-source-collaboration-replies.md)
 - Physical AI runtime safety working group: [Community/Working Group](./community/physical-ai-runtime-safety-working-group.md)
+- OWASP Agentic Landscape submission packet: [Community/OWASP Packet](./community/owasp-agentic-landscape-submission.md)
 - EU AI Act mapping: [Compliance/EU AI Act](./compliance/eu-ai-act-mapping.md)
 - ISO 13482 alignment: [Compliance/ISO 13482](./compliance/iso-13482-alignment.md)
 - Formal threat model: [Security/Formal Threat Model](./security/formal-threat-model.md)


### PR DESCRIPTION
## Summary
- add a submission-ready OWASP Agentic AI Security Solutions Landscape packet
- include machine-readable YAML with stages, evidence links, ASI01-ASI10 coverage, and claim boundaries
- link the packet from README and docs navigation

## Source check
- OWASP landscape page says contributions are open and reviewed for accuracy
- The same page exposes a `Submit - Agentic AI Solution` form
- Q2 2026 Agentic AI resource page is published March 17, 2026

## Validation
- pnpm run docs:build
- git diff --check

Refs #125
