### PR TITLE
docs: sharpen public positioning for SINT Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,50 +6,69 @@
 
 [![Glama](https://glama.ai/mcp/servers/sint-ai/sint-protocol/badges/card.svg)](https://glama.ai/mcp/servers/sint-ai/sint-protocol)
 
-**Security, permission, and economic enforcement layer for physical AI.**
+**Open-source runtime security and governance for AI agents, MCP tools, robotics, industrial automation, and physical AI.**
 
-SINT is the missing governance layer between AI agents and the physical world. Every tool call, robot command, and actuator movement flows through a single Policy Gateway that enforces capability-based permissions, graduated approval tiers, and tamper-evident audit logging.
+SINT Protocol is an open protocol and TypeScript reference stack that sits
+between AI agent intent and real-world execution. Before a governed tool call,
+robot command, industrial write, payment-like action, or actuator movement can
+run, the request passes through `PolicyGateway.intercept()` for capability-token
+authorization, T0-T3 approval tiering, physical constraint enforcement,
+revocation checks, and tamper-evident evidence logging.
 
-The protocol now includes a managed-autonomy authority lane in
-[`@pshkv/autonomy-supervisor`](packages/autonomy-supervisor/README.md). It adds
-a second, orthogonal pre-gate for whether an agent still has authority to emit
-external output at all: `stable -> metacognitive_recovery ->
-assisted_recovery -> regulated_control`. External output is structurally
-allowed only from `stable`, and exit from `regulated_control` requires an
-external human-operator or hardware-safety-controller authorization signal.
+## What is SINT Protocol?
 
-The next upgrade lane is factory control. As prompt-to-hardware and
-prompt-to-factory tooling gets better at generating industrial plans, SINT is
-expanding toward the control layer that decides what can be simulated,
-approved, executed, audited, and settled before AI-generated factory actions
-touch real machines. See
-[`docs/roadmaps/factory-action-pack-upgrade-sprints.md`](docs/roadmaps/factory-action-pack-upgrade-sprints.md).
-Sprint 1 now ships a control-standard pack with an industrial action profile,
-factory intent and cell graph schemas, a robot action schema, a simulation
-receipt schema, an industrial policy pack, and a refusal-first demo narrative.
-Sprint 2 has started with an executable conformance demo:
-`pnpm run demo:factory-action` proves the deny -> escalate -> allow path before
-any robot or PLC action reaches a vendor adapter stub. The ROS 2 bridge also
-maps the same factory action profile into a `/joint_commands` command envelope
-with force and velocity extraction, plus Universal Robots ROS2 demo and SRCI
-command-profile artifacts for adapter work that still routes through the same
-SINT policy resource. ABB RAPID, FANUC LS, KUKA KRL, and URScript export stubs
-now generate deterministic offline program text and SHA-256 hashes for
-simulation/review binding, and Isaac Sim, RoboDK, RobotStudio, KUKA.Sim, and
-FANUC ROBOGUIDE receipt stubs bind those hashes to collision, force-envelope,
-safety-zone, and decision-digest fields. The operator
-interface Conductor now surfaces industrial approval evidence from the live
-approval queue: cell, robot, motion, simulation receipt, envelope, tool, and
-quorum state, plus the compact plan -> simulation -> approval -> execution
-receipt chain before an operator can approve or deny the action.
-Sprint 3 is now represented as a preview
-[`sint-industrial`](sint-industrial/README.md) pack with a machine-readable
-manifest for ROS 2, SRCI, OPC UA, MQTT, simulator, and example-cell profiles:
-`pnpm run demo:industrial-pack` verifies that the pack keeps simulation,
-approval, receipt-chain evidence, and settlement attribution first-class across
-active execution paths.
+SINT is an AI agent security control plane for actions with real-world
+consequence. It helps teams answer four questions before an autonomous system
+acts:
 
-> **Academic grounding:** SINT is designed with reference to IEC 62443 FR1–FR7, EU AI Act Article 13, and NIST AI RMF. The evaluation framework references the ROSClaw empirical safety study ([arXiv:2603.26997](https://arxiv.org/abs/2603.26997)) and MCP security analysis ([arXiv:2601.17549](https://arxiv.org/abs/2601.17549)).
+- **Who is allowed to act?** Ed25519 capability tokens bind issuer, subject,
+  resource, action, expiry, constraints, and delegation chain.
+- **What constraints apply?** Velocity, force, geofence, budget, rate-limit, and
+  consent constraints travel with the token instead of living in ad hoc config.
+- **When is human review required?** T0-T3 approval tiers route low-risk actions
+  automatically and escalate physical or irreversible actions to operators.
+- **How do you prove what happened?** Every decision can be written to a
+  SHA-256 hash-chained `EvidenceLedger` with portable proof receipts.
+
+## Where SINT Fits
+
+SINT is not a replacement for MCP, A2A, ROS 2, MAVLink, MQTT, OPC UA, Open-RMF,
+or industrial robot tooling. It is the enforcement layer in front of those
+systems:
+
+- **MCP security:** authorize tool calls before an MCP server executes them.
+- **Agent runtime governance:** add pre-tool authorization, typed deny/escalate
+  outcomes, and evidence references to agent frameworks.
+- **Robotics and drones:** enforce ROS 2, MAVLink, PX4, and fleet actions with
+  physical constraints and e-stop semantics.
+- **Industrial automation:** govern OPC UA, MQTT/Sparkplug, SRCI, simulator, and
+  offline robot-program paths before PLC or robot actions touch equipment.
+- **Consumer and regulated data:** apply consent, caregiver delegation,
+  differential privacy, and audit exports for smart-home and health workflows.
+
+## Latest Implementation Highlights
+
+- **Installable MCP proxy:** `npx -y sint-mcp --stdio` runs the security-first
+  multi-MCP proxy.
+- **Five-minute interceptor demo:** `pnpm run demo:interceptor-quickstart`
+  shows `request -> decision -> receipt` and the fail-closed path.
+- **Production gateway posture:** production mode requires durable stores,
+  explicit authentication, readiness checks, and signature enforcement.
+- **Industrial action pack:** `pnpm run demo:factory-action` and
+  `pnpm run demo:industrial-pack` verify deny, escalate, approve, simulate, and
+  receipt-chain flows before vendor adapter execution.
+- **Autonomy supervisor:** `@pshkv/autonomy-supervisor` adds an authority lane
+  for managed autonomy: `stable -> metacognitive_recovery ->
+  assisted_recovery -> regulated_control`.
+- **External evidence packets:** OWASP Agentic AI landscape, MITRE ATLAS
+  candidate mappings, AAIF RFC-001 packet, NIST bundle, dependency review, and
+  production-slice validation artifacts are published under `docs/`.
+
+Academic and compliance grounding: SINT is designed with reference to IEC 62443
+FR1-FR7, EU AI Act Article 13, and NIST AI RMF. The evaluation framework
+references the ROSClaw empirical safety study
+([arXiv:2603.26997](https://arxiv.org/abs/2603.26997)) and MCP security
+analysis ([arXiv:2601.17549](https://arxiv.org/abs/2601.17549)).
 
 ```
 Agent ──► SINT Bridge ──► Policy Gateway ──► Allow / Deny / Escalate
@@ -121,9 +140,16 @@ Production references:
 
 ## Why SINT?
 
-AI agents can now control robots, execute code, move money, and operate machinery. They can also access your health data, control your smart home, and orchestrate critical infrastructure. But there's no standard security layer between "the LLM decided to do X" and "X happened in the physical world or with your personal data."
+AI agents now execute code, call tools, move money, operate robots, control
+smart-home devices, and interact with industrial systems. The risk is no longer
+only prompt quality; it is whether the runtime has a verifiable control point
+between "the model decided" and "the world changed."
 
-### SINT vs. Other Frameworks
+SINT makes that control point explicit. It turns agent execution into a governed
+workflow with scoped authority, pre-action policy evaluation, operator review,
+physical limits, revocation, and audit evidence.
+
+### Capability Coverage
 
 | Capability | **SINT Protocol** | Microsoft AGT | MCP Baseline | SROS2 |
 |---|---|---|---|---|
@@ -140,7 +166,11 @@ AI agents can now control robots, execute code, move money, and operate machiner
 | Caregiver delegation + consent | ✅ FHIR Consent tokens | ❌ | ❌ | ❌ |
 | Differential privacy ledger | ✅ Per-query epsilon budget | ❌ | ❌ | ❌ |
 
-**SINT is the only framework purpose-built for physical AI and personal data governance** — where actions are irreversible and have real-world consequences. [Microsoft AGT](https://github.com/microsoft/agent-governance-toolkit) targets digital/software agents; SINT targets robots, drones, smart homes, health fabric, and critical infrastructure.
+SINT is designed for physical AI and regulated data workflows where actions can
+be irreversible: robots, drones, smart homes, health fabric, industrial control,
+and critical infrastructure. [Microsoft AGT](https://github.com/microsoft/agent-governance-toolkit)
+focuses on digital/software governance patterns; SINT focuses on pre-action
+enforcement across tool, robotics, and industrial execution boundaries.
 
 
 **The empirical case for SINT:**
@@ -297,11 +327,11 @@ pnpm run stack:interface  # starts gateway + interface + postgres + redis
 ```
 
 Features:
-- 🎙️ **Voice input** — Web Speech API (zero external deps), real-time transcript
-- 🖥️ **Command HUD** — 3-panel grid: approvals | action stream | context
-- 💾 **Operator memory** — ledger-backed persistent context (`@sint/memory`)
-- 🔔 **Proactive notifications** — `sint__notify` (T2 tier, requires confirmation)
-- ✅ **T2/T3 approvals** — one-click approve/deny with timeout countdown
+- **Voice input**: Web Speech API, zero external dependencies, real-time transcript
+- **Command HUD**: three-panel approvals, action stream, and context view
+- **Operator memory**: ledger-backed persistent context (`@sint/memory`)
+- **Proactive notifications**: `sint__notify` runs as T2 and requires confirmation
+- **T2/T3 approvals**: one-click approve/deny with timeout countdown
 
 See [docs/guides/sint-interface.md](docs/guides/sint-interface.md) for full setup and usage.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,8 +1,14 @@
 # Getting Started with SINT Protocol
 
-This guide gets you from clone to a complete `token -> intercept -> approval -> ledger` flow in about 10 minutes.
+This guide gets you from clone to a complete `token -> intercept -> approval
+-> ledger` flow in about 10 minutes. By the end, you will have a local policy
+gateway that can authorize an AI agent action, escalate higher-risk requests,
+and record the decision in the evidence ledger.
 
-If you want the fastest builder-facing walkthrough for the new interceptor flagship instead of the full local stack, start with [SINT PDP Interceptor Quickstart](./guides/sint-pdp-interceptor-quickstart.md). It shows `request -> decision -> receipt` plus the fail-closed path in one terminal run.
+If you want the fastest builder-facing walkthrough for MCP and agent-runtime
+security, start with [SINT PDP Interceptor Quickstart](./guides/sint-pdp-interceptor-quickstart.md).
+It shows `request -> decision -> receipt` plus the fail-closed path in one
+terminal run.
 
 ## Prerequisites
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: SINT Protocol
-  text: Governance and Safety Control Plane for Physical AI
-  tagline: Delegated authority, runtime enforcement, and evidence for actions with real-world consequence.
+  text: Runtime Security and Governance for AI Agents
+  tagline: Capability-token authorization, approval tiers, physical constraints, and evidence receipts for MCP, robotics, industrial automation, and physical AI.
   image:
     src: /sint-logo.svg
     alt: SINT Protocol
@@ -20,13 +20,21 @@ hero:
       link: /SINT_v0.2_SPEC
 
 features:
-  - title: Runtime Safety Enforcement
-    details: Every request is validated, tiered, approved when required, and fail-closed under revocation or disconnect.
-  - title: Industrial Interoperability
-    details: Bridge profiles for MCP, A2A, ROS 2, MQTT/Sparkplug, OPC UA, Open-RMF, and gRPC.
-  - title: Auditability by Default
-    details: Evidence ledger records decisions and outcomes with tamper-evident hash chaining and proof routes.
+  - title: Pre-Action Policy Gateway
+    details: Every governed request is validated, tiered, approved when required, and refused fail-closed under revocation, missing signatures, or disconnect.
+  - title: Physical and Industrial AI Coverage
+    details: Bridge profiles and fixtures cover MCP, A2A, ROS 2, MAVLink, PX4, MQTT/Sparkplug, OPC UA, Open-RMF, gRPC, and simulator-backed industrial flows.
+  - title: Evidence for Audits and Incident Response
+    details: Hash-chained ledger records, proof receipts, OWASP ASI mappings, MITRE ATLAS candidate mappings, and release-gate artifacts make decisions verifiable.
 ---
+
+## What Is SINT Protocol?
+
+SINT Protocol is an open-source runtime governance layer for AI agents and
+physical AI systems. It places a policy gateway before tool calls, robot
+commands, industrial writes, payment-like actions, and regulated-data access so
+developers can enforce scoped authority, approval routing, revocation, physical
+limits, and tamper-evident audit evidence before execution.
 
 ## Developer Quick Links
 

--- a/docs/marketing-message-map.md
+++ b/docs/marketing-message-map.md
@@ -6,11 +6,22 @@ Use this document as the canonical source for public-facing positioning across R
 
 **Short version**
 
-SINT Protocol is an open protocol and reference stack for governing AI agent execution when actions have real-world consequences.
+SINT Protocol is an open-source runtime security and governance layer for AI
+agents, MCP tools, robotics, industrial automation, and physical AI.
 
 **One-sentence version**
 
-SINT gives developers a control plane for capability tokens, policy enforcement, approval routing, and tamper-evident evidence across MCP, robotics, and industrial execution surfaces.
+SINT gives developers a policy gateway for capability tokens, T0-T3 approval
+routing, physical constraints, revocation, and tamper-evident evidence receipts
+across MCP, robotics, and industrial execution surfaces.
+
+**Answer-engine version**
+
+SINT Protocol is used to authorize and audit AI agent actions before they reach
+tools, robots, drones, industrial systems, smart-home devices, health data, or
+payment-like workflows. Its core primitive is `PolicyGateway.intercept()`, which
+validates scoped Ed25519 capability tokens and returns typed allow, deny, or
+escalate decisions before execution.
 
 **What SINT is not**
 
@@ -65,13 +76,20 @@ SINT works across execution surfaces such as MCP, A2A, ROS 2, MAVLink, MQTT/Spar
 - runnable quick start and examples
 - protocol spec, SIP process, and implementation docs published in-repo
 - bridge integrations, gateway, dashboard, CLI, SDK, and conformance tooling all live in one public monorepo
+- installable MCP proxy: `npx -y sint-mcp --stdio`
+- evidence packets for OWASP Agentic AI, MITRE ATLAS candidate mappings, AAIF
+  RFC-001, NIST, dependency review, and production-slice validation
 
 ## Preferred phrasing
 
 - "execution governance"
+- "AI agent security"
+- "MCP security"
 - "policy gateway"
 - "capability tokens"
 - "approval tiers"
+- "physical AI governance"
+- "industrial AI safety"
 - "tamper-evident evidence ledger"
 - "open protocol and reference stack"
 - "real-world consequences"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sint-protocol",
   "version": "0.1.0",
   "private": true,
-  "description": "SINT Protocol — Security, permission, and economic enforcement layer for physical AI",
+  "description": "SINT Protocol - runtime security and governance for AI agents, MCP tools, robotics, industrial automation, and physical AI",
   "scripts": {
     "build": "turbo run build",
     "test": "turbo run test",


### PR DESCRIPTION
## Summary

- rewrite the README opening into a canonical, answer-engine-friendly description of SINT Protocol
- align docs homepage, getting started intro, package metadata, and marketing message map around the same public positioning
- emphasize concrete proof points: installable MCP proxy, interceptor demo, production gateway posture, industrial action pack, autonomy supervisor, and external evidence packets

## Why

The previous first screen had strong technical detail, but it buried the core answer behind roadmap prose. This makes the repo easier for humans, search engines, and answer engines to understand quickly: what SINT is, what it protects, and what proof exists in the repository.

## Validation

- `pnpm run docs:build`
- `git diff --check`
