### PR TITLE
docs: summarize latest shipyard and commerce updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ systems:
 
 - **Installable MCP proxy:** `npx -y sint-mcp --stdio` runs the security-first
   multi-MCP proxy.
+- **Industrial humanoid shipyard safety:** executable conformance fixtures now
+  cover Persona-style shipyard humanoid welding, hot-work permits, fire watch,
+  fume extraction, confined-space gas safety, bystander escalation,
+  simulation-to-execution drift, material load envelopes, and unconditional
+  e-stop rollback.
+- **Shipyard bridge and evidence scaffolding:** ROS 2 weld-start profile
+  helpers, OPC UA safety-signal mappings, Isaac Sim receipt stubs, and
+  `sintctl shipyard evidence export` generate hash-chained JSONL evidence for
+  supervisor review, remote survey support, and incident reconstruction.
+- **Agent commerce governance:** the Economic Layer now includes a conformance
+  profile for agent-to-agent task markets: task creation, bids, worker
+  selection, benchmark-proof submission, settlement release, and x402-style
+  payment permits.
 - **Five-minute interceptor demo:** `pnpm run demo:interceptor-quickstart`
   shows `request -> decision -> receipt` and the fail-closed path.
 - **Production gateway posture:** production mode requires durable stores,
@@ -741,6 +754,8 @@ docker-compose up
 - AutoGen interop fixtures guide: [`docs/guides/autogen-interop-fixtures.md`](docs/guides/autogen-interop-fixtures.md)
 - AgentSkill delegated authority fixtures guide: [`docs/guides/agentskill-authz-interop-fixtures.md`](docs/guides/agentskill-authz-interop-fixtures.md)
 - Industrial humanoid shipyard safety pack: [`docs/guides/industrial-humanoid-shipyard-safety-pack.md`](docs/guides/industrial-humanoid-shipyard-safety-pack.md)
+- Industrial humanoid shipyard sprint: [`docs/roadmaps/industrial-humanoid-shipyard-safety-sprint.md`](docs/roadmaps/industrial-humanoid-shipyard-safety-sprint.md)
+- Shipyard humanoid evidence export sample: [`docs/reports/shipyard-humanoid-evidence-export.jsonl`](docs/reports/shipyard-humanoid-evidence-export.jsonl)
 - action_ref identity/explainability profile: [`docs/specs/action-ref-identity-explainability-profile.md`](docs/specs/action-ref-identity-explainability-profile.md)
 - Payment governance profile (Economic Layer v1): [`docs/specs/payment-governance-profile-v1.md`](docs/specs/payment-governance-profile-v1.md)
 - Agent commerce governance profile: [`docs/specs/agent-commerce-governance-profile-v1.md`](docs/specs/agent-commerce-governance-profile-v1.md)

--- a/apps/sintctl/README.md
+++ b/apps/sintctl/README.md
@@ -74,6 +74,11 @@ Override output path with `--output <path>`.
 safety fixture into hash-chained JSONL evidence records for remote survey,
 incident reconstruction, and supervisor review.
 
+This command is designed for the latest shipyard safety pack. It reads the
+fixture scenarios, preserves their expected policy decisions, adds work-order
+and safety-context fields, and links every output row with `previousHash` and
+`eventHash`.
+
 ```bash
 pnpm --filter @sint/sintctl build
 node apps/sintctl/dist/cli.js shipyard evidence export \
@@ -83,3 +88,11 @@ node apps/sintctl/dist/cli.js shipyard evidence export \
 
 Use `--format json` for a single JSON array, or `--input <path>` to point at a
 site-specific fixture with the same scenario shape.
+
+Useful options:
+
+- `--work-order-prefix <id>` sets the generated work-order prefix.
+- `--wps-id <id>` sets the weld procedure specification reference.
+- `--hot-work-permit-id <id>` sets the default hot-work permit reference.
+- `--fire-watch-operator-id <id>` sets the default fire-watch operator.
+- `--gas-monitor-calibration-ref <id>` sets the gas-monitor calibration record.

--- a/docs/guides/industrial-humanoid-shipyard-safety-pack.md
+++ b/docs/guides/industrial-humanoid-shipyard-safety-pack.md
@@ -4,6 +4,9 @@ This guide defines a SINT safety and evidence pack for industrial humanoids
 working in shipyards, with emphasis on welding, hot work, confined-space entry,
 inspection, material handling, and remote survey evidence.
 
+Status: executable conformance pack plus Sprint 2 bridge and evidence-export
+scaffolding shipped.
+
 The target deployment shape matches companies building humanoid robots for
 heavy industry: a robot may inspect a hull block, enter a shared work zone,
 start a welding arc, grind material, lift parts, or generate evidence for a
@@ -22,6 +25,24 @@ Runtime mapping helpers:
 - ROS 2 weld-start profile: `packages/bridge-ros2/src/shipyard-humanoid-profile.ts`
 - OPC UA safety signals: `packages/bridge-opcua/src/shipyard-safety-signals.ts`
 - Evidence export CLI: `sintctl shipyard evidence export`
+- Sample evidence export: `docs/reports/shipyard-humanoid-evidence-export.jsonl`
+
+## What Shipped
+
+The latest build turns the original static conformance profile into a working
+operator path:
+
+- conformance scenarios declare expected allow, deny, escalate, and rollback
+  decisions for shipyard humanoid hazards
+- ROS 2 helpers map weld-start intent into a SINT-gated factory action envelope
+  and Isaac Sim receipt stub
+- OPC UA helpers map hot-work permit, fire-watch, fume extraction, gas monitor,
+  interlock, and e-stop safety signals into canonical resources
+- `sintctl shipyard evidence export` converts the fixture into hash-chained
+  JSONL records for supervisor review, remote survey support, and incident
+  reconstruction
+- docs and outreach material keep certification language support-only: SINT
+  provides policy receipts and evidence, not welding or shipyard certification
 
 ## Scope
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,9 +23,9 @@ features:
   - title: Pre-Action Policy Gateway
     details: Every governed request is validated, tiered, approved when required, and refused fail-closed under revocation, missing signatures, or disconnect.
   - title: Physical and Industrial AI Coverage
-    details: Bridge profiles and fixtures cover MCP, A2A, ROS 2, MAVLink, PX4, MQTT/Sparkplug, OPC UA, Open-RMF, gRPC, and simulator-backed industrial flows.
+    details: Bridge profiles and fixtures cover MCP, A2A, ROS 2, MAVLink, PX4, MQTT/Sparkplug, OPC UA, Open-RMF, gRPC, shipyard humanoids, and simulator-backed industrial flows.
   - title: Evidence for Audits and Incident Response
-    details: Hash-chained ledger records, proof receipts, OWASP ASI mappings, MITRE ATLAS candidate mappings, and release-gate artifacts make decisions verifiable.
+    details: Hash-chained ledger records, proof receipts, shipyard JSONL evidence exports, OWASP ASI mappings, MITRE ATLAS candidate mappings, and release-gate artifacts make decisions verifiable.
 ---
 
 ## What Is SINT Protocol?
@@ -38,6 +38,9 @@ limits, and tamper-evident audit evidence before execution.
 
 ## Developer Quick Links
 
+- Latest shipped: [Industrial Humanoid Shipyard Safety Pack](./guides/industrial-humanoid-shipyard-safety-pack.md),
+  [Shipyard Safety Sprint](./roadmaps/industrial-humanoid-shipyard-safety-sprint.md),
+  [Agent Commerce Governance Profile](./specs/agent-commerce-governance-profile-v1.md)
 - Protocol overview: [Protocol](./protocol.md)
 - Active roadmap: [Roadmap](./roadmap.md)
 - Gateway API docs: `/v1/docs`
@@ -55,6 +58,8 @@ limits, and tamper-evident audit evidence before execution.
 - Collaboration reply playbook: [Community/Replies](./community/open-source-collaboration-replies.md)
 - Physical AI runtime safety working group: [Community/Working Group](./community/physical-ai-runtime-safety-working-group.md)
 - Industrial humanoid shipyard safety pack: [Guide](./guides/industrial-humanoid-shipyard-safety-pack.md)
+- Industrial humanoid shipyard safety sprint: [Roadmap](./roadmaps/industrial-humanoid-shipyard-safety-sprint.md)
+- Shipyard humanoid evidence export sample: `docs/reports/shipyard-humanoid-evidence-export.jsonl`
 - OWASP Agentic Landscape submission packet: [Community/OWASP Packet](./community/owasp-agentic-landscape-submission.md)
 - EU AI Act mapping: [Compliance/EU AI Act](./compliance/eu-ai-act-mapping.md)
 - ISO 13482 alignment: [Compliance/ISO 13482](./compliance/iso-13482-alignment.md)

--- a/docs/marketing-message-map.md
+++ b/docs/marketing-message-map.md
@@ -82,6 +82,16 @@ confined spaces, or move through shared work zones. The message is not
 "certification replacement"; it is "policy receipts and runtime evidence for
 supervisors, safety teams, surveyors, and post-incident review."
 
+Latest proof points:
+
+- executable shipyard humanoid conformance scenarios for welding, hot work,
+  confined spaces, material handling, bystander escalation, simulation receipt
+  drift, and e-stop rollback
+- ROS 2 weld-start mapping plus OPC UA safety-signal mappings for permit,
+  fire-watch, fume extraction, gas monitor, interlock, and e-stop context
+- `sintctl shipyard evidence export` produces hash-chained JSONL evidence for
+  supervisor review, remote survey support, and incident reconstruction
+
 ## Proof points to emphasize
 
 - Apache-2.0 licensed

--- a/docs/roadmaps/industrial-humanoid-shipyard-safety-sprint.md
+++ b/docs/roadmaps/industrial-humanoid-shipyard-safety-sprint.md
@@ -2,6 +2,12 @@
 
 Status: Sprint 2 bridge and evidence-export scaffolding shipped
 
+Latest shipped commits:
+
+- PR #234: executable industrial humanoid shipyard safety conformance pack
+- PR #235: ROS 2 weld-start mapping, OPC UA safety-signal helpers, and
+  `sintctl shipyard evidence export`
+
 This sprint turns the Persona-style industrial humanoid opportunity into a
 SINT product lane: safety policy, certification evidence, and runtime receipts
 for shipyard robots doing welding, inspection, confined-space, and material
@@ -102,6 +108,9 @@ Shipped code:
 Remaining candidate:
 
 - dashboard card for hot-work approvals and evidence replay
+- site-specific adapter examples for a real safety PLC, simulator artifact, and
+  ROS 2 controller surface
+- public demo script showing `request -> decision -> receipt -> JSONL export`
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- update README latest highlights with the industrial humanoid shipyard pack, bridge/evidence scaffolding, and agent commerce governance profile
- add docs landing-page links for the latest shipped work and the shipyard sprint roadmap
- expand the shipyard guide, sprint roadmap, sintctl README, and marketing message map with the new evidence export path and proof points

## Validation

- `pnpm run docs:build`
- `git diff --check`
